### PR TITLE
fix(decode): install Huffman tables at file index, not component index

### DIFF
--- a/zenjpeg/examples/gen_permutation_corpus.rs
+++ b/zenjpeg/examples/gen_permutation_corpus.rs
@@ -54,7 +54,9 @@ fn lcg(seed: &mut u64) -> u32 {
 
 fn gen_noise(w: u32, h: u32, c: u32, seed: u64) -> Vec<u8> {
     let mut s = seed;
-    (0..(w * h * c)).map(|_| (lcg(&mut s) & 0xff) as u8).collect()
+    (0..(w * h * c))
+        .map(|_| (lcg(&mut s) & 0xff) as u8)
+        .collect()
 }
 
 fn gen_noise_patches(w: u32, h: u32, c: u32, seed: u64) -> Vec<u8> {
@@ -238,7 +240,14 @@ fn build_sources(tmp: &Path) -> Vec<Source> {
     }
 
     // Grayscale sources
-    for &(w, h) in &[(16u32, 16), (17, 19), (32, 32), (33, 31), (65, 63), (128, 128)] {
+    for &(w, h) in &[
+        (16u32, 16),
+        (17, 19),
+        (32, 32),
+        (33, 31),
+        (65, 63),
+        (128, 128),
+    ] {
         push(
             &format!("noise_{w}x{h}_gray"),
             w,
@@ -300,7 +309,11 @@ fn build_tasks(sources: &[Source], quick: bool) -> Vec<Task> {
     for (idx, src) in sources.iter().enumerate() {
         if src.channels == 1 {
             // Gray axis: quality × progressive × optimize × restart × dct
-            let dct_methods: &[&str] = if quick { &["int"] } else { &["int", "fast", "float"] };
+            let dct_methods: &[&str] = if quick {
+                &["int"]
+            } else {
+                &["int", "fast", "float"]
+            };
             for &q in qualities {
                 for prog in &[false, true] {
                     for opt in &[false, true] {
@@ -323,9 +336,8 @@ fn build_tasks(sources: &[Source], quick: bool) -> Vec<Task> {
                                     args.push("-restart".into());
                                     args.push(r.to_string());
                                 }
-                                let desc = format!(
-                                    "q={q} prog={prog} opt={opt} rst={r} dct={dct} gray"
-                                );
+                                let desc =
+                                    format!("q={q} prog={prog} opt={opt} rst={r} dct={dct} gray");
                                 out.push(Task {
                                     tool: "cjpeg",
                                     source_idx: idx,
@@ -379,9 +391,8 @@ fn build_tasks(sources: &[Source], quick: bool) -> Vec<Task> {
                                     args.push("-restart".into());
                                     args.push(r.to_string());
                                 }
-                                let desc = format!(
-                                    "q={q} prog={prog} opt={opt} rst={r} sub={sub_name}"
-                                );
+                                let desc =
+                                    format!("q={q} prog={prog} opt={opt} rst={r} sub={sub_name}");
                                 out.push(Task {
                                     tool: "cjpeg",
                                     source_idx: idx,
@@ -456,11 +467,7 @@ fn build_tasks(sources: &[Source], quick: bool) -> Vec<Task> {
                     out.push(Task {
                         tool: "cjpeg",
                         source_idx: idx,
-                        args: vec![
-                            "-quality".into(),
-                            q.to_string(),
-                            "-arithmetic".into(),
-                        ],
+                        args: vec!["-quality".into(), q.to_string(), "-arithmetic".into()],
                         desc: format!("q={q} arith"),
                         expect_zenjpeg_fail: true,
                     });
@@ -714,7 +721,8 @@ fn run_task(task: &Task, source: &Source, worker_id: usize) -> Option<TaskOutput
 // ── Main ───────────────────────────────────────────────────────────────────
 
 fn main() {
-    let out_dir = PathBuf::from(env::var("ZENJPEG_PERM_OUT").unwrap_or_else(|_| DEFAULT_OUT.into()));
+    let out_dir =
+        PathBuf::from(env::var("ZENJPEG_PERM_OUT").unwrap_or_else(|_| DEFAULT_OUT.into()));
     let cap_mb: u64 = env::var("ZENJPEG_PERM_CAP_MB")
         .ok()
         .and_then(|s| s.parse().ok())

--- a/zenjpeg/src/decode/parser/scan.rs
+++ b/zenjpeg/src/decode/parser/scan.rs
@@ -634,7 +634,7 @@ impl<'a> JpegParser<'a> {
             decoder.set_permissive_rst(true);
         }
 
-        for (comp_idx, dc_table, ac_table) in scan_components {
+        for (_comp_idx, dc_table, ac_table) in scan_components {
             let dc_idx = (*dc_table as usize).min(MAX_HUFFMAN_TABLES - 1);
             let ac_idx = (*ac_table as usize).min(MAX_HUFFMAN_TABLES - 1);
 
@@ -648,7 +648,9 @@ impl<'a> JpegParser<'a> {
                     }
                 }
             };
-            decoder.set_dc_table(*comp_idx, dc_table_ref);
+            // Install at the FILE table index (matches how decode_block_into
+            // looks it up via ac_table_idx/dc_table_idx), not comp_idx.
+            decoder.set_dc_table(dc_idx, dc_table_ref);
 
             let ac_table_ref: &HuffmanDecodeTable = match &self.ac_tables[ac_idx] {
                 Some(table) => table,
@@ -660,7 +662,7 @@ impl<'a> JpegParser<'a> {
                     }
                 }
             };
-            decoder.set_ac_table(*comp_idx, ac_table_ref);
+            decoder.set_ac_table(ac_idx, ac_table_ref);
         }
 
         // Allocate strip buffers for one MCU row (8 rows of pixels)
@@ -943,7 +945,7 @@ impl<'a> JpegParser<'a> {
         if self.strictness != Strictness::Strict {
             decoder.set_permissive_rst(true);
         }
-        for (comp_idx, dc_table, ac_table) in scan_components {
+        for (_comp_idx, dc_table, ac_table) in scan_components {
             let dc_idx = (*dc_table as usize).min(MAX_HUFFMAN_TABLES - 1);
             let ac_idx = (*ac_table as usize).min(MAX_HUFFMAN_TABLES - 1);
             let dc_table_ref: &HuffmanDecodeTable = match &self.dc_tables[dc_idx] {
@@ -956,7 +958,7 @@ impl<'a> JpegParser<'a> {
                     }
                 }
             };
-            decoder.set_dc_table(*comp_idx, dc_table_ref);
+            decoder.set_dc_table(dc_idx, dc_table_ref);
             let ac_table_ref: &HuffmanDecodeTable = match &self.ac_tables[ac_idx] {
                 Some(table) => table,
                 None => {
@@ -967,7 +969,7 @@ impl<'a> JpegParser<'a> {
                     }
                 }
             };
-            decoder.set_ac_table(*comp_idx, ac_table_ref);
+            decoder.set_ac_table(ac_idx, ac_table_ref);
         }
 
         // ---- Buffer allocation ----

--- a/zenjpeg/tests/permutation_corpus_decode.rs
+++ b/zenjpeg/tests/permutation_corpus_decode.rs
@@ -67,7 +67,12 @@ fn decode_zenjpeg(data: &[u8]) -> Result<Decoded, String> {
         }
         rgb
     } else {
-        return Err(format!("unexpected pixel length {} for {}x{}", raw.len(), w, h));
+        return Err(format!(
+            "unexpected pixel length {} for {}x{}",
+            raw.len(),
+            w,
+            h
+        ));
     };
     Ok(Decoded {
         width: w as u32,
@@ -201,8 +206,7 @@ fn zensim_regress(a: &Decoded, b: &Decoded) -> Option<(f64, String)> {
     let w = a.width as usize;
     let h = a.height as usize;
     let stride = w * 3;
-    let expected =
-        StridedBytes::try_new(&a.pixels, w, h, stride, PixelFormat::Srgb8Rgb).ok()?;
+    let expected = StridedBytes::try_new(&a.pixels, w, h, stride, PixelFormat::Srgb8Rgb).ok()?;
     let actual = StridedBytes::try_new(&b.pixels, w, h, stride, PixelFormat::Srgb8Rgb).ok()?;
     let tol = RegressionTolerance::off_by_one();
     let report = check_regression(&zsim, &expected, &actual, &tol).ok()?;
@@ -237,11 +241,7 @@ fn jpeg_sof_marker(data: &[u8]) -> Option<u8> {
         }
         let marker = data[i + 1];
         // SOFn: 0xC0..=0xCF except 0xC4 (DHT), 0xC8 (JPG reserved), 0xCC (DAC)
-        if (0xC0..=0xCF).contains(&marker)
-            && marker != 0xC4
-            && marker != 0xC8
-            && marker != 0xCC
-        {
+        if (0xC0..=0xCF).contains(&marker) && marker != 0xC4 && marker != 0xC8 && marker != 0xCC {
             return Some(marker);
         }
         // Reached entropy-coded data or end without SOF.
@@ -289,12 +289,12 @@ fn read_manifest(manifest_path: &Path) -> Result<Vec<ManifestRow>, String> {
     let mut out = Vec::new();
     let mut lines = reader.lines();
     // Skip header
-    if let Some(Ok(hdr)) = lines.next() {
-        if !hdr.starts_with("hash\t") {
-            return Err(format!("unexpected header: {hdr}"));
-        }
+    if let Some(Ok(hdr)) = lines.next()
+        && !hdr.starts_with("hash\t")
+    {
+        return Err(format!("unexpected header: {hdr}"));
     }
-    for line in lines.flatten() {
+    for line in lines.map_while(Result::ok) {
         let mut it = line.splitn(7, '\t');
         let hash = it.next().unwrap_or("").to_string();
         let rel_path = it.next().unwrap_or("").to_string();
@@ -530,9 +530,12 @@ fn write_result_row(w: &mut BufWriter<File>, r: &FileResult) -> std::io::Result<
         } else {
             (0, 0.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         };
-    let zen_err = r.zen_err.replace('\t', " ").replace('\n', " ");
-    let moz_err = r.moz_err.replace('\t', " ").replace('\n', " ");
-    let score = r.zensim_score.map(|s| format!("{s:.3}")).unwrap_or_default();
+    let zen_err = r.zen_err.replace(['\t', '\n'], " ");
+    let moz_err = r.moz_err.replace(['\t', '\n'], " ");
+    let score = r
+        .zensim_score
+        .map(|s| format!("{s:.3}"))
+        .unwrap_or_default();
     let cat = r.zensim_category.clone().unwrap_or_default();
     writeln!(
         w,
@@ -572,9 +575,8 @@ fn write_header(w: &mut BufWriter<File>) -> std::io::Result<()> {
 #[test]
 #[ignore = "requires pre-generated corpus via `cargo run --release --example gen_permutation_corpus`"]
 fn validate_permutation_corpus() {
-    let out_dir = PathBuf::from(
-        std::env::var("ZENJPEG_PERM_OUT").unwrap_or_else(|_| DEFAULT_OUT.into()),
-    );
+    let out_dir =
+        PathBuf::from(std::env::var("ZENJPEG_PERM_OUT").unwrap_or_else(|_| DEFAULT_OUT.into()));
     let manifest_path = out_dir.join("manifest.tsv");
     if !manifest_path.exists() {
         panic!(
@@ -585,10 +587,10 @@ fn validate_permutation_corpus() {
     }
 
     let mut rows = read_manifest(&manifest_path).expect("read manifest");
-    if let Ok(limit_str) = std::env::var("ZENJPEG_PERM_LIMIT") {
-        if let Ok(n) = limit_str.parse::<usize>() {
-            rows.truncate(n);
-        }
+    if let Ok(limit_str) = std::env::var("ZENJPEG_PERM_LIMIT")
+        && let Ok(n) = limit_str.parse::<usize>()
+    {
+        rows.truncate(n);
     }
 
     let report_path = std::env::var("ZENJPEG_PERM_REPORT")

--- a/zenjpeg/tests/permutation_regression.rs
+++ b/zenjpeg/tests/permutation_regression.rs
@@ -188,37 +188,43 @@ fn mixed1_q75_has_large_diff() {
     );
 }
 
-// ── Bug 3: cjpegli -p 0 Huffman / AC errors ────────────────────────────────
+// ── Bug 3 (FIXED): cjpegli -p 0 Huffman / AC errors ────────────────────────
 //
-// cjpegli -p 0 on specific noise/edges source dimensions at sub=422/444
-// produces JPEG files zenjpeg rejects with "invalid Huffman table 0: invalid
-// code" or "AC coefficient index out of bounds". mozjpeg decodes these fine.
-// 21 files in the generated corpus exhibit this.
+// Was: cjpegli -p 0 on noise/edges sources at sub=422/444 produced JPEGs
+// zenjpeg rejected with "invalid Huffman table 0: invalid code" or
+// "AC coefficient index out of bounds". mozjpeg, zune-jpeg, and jpeg-decoder
+// all handled the same files.
+//
+// Root cause: the baseline streaming decode paths in parser/scan.rs installed
+// Huffman tables via `decoder.set_*_table(*comp_idx, ...)`, passing the
+// COMPONENT index instead of the FILE TABLE INDEX that decode_block_into
+// later looks up. For the usual arrangement (Y=AC0, Cb=AC1, Cr=AC1), file
+// index and component index produce the same final layout by coincidence.
+// For cjpegli-optimized files where Y and Cb share AC table 0 and Cr uses
+// AC table 1, Cr's real table (file AC 1) was stored at slot 2, but decode
+// looked up slot 1 — reading Cb's table (file AC 0) for Cr blocks. The
+// resulting desync propagated until the decoder tripped on a bogus code or
+// an out-of-range run.
+//
+// Fix: install tables at `dc_idx` / `ac_idx` like the non-streaming path
+// already did (parser/scan.rs:274,286 and parser/progressive.rs:124,136).
 
-#[test]
-fn cjpegli_p0_huffman_error() {
-    // noise_47x63 at distance 5, sub=422, p=0 → "invalid Huffman table 0"
-    let data: &[u8] =
-        include_bytes!("testdata/permutation_regression/cjpegli_p0_huffman_noise_47x63_d5.jpg");
-    let err = decode_zen(data).expect_err(
-        "cjpegli p=0 Huffman bug: currently fails; if this decodes, bug is fixed",
-    );
-    assert!(
-        err.contains("Huffman") || err.contains("huffman"),
-        "bug signature changed: {err}"
-    );
+fn assert_decodes_ok(data: &[u8], label: &str) {
+    decode_zen(data).unwrap_or_else(|e| panic!("{label} must decode after table-slot fix: {e}"));
 }
 
 #[test]
-fn cjpegli_p0_ac_error() {
-    // noise_64x64 at distance 5, sub=422, p=0 → "AC coefficient index out of bounds"
+fn cjpegli_p0_huffman_decodes() {
+    // noise_47x63 at distance 5, sub=422, p=0
+    let data: &[u8] =
+        include_bytes!("testdata/permutation_regression/cjpegli_p0_huffman_noise_47x63_d5.jpg");
+    assert_decodes_ok(data, "cjpegli p=0 Huffman fixture");
+}
+
+#[test]
+fn cjpegli_p0_ac_decodes() {
+    // noise_64x64 at distance 5, sub=422, p=0
     let data: &[u8] =
         include_bytes!("testdata/permutation_regression/cjpegli_p0_ac_noise_64x64_d5.jpg");
-    let err = decode_zen(data).expect_err(
-        "cjpegli p=0 AC bug: currently fails; if this decodes, bug is fixed",
-    );
-    assert!(
-        err.contains("AC coefficient") || err.contains("out of bounds"),
-        "bug signature changed: {err}"
-    );
+    assert_decodes_ok(data, "cjpegli p=0 AC fixture");
 }

--- a/zenjpeg/tests/permutation_regression.rs
+++ b/zenjpeg/tests/permutation_regression.rs
@@ -152,8 +152,7 @@ fn xyb_p0_sub420_decodes() {
 fn mixed1_q5_has_small_diff() {
     // Q5 noise_96x72: recorded max_diff = 10 vs mozjpeg. Asserting > 8 so
     // the test fails when the bug is fixed (expected post-fix: ≤ 7).
-    let data: &[u8] =
-        include_bytes!("testdata/permutation_regression/mixed1_q5_noise_96x72.jpg");
+    let data: &[u8] = include_bytes!("testdata/permutation_regression/mixed1_q5_noise_96x72.jpg");
     let (zw, zh, zp) = decode_zen(data).expect("decodes");
     let (mw, mh, mp) = decode_mozjpeg_rgb(data).expect("mozjpeg decodes");
     assert_eq!((zw, zh), (mw, mh));


### PR DESCRIPTION
## Root cause

The two baseline streaming decode paths in \`zenjpeg/src/decode/parser/scan.rs\` (\`decode_baseline_streaming_rgb\` at the 4:4:4 entry and \`decode_baseline_streaming\` at the subsampled entry) installed Huffman tables into the entropy decoder via \`decoder.set_*_table(*comp_idx, …)\` — passing the **component index** instead of the **file table index** that \`decode_block_into\` later looks up.

For the overwhelmingly common Y=AC0, Cb=AC1, Cr=AC1 arrangement, component index and file table index happen to produce the same final slot layout, so the bug was invisible in every corpus we had. For cjpegli-optimized files where Y and Cb share AC table 0 and Cr uses AC table 1 — common with jpegli's per-component Huffman optimization — Cr's real table (file AC 1) ended up stored at slot 2 while \`decode_block_into\` looked up slot 1, reading Cb's table (file AC 0) for Cr blocks. The bit stream desynced inside the very first Cr block and the decoder either tripped on an invalid Huffman code or on a run that pushed the AC index past 63.

## Fix

Install at \`dc_idx\` / \`ac_idx\`, matching the non-streaming path at \`parser/scan.rs:274,286\` and \`parser/progressive.rs:124,136\` which already did the right thing.

## Results

The permutation corpus generated in #30 surfaced 21 files with \"invalid Huffman table 0: invalid code\" / \"AC coefficient index out of bounds\" errors.

- Before: \`zen_err_moz_ok: 21\`
- After: \`zen_err_moz_ok: 0\`

The remaining 162 \`diff_large\` files all use the non-uniform \`-sample 2x2,2x1,1x2\` subsampling — that's a separate bug, investigated on a different branch.

## Test plan
- [x] 7/7 regression fixtures in \`permutation_regression.rs\` pass (2 of them were flipped from assert-failure to assert-success by this PR)
- [x] Full permutation corpus validator: \`zen_err_moz_ok\` went \`21 → 0\`, no other categories changed
- [x] \`cargo test --release --features decoder -p zenjpeg\` — entire zenjpeg suite passes, no regressions
- [x] Both cjpegli p=0 fixture files now decode bit-for-bit matching mozjpeg

## Notes

This PR depends on the permutation corpus scaffolding in #30 (which this branch is rebased onto). Merging #30 first is recommended so the fixtures and regression-test machinery are in place.