### PR TITLE
fix(decode): support non-uniform chroma subsampling via edge-replication in f32 upsample

### DIFF
--- a/zenjpeg/src/decode/fused_parallel.rs
+++ b/zenjpeg/src/decode/fused_parallel.rs
@@ -217,6 +217,18 @@ impl<'a> JpegParser<'a> {
             return Ok(false);
         }
 
+        // Non-uniform chroma subsampling (Cb and Cr have different sampling
+        // factors, e.g. `cjpeg -sample 2x2,2x1,1x2`). All fused decode paths
+        // here assume Cb and Cr share the same chroma strip layout. The
+        // sequential f32 generic path in `output.rs` handles per-component
+        // sampling correctly; fall through to it.
+        let cb_cr_asymmetric = num_comps == 3
+            && (self.components[1].h_samp_factor != self.components[2].h_samp_factor
+                || self.components[1].v_samp_factor != self.components[2].v_samp_factor);
+        if cb_cr_asymmetric {
+            return Ok(false);
+        }
+
         // Select fused path
         let chroma_upsampling = self.chroma_upsampling;
         let idct_method = self.idct_method;

--- a/zenjpeg/src/decode/parser/output.rs
+++ b/zenjpeg/src/decode/parser/output.rs
@@ -887,7 +887,7 @@ impl<'a> JpegParser<'a> {
     /// Full-res components are clipped to image dimensions without interpolation.
     fn upsample_planes_f32(
         &self,
-        comp_planes_f32: &[Vec<f32>],
+        comp_planes_f32: &mut [Vec<f32>],
         comp_infos: &[CompInfo],
         max_h_samp: u8,
         max_v_samp: u8,
@@ -899,11 +899,58 @@ impl<'a> JpegParser<'a> {
         let mut planes_f32 = Vec::with_capacity(comp_infos.len());
 
         for (comp_idx, info) in comp_infos.iter().enumerate() {
-            let comp_plane = &comp_planes_f32[comp_idx];
-
             let plane = if info.h_samp < max_h_samp as usize || info.v_samp < max_v_samp as usize {
                 let scale_x = max_h_samp as usize / info.h_samp;
                 let scale_y = max_v_samp as usize / info.v_samp;
+
+                // Edge-replicate the block-padding region of the chroma plane
+                // before upsampling, mirroring libjpeg-turbo's
+                // `set_bottom_pointers`. Non-MCU-aligned images have stale
+                // IDCT output in the padding rows/columns, and the fancy
+                // upsamplers read `input[(in_y+1) * stride + in_x]` at image
+                // boundaries, which otherwise lands inside the garbage region.
+                //
+                // Only touches O(comp_width + comp_height) elements in the
+                // padding area; MCU-aligned files skip it entirely.
+                let real_w =
+                    (width * info.h_samp + (max_h_samp as usize) - 1) / (max_h_samp as usize);
+                let real_h =
+                    (height * info.v_samp + (max_v_samp as usize) - 1) / (max_v_samp as usize);
+                let pad_right = real_w < info.comp_width && real_w > 0;
+                let pad_bottom = real_h < info.comp_height && real_h > 0;
+
+                if pad_right || pad_bottom {
+                    let comp_plane = &mut comp_planes_f32[comp_idx];
+                    let cw = info.comp_width;
+
+                    // Right-edge column replication over real content rows.
+                    if pad_right {
+                        for row in 0..real_h {
+                            let row_start = row * cw;
+                            let last = comp_plane[row_start + real_w - 1];
+                            for x in real_w..cw {
+                                comp_plane[row_start + x] = last;
+                            }
+                        }
+                    }
+
+                    // Bottom-edge row replication (picks up any right-pad fill
+                    // from the previous step).
+                    if pad_bottom {
+                        let src_start = (real_h - 1) * cw;
+                        let src_end = src_start + cw;
+                        // Split the vec so we can borrow src immutably and
+                        // dst mutably at the same time without allocating.
+                        let (before_dst, dst_slab) = comp_plane.split_at_mut(real_h * cw);
+                        let src_row = &before_dst[src_start..src_end];
+                        for row_idx in 0..(info.comp_height - real_h) {
+                            let dst_start = row_idx * cw;
+                            dst_slab[dst_start..dst_start + cw].copy_from_slice(src_row);
+                        }
+                    }
+                }
+
+                let comp_plane: &[f32] = &comp_planes_f32[comp_idx];
 
                 match chroma_upsampling {
                     super::super::ChromaUpsampling::Triangle => upsample_libjpeg_f32(
@@ -931,6 +978,7 @@ impl<'a> JpegParser<'a> {
                     }
                 }
             } else {
+                let comp_plane = &comp_planes_f32[comp_idx];
                 // Full resolution — clip to image dimensions
                 let mut plane = vec![0.0f32; output_size];
                 for py in 0..height {
@@ -1161,7 +1209,7 @@ impl<'a> JpegParser<'a> {
 
         // Upsample and convert to output format
         let planes_f32 = self.upsample_planes_f32(
-            &comp_planes_f32,
+            &mut comp_planes_f32,
             &comp_infos,
             max_h_samp,
             max_v_samp,
@@ -1382,7 +1430,7 @@ impl<'a> JpegParser<'a> {
 
         // Upsample and convert to output format
         let planes_f32 = self.upsample_planes_f32(
-            &comp_planes_f32,
+            &mut comp_planes_f32,
             &comp_infos,
             max_h_samp,
             max_v_samp,
@@ -1551,7 +1599,7 @@ impl<'a> JpegParser<'a> {
 
         // Upsample chroma and return planes
         let mut planes_f32 = self.upsample_planes_f32(
-            &comp_planes_f32,
+            &mut comp_planes_f32,
             &comp_infos,
             max_h_samp,
             max_v_samp,

--- a/zenjpeg/src/decode/pipeline.rs
+++ b/zenjpeg/src/decode/pipeline.rs
@@ -150,6 +150,22 @@ impl StripProcessor {
     ) -> Result<Self> {
         let is_grayscale = num_components == 1;
 
+        // StripProcessor assumes Cb and Cr share the same sampling factors.
+        // Asymmetric chroma should be routed through the f32 generic path in
+        // output.rs (see `cb_h != cr_h` guards in scanline_reader /
+        // Decoder::decode / can_use_fast_i16_subsampled). If any caller slips
+        // through, panic loudly in debug builds rather than silently producing
+        // wrong chroma.
+        debug_assert!(
+            num_components < 3 || (h_samp[1] == h_samp[2] && v_samp[1] == v_samp[2]),
+            "StripProcessor requires symmetric Cb/Cr sampling factors; \
+             got Cb=({},{}) Cr=({},{})",
+            h_samp[1],
+            v_samp[1],
+            h_samp[2],
+            v_samp[2]
+        );
+
         let (max_h_samp, max_v_samp) = if is_grayscale {
             (h_samp[0], v_samp[0])
         } else {

--- a/zenjpeg/src/decode/scanline.rs
+++ b/zenjpeg/src/decode/scanline.rs
@@ -888,6 +888,18 @@ impl<'a> ScanlineReader<'a> {
         if self.num_components == 1 {
             return 0;
         }
+        // Reports a single chroma height — only valid when Cb and Cr share
+        // sampling factors. Asymmetric files are routed through the buffered
+        // f32 path in `Decoder::scanline_reader` before reaching this point.
+        debug_assert!(
+            self.strip.v_samp[1] == self.strip.v_samp[2]
+                && self.strip.h_samp[1] == self.strip.h_samp[2],
+            "chroma_height requires symmetric Cb/Cr; got Cb=({},{}) Cr=({},{})",
+            self.strip.h_samp[1],
+            self.strip.v_samp[1],
+            self.strip.h_samp[2],
+            self.strip.v_samp[2]
+        );
         // Wave-only readers have a dummy strip; derive from wave_state
         #[cfg(feature = "parallel")]
         if let Some(ref ws) = self.wave_state {

--- a/zenjpeg/tests/permutation_regression.rs
+++ b/zenjpeg/tests/permutation_regression.rs
@@ -141,50 +141,57 @@ fn xyb_p0_sub420_decodes() {
     assert_xyb_decodes(data, "XYB p=0 sub=420");
 }
 
-// ── Bug 2: non-uniform chroma subsampling (-sample 2x2,2x1,1x2) ────────────
+// ── Bug 2 (FIXED): non-uniform chroma subsampling `-sample 2x2,2x1,1x2` ────
 //
-// cjpeg with Y:(2H,2V), Cb:(2H,1V), Cr:(1H,2V) produces JPEG files zenjpeg
-// decodes with max pixel diff up to 49 vs mozjpeg. Normal subsampling
-// (444/422/420/440/411) has max diff ≤ 7 across the full corpus. 162 files
-// in the generated corpus exhibit this.
+// Was: cjpeg with Y:(2H,2V), Cb:(2H,1V), Cr:(1H,2V) produced files zenjpeg
+// decoded with wrong pixels (max diff up to 49 vs mozjpeg on 96×72 sources).
+// All four fast paths correctly gated asymmetric chroma, so these files
+// reached the f32 generic decode path in `parser/output.rs::to_pixels`.
+// That path already allocates per-component planes with per-component
+// sampling factors and applies per-component upsamplers — but it was
+// reading the block-padded region of the chroma plane without edge-
+// replicating the last real row/column first, so the upsamplers saw
+// stale IDCT output from the padding blocks at image boundaries.
+//
+// Fix: `upsample_planes_f32` now materializes a padded copy of the
+// component plane with the last real row / column replicated into the
+// padding region before dispatching to the upsampler — mirroring
+// libjpeg-turbo's `set_bottom_pointers`. Only allocates when the image
+// isn't MCU-aligned and the component is actually subsampled; no-op
+// for aligned files.
+//
+// Also adds a missing asymmetric-chroma guard to `fused_parallel.rs` so
+// files with Cb≠Cr fall through to the sequential coefficient path
+// instead of the parallel fused path (which hard-codes symmetric chroma).
 
-#[test]
-fn mixed1_q5_has_small_diff() {
-    // Q5 noise_96x72: recorded max_diff = 10 vs mozjpeg. Asserting > 8 so
-    // the test fails when the bug is fixed (expected post-fix: ≤ 7).
-    let data: &[u8] = include_bytes!("testdata/permutation_regression/mixed1_q5_noise_96x72.jpg");
-    let (zw, zh, zp) = decode_zen(data).expect("decodes");
-    let (mw, mh, mp) = decode_mozjpeg_rgb(data).expect("mozjpeg decodes");
-    assert_eq!((zw, zh), (mw, mh));
+fn assert_decodes_close_to_mozjpeg(data: &[u8], label: &str, threshold: u8) {
+    let (zw, zh, zp) =
+        decode_zen(data).unwrap_or_else(|e| panic!("{label}: zen decode failed: {e}"));
+    let (mw, mh, mp) =
+        decode_mozjpeg_rgb(data).unwrap_or_else(|e| panic!("{label}: moz decode failed: {e}"));
+    assert_eq!((zw, zh), (mw, mh), "{label}: dim mismatch");
     let zrgb = normalize_to_rgb(zw, zh, zp);
     let mrgb = normalize_to_rgb(mw, mh, mp);
     let max = max_abs_diff(&zrgb, &mrgb);
     assert!(
-        max > 8,
-        "mixed1 Q5 max_diff={max} (expected > 8 while bug exists). \
-         If max_diff ≤ 8, the non-uniform-subsampling bug is fixed — \
-         update or remove this test"
+        max <= threshold,
+        "{label} max_diff={max} exceeds threshold {threshold} vs mozjpeg"
     );
 }
 
 #[test]
-fn mixed1_q75_has_large_diff() {
-    // Q75 patches_96x72: recorded max_diff = 49 vs mozjpeg. Asserting > 30
-    // to leave headroom for small changes while still failing on a real fix.
+fn mixed1_q5_decodes_correctly() {
+    // noise_96x72, Q5, `cjpeg -sample 2x2,2x1,1x2`. Pre-fix max_diff was 10.
+    let data: &[u8] = include_bytes!("testdata/permutation_regression/mixed1_q5_noise_96x72.jpg");
+    assert_decodes_close_to_mozjpeg(data, "mixed1 Q5 noise_96x72", 7);
+}
+
+#[test]
+fn mixed1_q75_decodes_correctly() {
+    // patches_96x72, Q75, `cjpeg -sample 2x2,2x1,1x2`. Pre-fix max_diff was 49.
     let data: &[u8] =
         include_bytes!("testdata/permutation_regression/mixed1_q75_patches_96x72.jpg");
-    let (zw, zh, zp) = decode_zen(data).expect("decodes");
-    let (mw, mh, mp) = decode_mozjpeg_rgb(data).expect("mozjpeg decodes");
-    assert_eq!((zw, zh), (mw, mh));
-    let zrgb = normalize_to_rgb(zw, zh, zp);
-    let mrgb = normalize_to_rgb(mw, mh, mp);
-    let max = max_abs_diff(&zrgb, &mrgb);
-    assert!(
-        max > 30,
-        "mixed1 Q75 max_diff={max} (expected > 30 while bug exists). \
-         If max_diff ≤ 30, the non-uniform-subsampling bug is fixed — \
-         update or remove this test"
-    );
+    assert_decodes_close_to_mozjpeg(data, "mixed1 Q75 patches_96x72", 7);
 }
 
 // ── Bug 3 (FIXED): cjpegli -p 0 Huffman / AC errors ────────────────────────


### PR DESCRIPTION
Replaces #32 (the rejection PR). The slow-path approach works: all 162 diff_large files in the permutation corpus now decode within the IDCT rounding envelope (max_diff ≤ 7).

## Problem

JPEG files with asymmetric Cb/Cr chroma subsampling (e.g. \`cjpeg -sample 2x2,2x1,1x2\` which produces Y=(2,2), Cb=(2,1), Cr=(1,2)) previously decoded with max_diff up to 49 vs mozjpeg on 96×72 sources in the permutation corpus surfaced by #30. 162 files in the 25,442-file corpus exhibited this.

## Investigation

All four fast paths (\`can_use_streaming\`, \`can_use_fast_i16_path\`, \`can_use_fast_i16_subsampled\`, and the \`cb_h != cr_h\` guards in \`Decoder::scanline_reader\` and \`Decoder::decode\`) already route asymmetric files to the f32 generic decode path in \`parser/output.rs::to_pixels\`. That path allocates per-component planes at per-component dimensions and dispatches to per-axis upsamplers (\`upsample_h2v1_f32_libjpeg\`, \`upsample_h1v2_f32_libjpeg\`, \`upsample_h2v2_f32_libjpeg\`, and the (1,1) identity). So the routing was correct.

The actual bug was in **what the upsamplers read at the image boundary**:

- zenjpeg allocates each component's plane at **block-aligned** dimensions (\`comp_blocks_h × 8\` × \`comp_blocks_v × 8\`) because the IDCT writes 8×8 blocks.
- For non-MCU-aligned images, the last block row / column of the chroma plane sits **outside** the image's real chroma rectangle and contains stale IDCT output from whatever the encoder wrote into the padding blocks.
- \`upsample_h1v2_f32_libjpeg\` reads \`input[(in_y+1) * stride + in_x]\` at the bottom boundary to interpolate with the row below. \`in_height\` was passed as the block-aligned dimension, so the \`in_y.min(in_height-1)\` clamp didn't stop these reads from landing inside the padding region.
- libjpeg-turbo handles this via \`set_bottom_pointers\`, which edge-replicates the last real row over the MCU padding before upsampling.

The bug affected symmetric subsampled files (4:2:0 / 4:2:2 / 4:4:0) at image boundaries too but much less visibly — the symmetric cases' padding rows happened to produce interpolation errors small enough to stay inside the ≤ 7 IDCT rounding envelope. The asymmetric cases accumulated the error on both Cb (bottom) and Cr (right), which is why they blew out to max_diff 49.

## Fix

\`upsample_planes_f32\` now materializes a padded copy of the component plane with the last real row and last real column replicated into the block-padding region before dispatching to the upsampler. Real dimensions are computed as \`ceil(image_dim * comp_samp / max_samp)\`. The copy only allocates when \`real_w < comp_width\` or \`real_h < comp_height\` — i.e. only when the image is not MCU-aligned *and* the component is actually subsampled. MCU-aligned files, full-resolution components (Y in 4:2:x), and grayscale take a zero-cost fast path.

Also adds a missing asymmetric-chroma early-out to \`fused_parallel.rs\` so Cb≠Cr files fall through to the sequential coefficient path instead of the parallel fused path (which hard-codes symmetric chroma). The other four fast paths already had this guard; \`fused_parallel\` was the only one missing it.

Two defensive \`debug_assert!\`s catch future regressions:
- \`StripProcessor::new\` in \`pipeline.rs\` asserts Cb/Cr sampling match
- \`ScanlineReader::chroma_height\` in \`scanline.rs\` asserts the same

## Results

Permutation corpus (25,442 files) before → after:

| Metric | Before | After |
|---|---|---|
| \`diff_large\` (>8) | 162 | **0** |
| \`max_diff\` seen | 49 | **7** (pure IDCT rounding) |
| \`zen_err_moz_ok\` | 0 | 0 |

Regression fixtures:

| Fixture | Before | After |
|---|---|---|
| \`mixed1_q5_noise_96x72\` | max_diff 10 | **2** |
| \`mixed1_q75_patches_96x72\` | max_diff 49 | **2** |

## Test plan

- [x] \`cargo test --release --features decoder -p zenjpeg --test permutation_regression\` — 7/7 pass (mixed1 fixtures now assert decode+compare against mozjpeg within 7, not \"reject with error\")
- [x] \`cargo test --release --features decoder -p zenjpeg\` — full suite, 120 test result lines, 0 failures
- [x] \`cargo test --release --features decoder -p zenjpeg --test permutation_corpus_decode -- --nocapture --ignored\` — all 25,442 files green, max_diff 7
- [x] \`cargo clippy ... -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean

## Replaces #32

This supersedes #32 (fix/nonuniform-chroma-subsampling), which took the bail-out approach of rejecting asymmetric files at SOF parse time with \`UnsupportedFeature\`. That approach followed the zero-tolerance correctness rule but sacrificed 2,682 corpus files. This slow-path approach actually decodes them correctly. Close #32 in favor of this.

## Stacking

Independent of #33 (fix/cpp-parity-ci). Branched off current main. No dependencies.