### PR TITLE
fix(decode): complete AC refinement at end of progressive scan

### DIFF
--- a/zenjpeg/src/decode/mod.rs
+++ b/zenjpeg/src/decode/mod.rs
@@ -3617,3 +3617,19 @@ mod quality_estimation_tests {
         );
     }
 }
+
+/// Decode a JPEG and return the raw DCT coefficients per component.
+///
+/// Each component is a `Vec<[i16; 64]>` of blocks in raster order (left-to-right,
+/// top-to-bottom). Coefficients are in JPEG zigzag order within each block.
+///
+/// Only available with the `__test-utils` feature.
+#[cfg(feature = "__test-utils")]
+pub fn decode_coefficients(
+    data: &[u8],
+) -> crate::error::Result<Vec<Vec<[i16; crate::foundation::consts::DCT_BLOCK_SIZE]>>> {
+    use enough::Unstoppable;
+    let mut parser = parser::JpegParser::new(data, 0, None)?;
+    parser.decode(&Unstoppable)?;
+    Ok(parser.coeffs)
+}

--- a/zenjpeg/src/entropy/decoder.rs
+++ b/zenjpeg/src/entropy/decoder.rs
@@ -1852,57 +1852,78 @@ impl<'data, 'tables> EntropyDecoder<'data, 'tables> {
                 let _ = self.reader.ensure_bits();
 
                 while k <= se_usize {
-                    // Refill when bits are low. Fast lookup needs 9 bits minimum;
-                    // 25 covers one full Huffman event (16-bit code + 1 sign + 8 refine).
+                    // Refill when bits are low.
                     if self.reader.bits_available() < 25 {
                         let _ = self.reader.ensure_bits();
-                        if self.reader.bits_available() < 9 {
-                            break; // Not enough for even a fast Huffman lookup
-                        }
                     }
 
-                    // Huffman decode: peek_top is safe because we have >= 9 bits.
-                    // Fast lookup (positive) always has code_len <= 9, so no overflow.
-                    let bits9 = self.reader.peek_top(9) as usize;
-                    let lookup = ac_table.fast_lookup[bits9];
-                    let symbol = if lookup >= 0 {
-                        let code_len = (lookup >> 8) as u8;
-                        self.reader.skip_bits_fast(code_len);
-                        (lookup & 0xFF) as u8
-                    } else {
-                        // Slow path: extended codes need up to 16 bits
-                        if self.reader.bits_available() < 16 {
-                            let _ = self.reader.refill();
-                        }
-                        if self.reader.bits_available() >= 16 {
-                            let bits16 = self.reader.peek_top(16);
-                            if let Some((sym, len)) = ac_table.decode_slow(bits16 as i32) {
-                                self.reader.skip_bits_fast(len);
-                                sym
-                            } else {
-                                break;
-                            }
+                    // Huffman decode with tiered fallback: fast (≥9 bits) →
+                    // slow (≥16 bits) → bit-by-bit (any count). The previous
+                    // code broke out of the loop when < 9 bits remained,
+                    // skipping refinement of the last coefficients in the last
+                    // block of a scan. The bit-by-bit fallback handles this
+                    // correctly by reading one bit at a time.
+                    let symbol = if self.reader.bits_available() >= 9 {
+                        let bits9 = self.reader.peek_top(9) as usize;
+                        let lookup = ac_table.fast_lookup[bits9];
+                        if lookup >= 0 {
+                            let code_len = (lookup >> 8) as u8;
+                            self.reader.skip_bits_fast(code_len);
+                            (lookup & 0xFF) as u8
                         } else {
-                            // Edge case: near restart marker or end of scan,
-                            // fewer than 16 bits available. Fall back to
-                            // bit-by-bit Huffman decode.
-                            let mut code = 0u32;
-                            let mut found_symbol = None;
-                            for len in 1..=16usize {
-                                let bit = self.reader.read_bit_refine();
-                                code = (code << 1) | (bit as u32);
-                                if (code as i32) <= ac_table.maxcode[len] {
-                                    let idx = (code as i32 + ac_table.valoffset[len]) as usize;
-                                    if idx < ac_table.values.len() {
-                                        found_symbol = Some(ac_table.values[idx]);
-                                        break;
+                            // Code is > 9 bits — try slow path with 16-bit peek
+                            if self.reader.bits_available() < 16 {
+                                let _ = self.reader.refill();
+                            }
+                            if self.reader.bits_available() >= 16 {
+                                let bits16 = self.reader.peek_top(16);
+                                if let Some((sym, len)) = ac_table.decode_slow(bits16 as i32) {
+                                    self.reader.skip_bits_fast(len);
+                                    sym
+                                } else {
+                                    break;
+                                }
+                            } else {
+                                // < 16 bits: bit-by-bit fallback (below)
+                                let mut code = 0u32;
+                                let mut found_symbol = None;
+                                for len in 1..=16usize {
+                                    let bit = self.reader.read_bit_refine();
+                                    code = (code << 1) | (bit as u32);
+                                    if (code as i32) <= ac_table.maxcode[len] {
+                                        let idx = (code as i32 + ac_table.valoffset[len]) as usize;
+                                        if idx < ac_table.values.len() {
+                                            found_symbol = Some(ac_table.values[idx]);
+                                            break;
+                                        }
                                     }
                                 }
+                                match found_symbol {
+                                    Some(sym) => sym,
+                                    None => break,
+                                }
                             }
-                            match found_symbol {
-                                Some(sym) => sym,
-                                None => break,
+                        }
+                    } else {
+                        // < 9 bits after refill: near end of scan or restart
+                        // marker. Use bit-by-bit Huffman fallback so the last
+                        // block's high-frequency coefficients still get refined.
+                        let mut code = 0u32;
+                        let mut found_symbol = None;
+                        for len in 1..=16usize {
+                            let bit = self.reader.read_bit_refine();
+                            code = (code << 1) | (bit as u32);
+                            if (code as i32) <= ac_table.maxcode[len] {
+                                let idx = (code as i32 + ac_table.valoffset[len]) as usize;
+                                if idx < ac_table.values.len() {
+                                    found_symbol = Some(ac_table.values[idx]);
+                                    break;
+                                }
                             }
+                        }
+                        match found_symbol {
+                            Some(sym) => sym,
+                            None => break,
                         }
                     };
 


### PR DESCRIPTION
## Problem

\`decode_ac_refine_scan\` broke out of its Huffman decode loop when fewer than 9 bits remained in the bit buffer after refill (\`entropy/decoder.rs:1859-1860\`). This skipped the refinement of high-frequency AC coefficients (zigzag positions 61-63) in the **last block of each progressive AC scan**. libjpeg-turbo continues with bit-by-bit Huffman decoding in this situation.

The result: coefficients at the end of the last block were off by ±1 from the reference. After IDCT, this produced pixel errors of up to **7** at the corresponding spatial positions — always in the last column of blocks, always on progressive JPEGs at Q92/Q97.

## Fix

When < 9 bits remain after refill, fall through to the existing bit-by-bit Huffman fallback (which reads one bit at a time and handles any remaining count) instead of breaking. The bit-by-bit path was already present for the < 16 bits case; this change routes < 9 bits to it too, completing the tiered fallback chain:

\`\`\`
≥ 9 bits → fast 9-bit lookup table
≥ 16 bits (but fast lookup missed) → slow 16-bit maxcode comparison
< 16 bits → bit-by-bit Huffman (reads 1 bit per iteration)
< 9 bits → **previously: break (BUG). now: bit-by-bit Huffman**
\`\`\`

## Evidence

Raw coefficient comparison (after zigzag→natural reordering) against mozjpeg's \`jpeg_read_coefficients\`:

- **Before fix**: 3 coefficient diffs in \`comp[1] block(5,7)\` at natural positions 55, 62, 63 (zigzag 61, 62, 63 — the last three positions in scan order). All ±1.
- **After fix**: **0 coefficient diffs**. Perfect match.

## Results

Permutation corpus (25,442 files):

| Metric | Before | After |
|---|---|---|
| \`max_diff seen\` | 7 | **3** |
| Files with max_diff ≥ 4 | 27 | **0** |

The entire corpus is now within the pure IDCT rounding envelope (max_diff ≤ 3). No coefficient divergence remains.

## Test plan

- [x] \`cargo test --release --features decoder -p zenjpeg\` — 120 test result lines, 0 failures
- [x] Permutation corpus validator: \`max_diff 7 → 3\`, \`diff_large: 0\`
- [x] Coefficient comparison test: 0 diffs after zigzag→natural reorder (verified via \`decode_coefficients()\` + mozjpeg \`jpeg_read_coefficients\`)
- [x] Clippy + fmt clean