### PR TITLE
Refine Huffman cluster assignments after greedy pass

### DIFF
--- a/zenjpeg/src/huffman/optimize/cluster.rs
+++ b/zenjpeg/src/huffman/optimize/cluster.rs
@@ -284,5 +284,109 @@ pub fn cluster_histograms(
         result.merge_log = merge_log;
     }
 
+    // Refine: try moving each context to a better cluster.
+    // The greedy pass is order-dependent — early contexts always get their own
+    // cluster even if a later context would share well. This 1-opt pass fixes
+    // suboptimal assignments after all histograms are known.
+    refine_clustering(histograms, &mut result);
+
     result
+}
+
+/// Iterative 1-opt refinement of cluster assignments.
+///
+/// For each non-empty context, tries moving it to every other cluster.
+/// If moving reduces total encoding cost, applies the move. Repeats
+/// until a full pass produces no improvement.
+fn refine_clustering(histograms: &[FrequencyCounter], result: &mut ClusterResult) {
+    let active: Vec<usize> = (0..histograms.len())
+        .filter(|&i| !histograms[i].is_empty_histogram())
+        .collect();
+
+    if active.is_empty() || result.num_clusters <= 1 {
+        return;
+    }
+
+    // Rebuild cluster histograms from scratch for exact accounting
+    let mut clusters = vec![FrequencyCounter::new(); result.num_clusters];
+    for &ctx in &active {
+        let cluster = result.context_map[ctx];
+        if cluster < result.num_clusters {
+            clusters[cluster].add(&histograms[ctx]);
+        }
+    }
+    result.cluster_histograms = clusters;
+
+    let mut cluster_costs: Vec<f64> = result
+        .cluster_histograms
+        .iter()
+        .map(|h| {
+            if h.is_empty_histogram() {
+                0.0
+            } else {
+                h.estimate_encoding_cost()
+            }
+        })
+        .collect();
+
+    const MAX_PASSES: usize = 10;
+    for _ in 0..MAX_PASSES {
+        let mut improved = false;
+
+        for &ctx in &active {
+            let current = result.context_map[ctx];
+            let ctx_histo = &histograms[ctx];
+
+            // Cost of current cluster without this context
+            let mut without = result.cluster_histograms[current].clone();
+            without.subtract(ctx_histo);
+            let cost_without = if without.is_empty_histogram() {
+                0.0
+            } else {
+                without.estimate_encoding_cost()
+            };
+            let removal_savings = cluster_costs[current] - cost_without;
+
+            // Try each other cluster as a target.
+            // Require savings > 1 DHT header (136 bits) to avoid moves where
+            // the estimated gain is swallowed by slot redefinition overhead
+            // that the cost estimator doesn't model.
+            let mut best_target = current;
+            let mut best_delta = -136.0_f64;
+
+            for target in 0..result.num_clusters {
+                if target == current {
+                    continue;
+                }
+                let combined = result.cluster_histograms[target].combined(ctx_histo);
+                let addition_cost = combined.estimate_encoding_cost() - cluster_costs[target];
+                let delta = addition_cost - removal_savings;
+                if delta < best_delta {
+                    best_delta = delta;
+                    best_target = target;
+                }
+            }
+
+            if best_target != current {
+                result.cluster_histograms[current].subtract(ctx_histo);
+                result.cluster_histograms[best_target].add(ctx_histo);
+                result.context_map[ctx] = best_target;
+
+                cluster_costs[current] = if result.cluster_histograms[current].is_empty_histogram()
+                {
+                    0.0
+                } else {
+                    result.cluster_histograms[current].estimate_encoding_cost()
+                };
+                cluster_costs[best_target] =
+                    result.cluster_histograms[best_target].estimate_encoding_cost();
+
+                improved = true;
+            }
+        }
+
+        if !improved {
+            break;
+        }
+    }
 }

--- a/zenjpeg/src/huffman/optimize/frequency.rs
+++ b/zenjpeg/src/huffman/optimize/frequency.rs
@@ -279,6 +279,13 @@ impl FrequencyCounter {
         }
     }
 
+    /// Subtracts another histogram's counts from this one (saturating at 0).
+    pub fn subtract(&mut self, other: &FrequencyCounter) {
+        for i in 0..257 {
+            self.counts[i] = (self.counts[i] - other.counts[i]).max(0);
+        }
+    }
+
     /// Creates a new histogram that is the sum of two histograms.
     pub fn combined(&self, other: &FrequencyCounter) -> FrequencyCounter {
         let mut result = self.clone();


### PR DESCRIPTION
## Summary

- Add 1-opt refinement pass after greedy Huffman histogram clustering
- After the greedy pass sees all histograms, try moving each context to a better cluster; keep moves that save >136 bits (1 DHT header threshold to prevent estimation-error regressions)
- Add `FrequencyCounter::subtract()` for efficient cluster reassignment

## Investigation (issue #38)

Tested 5 slot replacement strategies (RoundRobin, SmallestCount, LowestEvictionCost, OldestSlot, HighestSlotCost) across 251 images at 4 quality levels. All were within 0.03% of each other — the issue's "~1-2%" estimate was ~100x too high. The slot replacement strategy barely matters because each cluster gets its own optimized Huffman table regardless of slot assignment.

The greedy *merge decision* is what matters, and it's order-dependent: early contexts always get their own cluster even if sharing with a later context would be cheaper. The 1-opt refinement fixes this after all histograms are known.

## Results (251 images, Q50-Q95, 4:2:0 progressive)

| Corpus | Images | Q50 | Q75 | Q85 | Q95 |
|--------|--------|-----|-----|-----|-----|
| CID22 | 209 | -0.015% | -0.021% | -0.022% | -0.012% |
| Screenshots | 10 | +0.004% | -0.011% | -0.001% | -0.001% |
| CLIC | 32 | -0.002% | -0.001% | -0.000% | -0.000% |

## Test plan

- [x] All 808 lib tests pass
- [x] All integration tests pass (including locked hash values)
- [x] Visual encoding outputs updated (Q85: -52 bytes, Q95: -19 bytes)
- [x] 136-bit threshold prevents estimation-error regressions (verified: XYB progressive Q75 locked hash unchanged)