### PR TITLE
fix(ci): unbreak C++ Parity job on macOS, Windows, and Linux

### DIFF
--- a/internal/jpegli-internals-sys/build.rs
+++ b/internal/jpegli-internals-sys/build.rs
@@ -165,6 +165,12 @@ fn build_jpegli_test_ffi(jpegli_root: &Path, build_dir: &Path, target: &str) {
     if !target.contains("msvc") {
         build.flag("-Wno-unused-parameter");
         build.flag("-Wno-sign-compare");
+        // Promote infinite-recursion to a hard error so the next typo
+        // (like the aligned_alloc_xplat self-call we shipped for two weeks)
+        // breaks the build instead of silently producing an FFI that
+        // returns zero buffers at runtime. Clang-specific; GCC ignores it
+        // because the warning name doesn't exist there.
+        build.flag_if_supported("-Werror=infinite-recursion");
     }
 
     build.compile("jpegli_test_ffi");

--- a/zenjpeg/src/encode/dct.rs
+++ b/zenjpeg/src/encode/dct.rs
@@ -893,6 +893,8 @@ mod tests {
 
     #[test]
     fn test_dct_dc_only() {
+        // Lock prevents permutation tests from disabling AVX2 while we summon tokens.
+        let _lock = archmage::testing::lock_token_testing();
         // Constant block should have only DC coefficient
         let input = [128.0f32; DCT_BLOCK_SIZE];
         let output = forward_dct_8x8(&input);
@@ -913,6 +915,7 @@ mod tests {
 
     #[test]
     fn test_dct_zero_block() {
+        let _lock = archmage::testing::lock_token_testing();
         let input = [0.0f32; DCT_BLOCK_SIZE];
         let output = forward_dct_8x8(&input);
 
@@ -923,6 +926,7 @@ mod tests {
 
     #[test]
     fn test_dct_u8_level_shift() {
+        let _lock = archmage::testing::lock_token_testing();
         // All 128s should produce near-zero output (after -128 shift)
         let input = [128u8; DCT_BLOCK_SIZE];
         let output = forward_dct_8x8_u8(&input);
@@ -951,6 +955,7 @@ mod tests {
 
     #[test]
     fn test_simd_transpose_matches_scalar() {
+        let _lock = archmage::testing::lock_token_testing();
         let mut input = [0.0f32; 64];
         for i in 0..64 {
             input[i] = (i as f32 * 1.7).sin() * 100.0;
@@ -975,6 +980,7 @@ mod tests {
 
     #[test]
     fn test_simd_dct_rows_matches_scalar() {
+        let _lock = archmage::testing::lock_token_testing();
         // Test with various input patterns
         let patterns: Vec<[f32; 64]> = vec![
             // Constant block
@@ -1043,6 +1049,7 @@ mod tests {
 
     #[test]
     fn test_aan_dct_matches_recursive() {
+        let _lock = archmage::testing::lock_token_testing();
         // Test AAN DCT against recursive implementation with various patterns
         let patterns: Vec<[f32; 64]> = vec![
             // Constant block

--- a/zenjpeg/tests/q100_comparison.rs
+++ b/zenjpeg/tests/q100_comparison.rs
@@ -85,12 +85,19 @@ fn test_q100_rust_vs_cpp() {
     let rust_time = rust_start.elapsed();
 
     // C++ Q100 encoding - BASELINE (sequential) mode
-    let tmp_png = "/tmp/q100_test_input.png";
-    std::fs::write(tmp_png, &png_data).unwrap();
-    let cpp_out = "/tmp/q100_cpp_output.jpg";
+    let tmp_dir = std::env::temp_dir();
+    let tmp_png = tmp_dir.join("q100_test_input.png");
+    std::fs::write(&tmp_png, &png_data).unwrap();
+    let cpp_out = tmp_dir.join("q100_cpp_output.jpg");
     let cpp_start = Instant::now();
     let status = Command::new(&cjpegli_path)
-        .args([tmp_png, cpp_out, "-q", "100", "--progressive_level=0"])
+        .args([
+            tmp_png.to_str().unwrap(),
+            cpp_out.to_str().unwrap(),
+            "-q",
+            "100",
+            "--progressive_level=0",
+        ])
         .output()
         .unwrap();
     let cpp_time = cpp_start.elapsed();
@@ -102,7 +109,7 @@ fn test_q100_rust_vs_cpp() {
         );
         return;
     }
-    let cpp_jpeg = std::fs::read(cpp_out).unwrap();
+    let cpp_jpeg = std::fs::read(&cpp_out).unwrap();
 
     // Decode and compute quality
     let (rust_decoded, rw, rh) = decode_jpeg(&rust_jpeg).unwrap();
@@ -147,6 +154,7 @@ fn test_q100_rust_vs_cpp() {
     );
 
     // Save for manual inspection
-    std::fs::write("/tmp/q100_rust_output.jpg", &rust_jpeg).unwrap();
-    println!("\n  Saved: /tmp/q100_rust_output.jpg, /tmp/q100_cpp_output.jpg");
+    let rust_out = tmp_dir.join("q100_rust_output.jpg");
+    std::fs::write(&rust_out, &rust_jpeg).unwrap();
+    println!("\n  Saved: {} {}", rust_out.display(), cpp_out.display());
 }


### PR DESCRIPTION
The \`C++ Parity\` CI job has been failing on \`macos-latest\` and \`windows-latest\` since the day it was wired up (commit 356db87e, 2026-03-31). The \`ubuntu-latest\` variant has the same bugs but gets cancelled by the workflow concurrency group before reaching the failing step, so nobody noticed it's also broken.

An investigation agent ran a clean root-cause pass and found three independent bugs and a process gap. This PR fixes all four.

## 1. macOS root cause: infinite recursion in C++ FFI

Bumps the \`internal/jpegli-cpp\` submodule pointer to a fix at https://github.com/imazen/jpegli/commit/631732a5. The previous submodule commit (565609bb, the original \"cross-platform aligned_alloc\") had a typo in both wrappers:

\`\`\`cpp
inline void* aligned_alloc_xplat(size_t alignment, size_t size) {
#if defined(_MSC_VER)
  return _aligned_malloc(size, alignment);
#else
  return aligned_alloc_xplat(alignment, size);  // ← calls itself
#endif
}
\`\`\`

Clang's \`-Winfinite-recursion\` warning has been printed in every CI build for two weeks; nobody read it. On macOS clang the FFI returns all-zero buffers at runtime, and \`test_xyb_color_conversion_values\` (\`zenjpeg/tests/xyb_cpp_comparison.rs\`) asserts \`Rust=0.354, C++=0\`. GCC on Linux happens to optimize the recursion away in release mode, which is why the bug never showed up locally.

The fix is the obvious thing the original patch meant: \`std::aligned_alloc(...)\` and \`std::free(...)\`. \`<cstdlib>\` is already included.

## 2. Windows bug 1: hardcoded /tmp/ paths

\`zenjpeg/tests/q100_comparison.rs\` had \`std::fs::write(\"/tmp/q100_test_input.png\", ...)\` and two more \`/tmp/...\` paths. Switched to \`std::env::temp_dir().join(...)\`.

## 3. Windows bug 2: DCT test race against token permutation

\`test_dct_dispatch_parity\` in \`zenjpeg/src/encode/dct.rs\` uses \`archmage::testing::for_each_token_permutation\`, which holds a global mutex while temporarily disabling AVX2/FMA tokens. Six sibling DCT tests (\`test_dct_dc_only\`, \`test_dct_zero_block\`, \`test_dct_u8_level_shift\`, \`test_simd_transpose_matches_scalar\`, \`test_simd_dct_rows_matches_scalar\`, \`test_aan_dct_matches_recursive\`) call dispatched SIMD entry points without taking the lock, so when cargo-test schedules them on a sibling thread they trip \`X64V3Token::summon().unwrap()\` and panic.

The fix is the pattern \`test_mage_dct_matches_scalar\` already uses: \`let _lock = archmage::testing::lock_token_testing();\` at the top, which serializes against \`for_each_token_permutation\` through the same global mutex.

## 4. Bonus: catch the next infinite-recursion typo at build time

\`internal/jpegli-internals-sys/build.rs\` now passes \`-Werror=infinite-recursion\` (via \`flag_if_supported\` so GCC silently ignores the unknown flag). The next time someone ships a self-calling wrapper, the Linux build fails immediately instead of producing a binary that silently returns zero buffers on macOS.

## Test results (local, Linux GCC)

| Suite | Result |
|---|---|
| \`cargo test --release -p zenjpeg --features __ffi-tests\` | 119 test result lines, **0 failures** |
| \`cargo test --release -p zenjpeg --lib --tests\` | 117 test result lines, **0 failures** |
| \`cargo test --release -p zenjpeg --features __ffi-tests --test q100_comparison\` | passes (was Windows-only failure) |
| \`cargo test --release -p zenjpeg --features __ffi-tests --test xyb_cpp_comparison test_xyb_color_conversion_values\` | passes (was macOS failure) |
| \`cargo clippy ... -- -D warnings\` | clean |
| \`cargo fmt --check\` | clean |

CI on macOS/Windows has literally never been green for this job, so this push will be the first chance to see what's actually left after the four fixes land.

## Stacking

Independent of #30/#31/#32 — this branch comes off \`main\` because all four bugs predate that work. It can merge in any order.