### PR TITLE
fix(decode): reject non-uniform chroma subsampling for YCbCr JPEGs

### DIFF
--- a/zenjpeg/examples/gen_permutation_corpus.rs
+++ b/zenjpeg/examples/gen_permutation_corpus.rs
@@ -54,7 +54,9 @@ fn lcg(seed: &mut u64) -> u32 {
 
 fn gen_noise(w: u32, h: u32, c: u32, seed: u64) -> Vec<u8> {
     let mut s = seed;
-    (0..(w * h * c)).map(|_| (lcg(&mut s) & 0xff) as u8).collect()
+    (0..(w * h * c))
+        .map(|_| (lcg(&mut s) & 0xff) as u8)
+        .collect()
 }
 
 fn gen_noise_patches(w: u32, h: u32, c: u32, seed: u64) -> Vec<u8> {
@@ -238,7 +240,14 @@ fn build_sources(tmp: &Path) -> Vec<Source> {
     }
 
     // Grayscale sources
-    for &(w, h) in &[(16u32, 16), (17, 19), (32, 32), (33, 31), (65, 63), (128, 128)] {
+    for &(w, h) in &[
+        (16u32, 16),
+        (17, 19),
+        (32, 32),
+        (33, 31),
+        (65, 63),
+        (128, 128),
+    ] {
         push(
             &format!("noise_{w}x{h}_gray"),
             w,
@@ -300,7 +309,11 @@ fn build_tasks(sources: &[Source], quick: bool) -> Vec<Task> {
     for (idx, src) in sources.iter().enumerate() {
         if src.channels == 1 {
             // Gray axis: quality × progressive × optimize × restart × dct
-            let dct_methods: &[&str] = if quick { &["int"] } else { &["int", "fast", "float"] };
+            let dct_methods: &[&str] = if quick {
+                &["int"]
+            } else {
+                &["int", "fast", "float"]
+            };
             for &q in qualities {
                 for prog in &[false, true] {
                     for opt in &[false, true] {
@@ -323,9 +336,8 @@ fn build_tasks(sources: &[Source], quick: bool) -> Vec<Task> {
                                     args.push("-restart".into());
                                     args.push(r.to_string());
                                 }
-                                let desc = format!(
-                                    "q={q} prog={prog} opt={opt} rst={r} dct={dct} gray"
-                                );
+                                let desc =
+                                    format!("q={q} prog={prog} opt={opt} rst={r} dct={dct} gray");
                                 out.push(Task {
                                     tool: "cjpeg",
                                     source_idx: idx,
@@ -379,9 +391,8 @@ fn build_tasks(sources: &[Source], quick: bool) -> Vec<Task> {
                                     args.push("-restart".into());
                                     args.push(r.to_string());
                                 }
-                                let desc = format!(
-                                    "q={q} prog={prog} opt={opt} rst={r} sub={sub_name}"
-                                );
+                                let desc =
+                                    format!("q={q} prog={prog} opt={opt} rst={r} sub={sub_name}");
                                 out.push(Task {
                                     tool: "cjpeg",
                                     source_idx: idx,
@@ -456,11 +467,7 @@ fn build_tasks(sources: &[Source], quick: bool) -> Vec<Task> {
                     out.push(Task {
                         tool: "cjpeg",
                         source_idx: idx,
-                        args: vec![
-                            "-quality".into(),
-                            q.to_string(),
-                            "-arithmetic".into(),
-                        ],
+                        args: vec!["-quality".into(), q.to_string(), "-arithmetic".into()],
                         desc: format!("q={q} arith"),
                         expect_zenjpeg_fail: true,
                     });
@@ -714,7 +721,8 @@ fn run_task(task: &Task, source: &Source, worker_id: usize) -> Option<TaskOutput
 // ── Main ───────────────────────────────────────────────────────────────────
 
 fn main() {
-    let out_dir = PathBuf::from(env::var("ZENJPEG_PERM_OUT").unwrap_or_else(|_| DEFAULT_OUT.into()));
+    let out_dir =
+        PathBuf::from(env::var("ZENJPEG_PERM_OUT").unwrap_or_else(|_| DEFAULT_OUT.into()));
     let cap_mb: u64 = env::var("ZENJPEG_PERM_CAP_MB")
         .ok()
         .and_then(|s| s.parse().ok())

--- a/zenjpeg/src/decode/parser/markers.rs
+++ b/zenjpeg/src/decode/parser/markers.rs
@@ -180,6 +180,37 @@ impl<'a> JpegParser<'a> {
             self.components[i].quant_table_idx = quant_idx;
         }
 
+        // Reject non-uniform chroma subsampling for traditional YCbCr JPEGs
+        // (Cb and Cr with different h_samp or v_samp factors). The decode
+        // pipeline — buffer allocation, upsample dispatch, YCbCr→RGB — assumes
+        // both chroma components share the same ratio relative to luma.
+        // Silently producing wrong pixels would violate the zero-tolerance
+        // correctness rule. Example trigger: `cjpeg -sample 2x2,2x1,1x2`.
+        //
+        // Skip the check when component IDs are 'R','G','B' (82, 71, 66):
+        // those are RGB or XYB JPEGs where per-component sampling factors are
+        // a legitimate encoding choice (XYB even uses R=G=(2,2), B=(1,1) by
+        // design). In those color spaces there's no chroma subsampling at all.
+        if self.num_components == 3 {
+            let ids = [
+                self.components[0].id,
+                self.components[1].id,
+                self.components[2].id,
+            ];
+            let is_rgb_ids = ids == [b'R', b'G', b'B'];
+            if !is_rgb_ids {
+                let cb_h = self.components[1].h_samp_factor;
+                let cb_v = self.components[1].v_samp_factor;
+                let cr_h = self.components[2].h_samp_factor;
+                let cr_v = self.components[2].v_samp_factor;
+                if cb_h != cr_h || cb_v != cr_v {
+                    return Err(Error::unsupported_feature(
+                        "non-uniform chroma subsampling: Cb and Cr have different sampling factors",
+                    ));
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/zenjpeg/src/decode/parser/scan.rs
+++ b/zenjpeg/src/decode/parser/scan.rs
@@ -634,7 +634,7 @@ impl<'a> JpegParser<'a> {
             decoder.set_permissive_rst(true);
         }
 
-        for (comp_idx, dc_table, ac_table) in scan_components {
+        for (_comp_idx, dc_table, ac_table) in scan_components {
             let dc_idx = (*dc_table as usize).min(MAX_HUFFMAN_TABLES - 1);
             let ac_idx = (*ac_table as usize).min(MAX_HUFFMAN_TABLES - 1);
 
@@ -648,7 +648,9 @@ impl<'a> JpegParser<'a> {
                     }
                 }
             };
-            decoder.set_dc_table(*comp_idx, dc_table_ref);
+            // Install at the FILE table index (matches how decode_block_into
+            // looks it up via ac_table_idx/dc_table_idx), not comp_idx.
+            decoder.set_dc_table(dc_idx, dc_table_ref);
 
             let ac_table_ref: &HuffmanDecodeTable = match &self.ac_tables[ac_idx] {
                 Some(table) => table,
@@ -660,7 +662,7 @@ impl<'a> JpegParser<'a> {
                     }
                 }
             };
-            decoder.set_ac_table(*comp_idx, ac_table_ref);
+            decoder.set_ac_table(ac_idx, ac_table_ref);
         }
 
         // Allocate strip buffers for one MCU row (8 rows of pixels)
@@ -943,7 +945,7 @@ impl<'a> JpegParser<'a> {
         if self.strictness != Strictness::Strict {
             decoder.set_permissive_rst(true);
         }
-        for (comp_idx, dc_table, ac_table) in scan_components {
+        for (_comp_idx, dc_table, ac_table) in scan_components {
             let dc_idx = (*dc_table as usize).min(MAX_HUFFMAN_TABLES - 1);
             let ac_idx = (*ac_table as usize).min(MAX_HUFFMAN_TABLES - 1);
             let dc_table_ref: &HuffmanDecodeTable = match &self.dc_tables[dc_idx] {
@@ -956,7 +958,7 @@ impl<'a> JpegParser<'a> {
                     }
                 }
             };
-            decoder.set_dc_table(*comp_idx, dc_table_ref);
+            decoder.set_dc_table(dc_idx, dc_table_ref);
             let ac_table_ref: &HuffmanDecodeTable = match &self.ac_tables[ac_idx] {
                 Some(table) => table,
                 None => {
@@ -967,7 +969,7 @@ impl<'a> JpegParser<'a> {
                     }
                 }
             };
-            decoder.set_ac_table(*comp_idx, ac_table_ref);
+            decoder.set_ac_table(ac_idx, ac_table_ref);
         }
 
         // ---- Buffer allocation ----

--- a/zenjpeg/tests/permutation_corpus_decode.rs
+++ b/zenjpeg/tests/permutation_corpus_decode.rs
@@ -67,7 +67,12 @@ fn decode_zenjpeg(data: &[u8]) -> Result<Decoded, String> {
         }
         rgb
     } else {
-        return Err(format!("unexpected pixel length {} for {}x{}", raw.len(), w, h));
+        return Err(format!(
+            "unexpected pixel length {} for {}x{}",
+            raw.len(),
+            w,
+            h
+        ));
     };
     Ok(Decoded {
         width: w as u32,
@@ -201,8 +206,7 @@ fn zensim_regress(a: &Decoded, b: &Decoded) -> Option<(f64, String)> {
     let w = a.width as usize;
     let h = a.height as usize;
     let stride = w * 3;
-    let expected =
-        StridedBytes::try_new(&a.pixels, w, h, stride, PixelFormat::Srgb8Rgb).ok()?;
+    let expected = StridedBytes::try_new(&a.pixels, w, h, stride, PixelFormat::Srgb8Rgb).ok()?;
     let actual = StridedBytes::try_new(&b.pixels, w, h, stride, PixelFormat::Srgb8Rgb).ok()?;
     let tol = RegressionTolerance::off_by_one();
     let report = check_regression(&zsim, &expected, &actual, &tol).ok()?;
@@ -237,11 +241,7 @@ fn jpeg_sof_marker(data: &[u8]) -> Option<u8> {
         }
         let marker = data[i + 1];
         // SOFn: 0xC0..=0xCF except 0xC4 (DHT), 0xC8 (JPG reserved), 0xCC (DAC)
-        if (0xC0..=0xCF).contains(&marker)
-            && marker != 0xC4
-            && marker != 0xC8
-            && marker != 0xCC
-        {
+        if (0xC0..=0xCF).contains(&marker) && marker != 0xC4 && marker != 0xC8 && marker != 0xCC {
             return Some(marker);
         }
         // Reached entropy-coded data or end without SOF.
@@ -289,12 +289,12 @@ fn read_manifest(manifest_path: &Path) -> Result<Vec<ManifestRow>, String> {
     let mut out = Vec::new();
     let mut lines = reader.lines();
     // Skip header
-    if let Some(Ok(hdr)) = lines.next() {
-        if !hdr.starts_with("hash\t") {
-            return Err(format!("unexpected header: {hdr}"));
-        }
+    if let Some(Ok(hdr)) = lines.next()
+        && !hdr.starts_with("hash\t")
+    {
+        return Err(format!("unexpected header: {hdr}"));
     }
-    for line in lines.flatten() {
+    for line in lines.map_while(Result::ok) {
         let mut it = line.splitn(7, '\t');
         let hash = it.next().unwrap_or("").to_string();
         let rel_path = it.next().unwrap_or("").to_string();
@@ -530,9 +530,12 @@ fn write_result_row(w: &mut BufWriter<File>, r: &FileResult) -> std::io::Result<
         } else {
             (0, 0.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         };
-    let zen_err = r.zen_err.replace('\t', " ").replace('\n', " ");
-    let moz_err = r.moz_err.replace('\t', " ").replace('\n', " ");
-    let score = r.zensim_score.map(|s| format!("{s:.3}")).unwrap_or_default();
+    let zen_err = r.zen_err.replace(['\t', '\n'], " ");
+    let moz_err = r.moz_err.replace(['\t', '\n'], " ");
+    let score = r
+        .zensim_score
+        .map(|s| format!("{s:.3}"))
+        .unwrap_or_default();
     let cat = r.zensim_category.clone().unwrap_or_default();
     writeln!(
         w,
@@ -572,9 +575,8 @@ fn write_header(w: &mut BufWriter<File>) -> std::io::Result<()> {
 #[test]
 #[ignore = "requires pre-generated corpus via `cargo run --release --example gen_permutation_corpus`"]
 fn validate_permutation_corpus() {
-    let out_dir = PathBuf::from(
-        std::env::var("ZENJPEG_PERM_OUT").unwrap_or_else(|_| DEFAULT_OUT.into()),
-    );
+    let out_dir =
+        PathBuf::from(std::env::var("ZENJPEG_PERM_OUT").unwrap_or_else(|_| DEFAULT_OUT.into()));
     let manifest_path = out_dir.join("manifest.tsv");
     if !manifest_path.exists() {
         panic!(
@@ -585,10 +587,10 @@ fn validate_permutation_corpus() {
     }
 
     let mut rows = read_manifest(&manifest_path).expect("read manifest");
-    if let Ok(limit_str) = std::env::var("ZENJPEG_PERM_LIMIT") {
-        if let Ok(n) = limit_str.parse::<usize>() {
-            rows.truncate(n);
-        }
+    if let Ok(limit_str) = std::env::var("ZENJPEG_PERM_LIMIT")
+        && let Ok(n) = limit_str.parse::<usize>()
+    {
+        rows.truncate(n);
     }
 
     let report_path = std::env::var("ZENJPEG_PERM_REPORT")

--- a/zenjpeg/tests/permutation_regression.rs
+++ b/zenjpeg/tests/permutation_regression.rs
@@ -188,37 +188,43 @@ fn mixed1_q75_has_large_diff() {
     );
 }
 
-// ── Bug 3: cjpegli -p 0 Huffman / AC errors ────────────────────────────────
+// ── Bug 3 (FIXED): cjpegli -p 0 Huffman / AC errors ────────────────────────
 //
-// cjpegli -p 0 on specific noise/edges source dimensions at sub=422/444
-// produces JPEG files zenjpeg rejects with "invalid Huffman table 0: invalid
-// code" or "AC coefficient index out of bounds". mozjpeg decodes these fine.
-// 21 files in the generated corpus exhibit this.
+// Was: cjpegli -p 0 on noise/edges sources at sub=422/444 produced JPEGs
+// zenjpeg rejected with "invalid Huffman table 0: invalid code" or
+// "AC coefficient index out of bounds". mozjpeg, zune-jpeg, and jpeg-decoder
+// all handled the same files.
+//
+// Root cause: the baseline streaming decode paths in parser/scan.rs installed
+// Huffman tables via `decoder.set_*_table(*comp_idx, ...)`, passing the
+// COMPONENT index instead of the FILE TABLE INDEX that decode_block_into
+// later looks up. For the usual arrangement (Y=AC0, Cb=AC1, Cr=AC1), file
+// index and component index produce the same final layout by coincidence.
+// For cjpegli-optimized files where Y and Cb share AC table 0 and Cr uses
+// AC table 1, Cr's real table (file AC 1) was stored at slot 2, but decode
+// looked up slot 1 — reading Cb's table (file AC 0) for Cr blocks. The
+// resulting desync propagated until the decoder tripped on a bogus code or
+// an out-of-range run.
+//
+// Fix: install tables at `dc_idx` / `ac_idx` like the non-streaming path
+// already did (parser/scan.rs:274,286 and parser/progressive.rs:124,136).
 
-#[test]
-fn cjpegli_p0_huffman_error() {
-    // noise_47x63 at distance 5, sub=422, p=0 → "invalid Huffman table 0"
-    let data: &[u8] =
-        include_bytes!("testdata/permutation_regression/cjpegli_p0_huffman_noise_47x63_d5.jpg");
-    let err = decode_zen(data).expect_err(
-        "cjpegli p=0 Huffman bug: currently fails; if this decodes, bug is fixed",
-    );
-    assert!(
-        err.contains("Huffman") || err.contains("huffman"),
-        "bug signature changed: {err}"
-    );
+fn assert_decodes_ok(data: &[u8], label: &str) {
+    decode_zen(data).unwrap_or_else(|e| panic!("{label} must decode after table-slot fix: {e}"));
 }
 
 #[test]
-fn cjpegli_p0_ac_error() {
-    // noise_64x64 at distance 5, sub=422, p=0 → "AC coefficient index out of bounds"
+fn cjpegli_p0_huffman_decodes() {
+    // noise_47x63 at distance 5, sub=422, p=0
+    let data: &[u8] =
+        include_bytes!("testdata/permutation_regression/cjpegli_p0_huffman_noise_47x63_d5.jpg");
+    assert_decodes_ok(data, "cjpegli p=0 Huffman fixture");
+}
+
+#[test]
+fn cjpegli_p0_ac_decodes() {
+    // noise_64x64 at distance 5, sub=422, p=0
     let data: &[u8] =
         include_bytes!("testdata/permutation_regression/cjpegli_p0_ac_noise_64x64_d5.jpg");
-    let err = decode_zen(data).expect_err(
-        "cjpegli p=0 AC bug: currently fails; if this decodes, bug is fixed",
-    );
-    assert!(
-        err.contains("AC coefficient") || err.contains("out of bounds"),
-        "bug signature changed: {err}"
-    );
+    assert_decodes_ok(data, "cjpegli p=0 AC fixture");
 }

--- a/zenjpeg/tests/permutation_regression.rs
+++ b/zenjpeg/tests/permutation_regression.rs
@@ -28,72 +28,6 @@ fn decode_zen(data: &[u8]) -> Result<(u32, u32, Vec<u8>), String> {
     Ok((w, h, pixels))
 }
 
-fn decode_mozjpeg_rgb(data: &[u8]) -> Result<(u32, u32, Vec<u8>), String> {
-    use mozjpeg_sys::*;
-    use std::mem;
-
-    unsafe {
-        let mut err: jpeg_error_mgr = mem::zeroed();
-        jpeg_std_error(&mut err);
-
-        let mut cinfo: jpeg_decompress_struct = mem::zeroed();
-        cinfo.common.err = &mut err;
-        jpeg_create_decompress(&mut cinfo);
-
-        jpeg_mem_src(&mut cinfo, data.as_ptr(), data.len() as _);
-        if jpeg_read_header(&mut cinfo, true as boolean) != 1 {
-            jpeg_destroy_decompress(&mut cinfo);
-            return Err("mozjpeg: bad header".into());
-        }
-        cinfo.out_color_space = J_COLOR_SPACE::JCS_RGB;
-        if jpeg_start_decompress(&mut cinfo) == 0 {
-            jpeg_destroy_decompress(&mut cinfo);
-            return Err("mozjpeg: start_decompress failed".into());
-        }
-        let width = cinfo.output_width;
-        let height = cinfo.output_height;
-        let row_stride = width as usize * cinfo.output_components as usize;
-        let mut out = vec![0u8; height as usize * row_stride];
-        while cinfo.output_scanline < height {
-            let offset = cinfo.output_scanline as usize * row_stride;
-            let mut row_ptr = out[offset..].as_mut_ptr();
-            jpeg_read_scanlines(&mut cinfo, &mut row_ptr, 1);
-        }
-        jpeg_finish_decompress(&mut cinfo);
-        jpeg_destroy_decompress(&mut cinfo);
-        Ok((width, height, out))
-    }
-}
-
-fn normalize_to_rgb(w: u32, h: u32, pixels: Vec<u8>) -> Vec<u8> {
-    let n = w as usize * h as usize;
-    if pixels.len() == n * 3 {
-        pixels
-    } else if pixels.len() == n {
-        let mut rgb = Vec::with_capacity(n * 3);
-        for v in pixels {
-            rgb.push(v);
-            rgb.push(v);
-            rgb.push(v);
-        }
-        rgb
-    } else {
-        panic!("unexpected pixel length {} for {w}x{h}", pixels.len());
-    }
-}
-
-fn max_abs_diff(a: &[u8], b: &[u8]) -> u8 {
-    assert_eq!(a.len(), b.len());
-    let mut m = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        let d = (*x as i16 - *y as i16).unsigned_abs() as u8;
-        if d > m {
-            m = d;
-        }
-    }
-    m
-}
-
 // ── Bug 1 (FIXED): cjpegli XYB sequential mode (-p 0) ──────────────────────
 //
 // Was: cjpegli --xyb -p 0 --chroma_subsampling={444,422,420} produced JPEGs
@@ -141,50 +75,45 @@ fn xyb_p0_sub420_decodes() {
     assert_xyb_decodes(data, "XYB p=0 sub=420");
 }
 
-// ── Bug 2: non-uniform chroma subsampling (-sample 2x2,2x1,1x2) ────────────
+// ── Bug 2 (REJECTED): non-uniform chroma subsampling `-sample 2x2,2x1,1x2` ─
 //
-// cjpeg with Y:(2H,2V), Cb:(2H,1V), Cr:(1H,2V) produces JPEG files zenjpeg
-// decodes with max pixel diff up to 49 vs mozjpeg. Normal subsampling
-// (444/422/420/440/411) has max diff ≤ 7 across the full corpus. 162 files
-// in the generated corpus exhibit this.
+// Was: cjpeg with Y:(2H,2V), Cb:(2H,1V), Cr:(1H,2V) produced files zenjpeg
+// silently decoded with wrong pixels (max diff up to 49 vs mozjpeg on 96×72
+// sources). The entire decode pipeline — buffer allocation, upsample
+// dispatch, color conversion — assumes both chroma components share the
+// same ratio relative to luma. Fixing this properly requires per-chroma-
+// component upsampling buffers and dispatch, which is a substantial
+// refactor. Non-uniform chroma subsampling is vanishingly rare in real-
+// world JPEGs (standard encoders don't produce it by default; we triggered
+// it intentionally via cjpeg's exotic `-sample` syntax).
+//
+// Decision: reject at parse time with UnsupportedFeature rather than
+// silently produce wrong pixels. This follows the zero-tolerance rule for
+// image corruption. If we ever need to support it, the fix lives in
+// parser/markers.rs (remove the rejection), pipeline.rs (per-component
+// chroma buffer sizing), and output.rs (per-component upsample dispatch).
 
-#[test]
-fn mixed1_q5_has_small_diff() {
-    // Q5 noise_96x72: recorded max_diff = 10 vs mozjpeg. Asserting > 8 so
-    // the test fails when the bug is fixed (expected post-fix: ≤ 7).
-    let data: &[u8] = include_bytes!("testdata/permutation_regression/mixed1_q5_noise_96x72.jpg");
-    let (zw, zh, zp) = decode_zen(data).expect("decodes");
-    let (mw, mh, mp) = decode_mozjpeg_rgb(data).expect("mozjpeg decodes");
-    assert_eq!((zw, zh), (mw, mh));
-    let zrgb = normalize_to_rgb(zw, zh, zp);
-    let mrgb = normalize_to_rgb(mw, mh, mp);
-    let max = max_abs_diff(&zrgb, &mrgb);
+fn assert_mixed_chroma_rejected(data: &[u8], label: &str) {
+    let err = decode_zen(data)
+        .err()
+        .unwrap_or_else(|| panic!("{label} should return an error, got success"));
     assert!(
-        max > 8,
-        "mixed1 Q5 max_diff={max} (expected > 8 while bug exists). \
-         If max_diff ≤ 8, the non-uniform-subsampling bug is fixed — \
-         update or remove this test"
+        err.contains("non-uniform chroma subsampling"),
+        "{label}: unexpected error signature: {err}"
     );
 }
 
 #[test]
-fn mixed1_q75_has_large_diff() {
-    // Q75 patches_96x72: recorded max_diff = 49 vs mozjpeg. Asserting > 30
-    // to leave headroom for small changes while still failing on a real fix.
+fn mixed1_q5_rejected() {
+    let data: &[u8] = include_bytes!("testdata/permutation_regression/mixed1_q5_noise_96x72.jpg");
+    assert_mixed_chroma_rejected(data, "mixed1 Q5");
+}
+
+#[test]
+fn mixed1_q75_rejected() {
     let data: &[u8] =
         include_bytes!("testdata/permutation_regression/mixed1_q75_patches_96x72.jpg");
-    let (zw, zh, zp) = decode_zen(data).expect("decodes");
-    let (mw, mh, mp) = decode_mozjpeg_rgb(data).expect("mozjpeg decodes");
-    assert_eq!((zw, zh), (mw, mh));
-    let zrgb = normalize_to_rgb(zw, zh, zp);
-    let mrgb = normalize_to_rgb(mw, mh, mp);
-    let max = max_abs_diff(&zrgb, &mrgb);
-    assert!(
-        max > 30,
-        "mixed1 Q75 max_diff={max} (expected > 30 while bug exists). \
-         If max_diff ≤ 30, the non-uniform-subsampling bug is fixed — \
-         update or remove this test"
-    );
+    assert_mixed_chroma_rejected(data, "mixed1 Q75");
 }
 
 // ── Bug 3 (FIXED): cjpegli -p 0 Huffman / AC errors ────────────────────────

--- a/zenjpeg/tests/permutation_regression.rs
+++ b/zenjpeg/tests/permutation_regression.rs
@@ -152,8 +152,7 @@ fn xyb_p0_sub420_decodes() {
 fn mixed1_q5_has_small_diff() {
     // Q5 noise_96x72: recorded max_diff = 10 vs mozjpeg. Asserting > 8 so
     // the test fails when the bug is fixed (expected post-fix: ≤ 7).
-    let data: &[u8] =
-        include_bytes!("testdata/permutation_regression/mixed1_q5_noise_96x72.jpg");
+    let data: &[u8] = include_bytes!("testdata/permutation_regression/mixed1_q5_noise_96x72.jpg");
     let (zw, zh, zp) = decode_zen(data).expect("decodes");
     let (mw, mh, mp) = decode_mozjpeg_rgb(data).expect("mozjpeg decodes");
     assert_eq!((zw, zh), (mw, mh));


### PR DESCRIPTION
## Problem

The entire YCbCr decode pipeline — buffer allocation, upsample dispatch, color conversion — assumes Cb and Cr share the same sampling factors relative to luma. zenjpeg's subsampling detection at \`pipeline.rs:168\` consults only Cb's factors, and the chroma strip allocation at \`pipeline.rs:191\` uses Cb's dimensions for both chroma planes.

Files with asymmetric chroma subsampling (e.g. \`cjpeg -sample 2x2,2x1,1x2\`: Y=(2,2), Cb=(2,1), Cr=(1,2)) silently produced wrong pixels. The permutation corpus from #30 surfaced this: max diff **49** vs mozjpeg on 96×72 sources, with lesser diffs (down to bit-exact) on smaller sources where mis-upsampled chroma was visually invisible. The \"close enough\" cases are not correct — they're lucky.

## Fix

Per the zero-tolerance rule for silent pixel corruption, reject these files at parse time with \`UnsupportedFeature\`. The check lives in \`parser/markers.rs\` inside the SOF handler, right after all component sampling factors are known.

**Scope**: only traditional YCbCr JPEGs (numeric component IDs). The check is skipped when component IDs are \`'R'\`/\`'G'\`/\`'B'\` (82/71/66), because:

- RGB JPEGs (from \`cjpeg -rgb\`) have no chroma subsampling at all
- **XYB JPEGs legitimately use asymmetric sampling** — zenjpeg's own XYB encoder writes R=G=(2,2), B=(1,1) because R/G are the perceptually important channels. An earlier version of this PR broke all XYB encode/decode tests; scoping the check to YCbCr component IDs fixes that.

Supporting asymmetric chroma correctly requires per-component chroma buffer sizing, per-component upsample dispatch, and potentially different pre/post-processing paths — a substantial refactor not warranted for a feature no real-world encoder produces.

## Results

Permutation corpus (25,442 files) before:
- \`diff_large (>8): 162\`
- \`max_diff seen: 49\`

After:
- \`diff_large (>8): 0\`
- \`max_diff seen: 7\`  (IDCT rounding only)
- \`zen_err_moz_ok: 2682\` (all mixed1 files cleanly rejected, previously silently wrong)

## Test plan
- [x] 7/7 regression fixtures in \`permutation_regression.rs\` pass (2 of them flipped from assert-silent-wrong-output to assert-clean-error)
- [x] Full \`cargo test --release --features decoder -p zenjpeg\` — entire suite green, including \`codec_coverage::decode_xyb\` and \`roundtrip_xyb\`
- [x] Full permutation corpus validator: \`max_diff: 49 → 7\`, \`diff_large: 162 → 0\`

## Stacking

This PR is stacked on top of #31 (\`fix/cjpegli-p0-ac-desync\`) which is itself on top of #30. The base branch is set to \`fix/cjpegli-p0-ac-desync\` so GitHub will show only this PR's diff. Merge order: #30 → #31 → this PR.

## Known follow-up

Proper support for non-uniform chroma subsampling would need to live at three layers:
1. \`parser/markers.rs\`: remove this rejection
2. \`pipeline.rs\`: per-chroma-component strip sizing
3. \`output.rs\`: per-chroma-component upsample dispatch

No users are known to need it. Leave a follow-up issue only if a real use case appears.