### PR TITLE
feat(encode): implement Extended XMP splitting for >65KB payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3060,6 +3070,7 @@ dependencies = [
  "kamadak-exif",
  "linear-srgb",
  "magetypes",
+ "md-5",
  "moxcms 0.8.1",
  "mozjpeg-rs",
  "mozjpeg-sys",

--- a/zenjpeg/Cargo.toml
+++ b/zenjpeg/Cargo.toml
@@ -55,6 +55,7 @@ enough = { workspace = true }
 zencodec = { workspace = true }
 zenpixels = { workspace = true , version = "0.2.2" }
 tinyvec = { workspace = true }  # Stack-allocated bounded vectors
+md-5 = "0.10.6"  # MD5 for Extended XMP GUID (spec-mandated)
 linear-srgb = { workspace = true }
 whereat = { workspace = true }  # Error tracing with location tracking
 thiserror = { workspace = true }  # Error derive macros

--- a/zenjpeg/src/encode/byte_encoders.rs
+++ b/zenjpeg/src/encode/byte_encoders.rs
@@ -557,40 +557,9 @@ fn inject_exif(jpeg: Vec<u8>, exif_data: &[u8]) -> Vec<u8> {
 /// Inject XMP data into a JPEG as APP1 marker.
 ///
 /// Inserts after SOI and any existing APP1 (EXIF) markers.
-fn inject_xmp(jpeg: Vec<u8>, xmp_data: &[u8]) -> Vec<u8> {
-    if xmp_data.is_empty() {
-        return jpeg;
-    }
-
-    // Truncate if too large
-    let xmp_len = xmp_data.len().min(MAX_XMP_BYTES);
-
-    // Build XMP APP1 marker
-    let mut marker = Vec::with_capacity(4 + 29 + xmp_len);
-    marker.push(0xFF);
-    marker.push(0xE1); // APP1
-
-    // Length: 2 (length field) + 29 (namespace) + data
-    let segment_length = 2 + 29 + xmp_len;
-    marker.push((segment_length >> 8) as u8);
-    marker.push(segment_length as u8);
-
-    // XMP namespace
-    marker.extend_from_slice(XMP_NAMESPACE);
-
-    // XMP data
-    marker.extend_from_slice(&xmp_data[..xmp_len]);
-
-    // Find insertion point: after SOI and any existing EXIF APP1 markers
-    let insert_pos = find_xmp_insert_position(&jpeg);
-
-    // Construct new JPEG with XMP marker inserted
-    let mut result = Vec::with_capacity(jpeg.len() + marker.len());
-    result.extend_from_slice(&jpeg[..insert_pos]);
-    result.extend_from_slice(&marker);
-    result.extend_from_slice(&jpeg[insert_pos..]);
-
-    result
+fn inject_xmp(mut jpeg: Vec<u8>, xmp_data: &[u8]) -> Vec<u8> {
+    inject_xmp_inplace(&mut jpeg, xmp_data);
+    jpeg
 }
 
 /// Find the position to insert XMP marker (after SOI and EXIF APP1).
@@ -677,30 +646,28 @@ fn inject_xmp_inplace(jpeg: &mut Vec<u8>, xmp_data: &[u8]) {
         return;
     }
 
-    // Truncate if too large
-    let xmp_len = xmp_data.len().min(MAX_XMP_BYTES);
+    // Delegate to EncoderSegments for proper extended XMP handling
+    let segments = super::extras::EncoderSegments::new();
+    let xmp_str = core::str::from_utf8(xmp_data).unwrap_or("");
+    let segments = segments.set_xmp(xmp_str);
 
-    // Build XMP APP1 marker
-    let mut marker = Vec::with_capacity(4 + 29 + xmp_len);
-    marker.push(0xFF);
-    marker.push(0xE1); // APP1
-
-    // Length: 2 (length field) + 29 (namespace) + data
-    let segment_length = 2 + 29 + xmp_len;
-    marker.push((segment_length >> 8) as u8);
-    marker.push(segment_length as u8);
-
-    // XMP namespace
-    marker.extend_from_slice(XMP_NAMESPACE);
-
-    // XMP data
-    marker.extend_from_slice(&xmp_data[..xmp_len]);
-
-    // Find insertion point: after SOI and any existing EXIF APP1 markers
+    // Build all APP1 markers from segments
     let insert_pos = find_xmp_insert_position(jpeg);
+    let mut markers = Vec::new();
+    for seg in segments.segments() {
+        if seg.segment_type == super::extras::SegmentType::Xmp
+            || seg.segment_type == super::extras::SegmentType::XmpExtended
+        {
+            let seg_len = 2 + seg.data.len();
+            markers.push(0xFF);
+            markers.push(0xE1);
+            markers.push((seg_len >> 8) as u8);
+            markers.push(seg_len as u8);
+            markers.extend_from_slice(&seg.data);
+        }
+    }
 
-    // Insert using splice
-    jpeg.splice(insert_pos..insert_pos, marker);
+    jpeg.splice(insert_pos..insert_pos, markers);
 }
 
 /// Inject encoder segments into a JPEG in-place.

--- a/zenjpeg/src/encode/extras.rs
+++ b/zenjpeg/src/encode/extras.rs
@@ -180,6 +180,10 @@ pub struct AdobeInfo {
 /// 65535 - 2 (length) - 29 (namespace) - 2 (padding) = 65502
 const MAX_STANDARD_XMP_BYTES: usize = 65502;
 
+/// Maximum payload bytes per extended XMP chunk.
+/// 65533 (max segment data) - 35 (namespace) - 32 (GUID) - 4 (total_len) - 4 (offset) = 65458
+const MAX_EXTENDED_XMP_CHUNK_BYTES: usize = 65458;
+
 /// Maximum bytes per ICC chunk.
 /// 65535 - 2 (length) - 12 (signature) - 2 (chunk info) = 65519
 const MAX_ICC_CHUNK_BYTES: usize = 65519;
@@ -426,18 +430,60 @@ impl EncoderSegments {
                 segment_type: SegmentType::Xmp,
             });
         } else {
-            // Extended XMP - split across segments
-            // TODO: Implement extended XMP splitting
-            // For now, truncate to standard XMP size
-            let truncated = &xmp_bytes[..MAX_STANDARD_XMP_BYTES];
-            let mut data = Vec::with_capacity(XMP_NAMESPACE.len() + truncated.len());
+            // Extended XMP: split across multiple APP1 segments per the
+            // Adobe XMP Part 3 spec. The standard segment gets the first
+            // MAX_STANDARD_XMP_BYTES of the XMP string. Remaining bytes go
+            // into one or more extended segments, each prefixed with the
+            // extended namespace, a 32-char MD5 hex GUID of the full XMP,
+            // total extended length (u32 BE), and chunk offset (u32 BE).
+
+            // 1. Compute MD5 GUID of the full XMP
+            use md5::{Digest, Md5};
+            let guid = {
+                let hash = Md5::digest(xmp_bytes);
+                let mut hex = [0u8; 32];
+                for (i, byte) in hash.iter().enumerate() {
+                    let hi = byte >> 4;
+                    let lo = byte & 0x0F;
+                    hex[i * 2] = if hi < 10 { b'0' + hi } else { b'A' + hi - 10 };
+                    hex[i * 2 + 1] = if lo < 10 { b'0' + lo } else { b'A' + lo - 10 };
+                }
+                hex
+            };
+
+            // 2. Standard segment: first portion of XMP
+            let standard_bytes = &xmp_bytes[..MAX_STANDARD_XMP_BYTES];
+            let mut data = Vec::with_capacity(XMP_NAMESPACE.len() + standard_bytes.len());
             data.extend_from_slice(XMP_NAMESPACE);
-            data.extend_from_slice(truncated);
+            data.extend_from_slice(standard_bytes);
             self.segments.push(EncoderSegment {
                 marker: 0xE1,
                 data,
                 segment_type: SegmentType::Xmp,
             });
+
+            // 3. Extended segments: remaining bytes in chunks
+            let extended_bytes = &xmp_bytes[MAX_STANDARD_XMP_BYTES..];
+            let total_extended_len = extended_bytes.len() as u32;
+
+            for (chunk_idx, chunk) in extended_bytes
+                .chunks(MAX_EXTENDED_XMP_CHUNK_BYTES)
+                .enumerate()
+            {
+                let offset = (chunk_idx * MAX_EXTENDED_XMP_CHUNK_BYTES) as u32;
+                let header_len = XMP_EXTENDED_NAMESPACE.len() + 32 + 4 + 4;
+                let mut data = Vec::with_capacity(header_len + chunk.len());
+                data.extend_from_slice(XMP_EXTENDED_NAMESPACE);
+                data.extend_from_slice(&guid);
+                data.extend_from_slice(&total_extended_len.to_be_bytes());
+                data.extend_from_slice(&offset.to_be_bytes());
+                data.extend_from_slice(chunk);
+                self.segments.push(EncoderSegment {
+                    marker: 0xE1,
+                    data,
+                    segment_type: SegmentType::XmpExtended,
+                });
+            }
         }
 
         self

--- a/zenjpeg/tests/encoder_regression.rs
+++ b/zenjpeg/tests/encoder_regression.rs
@@ -108,9 +108,9 @@ fn test_dispatch_parity() {
                         if jpeg != *ref_jpeg {
                             let size_diff =
                                 (jpeg.len() as i64 - ref_jpeg.len() as i64).unsigned_abs();
-                            // Known: v4x token permutation causes small divergence at Q90
-                            // due to FP ordering differences in AQ pre_erosion.
-                            // Size diffs ≤16 bytes are tolerated (content may also differ).
+                            // Known: v4x token permutation causes small divergence
+                            // at Q90 due to FP ordering in AQ pre_erosion.
+                            // Size diffs ≤16 bytes are tolerated.
                             if size_diff <= 16 {
                                 eprintln!(
                                     "  (known parity gap at {perm}: {} vs {} bytes, size_diff={})",
@@ -158,6 +158,9 @@ fn min_zensim_score(quality: u8) -> f64 {
 
 #[test]
 fn test_quality_floor() {
+    // Lock prevents test_dispatch_parity's token permutation from changing
+    // SIMD dispatch tiers mid-encode on a concurrent thread.
+    let _lock = archmage::testing::lock_token_testing();
     let (rgb, w, h) = load_frymire();
 
     let zensim = zensim::Zensim::new(zensim::ZensimProfile::latest()).with_parallel(false);
@@ -222,6 +225,7 @@ const EXPECTED_SIZES: &[(&str, u8, usize)] = &[
 
 #[test]
 fn test_size_regression() {
+    let _lock = archmage::testing::lock_token_testing();
     let (rgb, w, h) = load_frymire();
 
     for &(config_name, quality, expected_size) in EXPECTED_SIZES {
@@ -265,6 +269,7 @@ fn test_size_regression() {
 
 #[test]
 fn test_content_checksums() {
+    let _lock = archmage::testing::lock_token_testing();
     let checksums_dir = std::path::Path::new("tests/checksums");
     std::fs::create_dir_all(checksums_dir).ok();
 

--- a/zenjpeg/tests/metadata_integration.rs
+++ b/zenjpeg/tests/metadata_integration.rs
@@ -989,3 +989,142 @@ mod cross_crate_tests {
     }
 }
 */
+
+// ── Extended XMP round-trip tests ───────────────────────────────────────────
+
+#[cfg(feature = "decoder")]
+mod extended_xmp {
+    use super::*;
+    use enough::Unstoppable;
+    use zenjpeg::decoder::Decoder;
+
+    /// Generate fake XMP of exactly `n` bytes.
+    fn make_xmp(n: usize) -> String {
+        let prefix = r#"<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="">"#;
+        let suffix = r#"</rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="w"?>"#;
+        let overhead = prefix.len() + suffix.len();
+        let padding = n.saturating_sub(overhead);
+        // Fill with valid XML attribute to reach target size
+        let fill = format!(
+            r#" xmlns:pad="x" pad:d="{}"#,
+            "X".repeat(padding.saturating_sub(22))
+        );
+        let mut s = String::with_capacity(n);
+        s.push_str(prefix);
+        s.push_str(&fill[..fill.len().min(padding)]);
+        s.push_str(suffix);
+        // Pad or truncate to exact length
+        while s.len() < n {
+            s.push(' ');
+        }
+        s.truncate(n);
+        s
+    }
+
+    fn encode_with_xmp_str(xmp: &str) -> Vec<u8> {
+        let w = 16u32;
+        let h = 16;
+        let pixels = create_test_image(w, h);
+        let cfg = EncoderConfig::ycbcr(85.0, ChromaSubsampling::None);
+        let mut enc = cfg
+            .request()
+            .xmp(xmp.as_bytes())
+            .encode_from_rgb::<RGB<u8>>(w, h)
+            .unwrap();
+        enc.push_packed(&pixels, Unstoppable).unwrap();
+        enc.finish().unwrap()
+    }
+
+    #[test]
+    fn standard_xmp_fits_in_one_segment() {
+        let xmp = make_xmp(1000);
+        let jpeg = encode_with_xmp_str(&xmp);
+        let ns = b"http://ns.adobe.com/xap/1.0/\0";
+        let ext_ns = b"http://ns.adobe.com/xmp/extension/\0";
+        assert!(
+            jpeg.windows(ns.len()).any(|w| w == ns),
+            "standard XMP namespace present"
+        );
+        assert!(
+            !jpeg.windows(ext_ns.len()).any(|w| w == ext_ns),
+            "no extended XMP for small payload"
+        );
+    }
+
+    #[test]
+    fn extended_xmp_splits_large_payload() {
+        // 100KB XMP — needs extended
+        let xmp = make_xmp(100_000);
+        let jpeg = encode_with_xmp_str(&xmp);
+        let ns = b"http://ns.adobe.com/xap/1.0/\0";
+        let ext_ns = b"http://ns.adobe.com/xmp/extension/\0";
+        assert!(
+            jpeg.windows(ns.len()).any(|w| w == ns),
+            "standard XMP present"
+        );
+        let ext_count = jpeg.windows(ext_ns.len()).filter(|w| *w == ext_ns).count();
+        assert!(ext_count >= 1, "at least one extended XMP segment");
+    }
+
+    #[test]
+    fn extended_xmp_round_trips_through_decoder() {
+        let xmp = make_xmp(100_000);
+        let jpeg = encode_with_xmp_str(&xmp);
+
+        // Decode and extract XMP
+        let result = Decoder::new().decode(&jpeg, Unstoppable).unwrap();
+        let extras = result.extras().expect("extras present");
+        let decoded_xmp = extras.xmp().expect("XMP round-tripped");
+
+        assert_eq!(decoded_xmp.len(), xmp.len(), "XMP length preserved");
+        assert_eq!(decoded_xmp, xmp, "XMP content preserved exactly");
+    }
+
+    #[test]
+    fn extended_xmp_boundary_65502() {
+        // Exactly at the boundary: should NOT need extended
+        let xmp = make_xmp(65502);
+        let jpeg = encode_with_xmp_str(&xmp);
+        let ext_ns = b"http://ns.adobe.com/xmp/extension/\0";
+        assert!(
+            !jpeg.windows(ext_ns.len()).any(|w| w == ext_ns),
+            "65502 bytes fits in standard"
+        );
+    }
+
+    #[test]
+    fn extended_xmp_boundary_65503() {
+        // One byte over: needs extended
+        let xmp = make_xmp(65503);
+        let jpeg = encode_with_xmp_str(&xmp);
+        let ext_ns = b"http://ns.adobe.com/xmp/extension/\0";
+        assert!(
+            jpeg.windows(ext_ns.len()).any(|w| w == ext_ns),
+            "65503 needs extended"
+        );
+
+        // Round-trip
+        let result = Decoder::new().decode(&jpeg, Unstoppable).unwrap();
+        let decoded = result.extras().unwrap().xmp().unwrap();
+        assert_eq!(decoded, xmp);
+    }
+
+    #[test]
+    fn extended_xmp_200kb_multi_chunk() {
+        // 200KB needs multiple extended chunks
+        let xmp = make_xmp(200_000);
+        let jpeg = encode_with_xmp_str(&xmp);
+        let ext_ns = b"http://ns.adobe.com/xmp/extension/\0";
+        let ext_count = jpeg.windows(ext_ns.len()).filter(|w| *w == ext_ns).count();
+        assert!(
+            ext_count >= 3,
+            "200KB needs 3+ extended chunks, got {ext_count}"
+        );
+
+        // Round-trip
+        let result = Decoder::new().decode(&jpeg, Unstoppable).unwrap();
+        let decoded = result.extras().unwrap().xmp().unwrap();
+        assert_eq!(decoded.len(), xmp.len());
+        assert_eq!(decoded, xmp);
+    }
+}


### PR DESCRIPTION
Closes #37.

## Problem

XMP metadata exceeding the standard APP1 segment limit (~65KB) was silently truncated at \`encode/extras.rs:430\`. Large XMP payloads (HDR gain map metadata, extensive editing history) were lost.

## Fix

Implement Extended XMP splitting per Adobe XMP Part 3:

1. Compute MD5 GUID of the full XMP byte string
2. Standard segment: first 65,502 bytes + \`http://ns.adobe.com/xap/1.0/\\0\` namespace
3. Extended segments: remaining bytes in ~65,458-byte chunks, each prefixed with:
   - \`http://ns.adobe.com/xmp/extension/\\0\` (35 bytes)
   - MD5 hex GUID (32 bytes, uppercase)
   - total extended length (u32 big-endian)
   - chunk offset (u32 big-endian)

The decoder already reassembles Extended XMP (\`decode/extras.rs:723\`) — verified via round-trip tests.

Also refactors \`inject_xmp\`/\`inject_xmp_inplace\` in \`byte_encoders.rs\` to delegate to \`EncoderSegments::set_xmp()\`, unifying extended XMP handling in one place.

## Dependencies

Adds \`md-5 = "0.10.6"\` (RustCrypto, 17KB, pure Rust) for the spec-mandated MD5 GUID.

## Tests (6 new)

| Test | What |
|---|---|
| \`standard_xmp_fits_in_one_segment\` | 1KB XMP → no extended segments |
| \`extended_xmp_splits_large_payload\` | 100KB XMP → extended segments present |
| \`extended_xmp_round_trips_through_decoder\` | 100KB encode → decode → exact match |
| \`extended_xmp_boundary_65502\` | Exactly at limit → no extended |
| \`extended_xmp_boundary_65503\` | One byte over → extended + round-trip |
| \`extended_xmp_200kb_multi_chunk\` | 200KB → 3+ chunks + round-trip |

All 6 pass. Full test suite (120 result lines) 0 failures. Clippy + fmt clean.