### PR TITLE
fix(decode): detect and reject lossless JPEG (SOF3/SOF7/SOF11) with clear error

### DIFF
--- a/zenjpeg/src/decode/parser/markers.rs
+++ b/zenjpeg/src/decode/parser/markers.rs
@@ -10,7 +10,8 @@ use crate::foundation::alloc::validate_dimensions;
 use crate::foundation::consts::{
     DCT_BLOCK_SIZE, JPEG_NATURAL_ORDER, MARKER_APP0, MARKER_APP14, MARKER_COM, MARKER_DAC,
     MARKER_DHT, MARKER_DQT, MARKER_DRI, MARKER_EOI, MARKER_SOF0, MARKER_SOF1, MARKER_SOF2,
-    MARKER_SOF9, MARKER_SOF10, MAX_COMPONENTS, MAX_HUFFMAN_TABLES, MAX_QUANT_TABLES,
+    MARKER_SOF3, MARKER_SOF7, MARKER_SOF9, MARKER_SOF10, MARKER_SOF11, MAX_COMPONENTS,
+    MAX_HUFFMAN_TABLES, MAX_QUANT_TABLES,
 };
 use crate::huffman::HuffmanDecodeTable;
 use crate::types::JpegMode;
@@ -45,6 +46,21 @@ impl<'a> JpegParser<'a> {
                     self.mode = JpegMode::ArithmeticProgressive;
                     self.parse_frame_header()?;
                     return Ok(());
+                }
+                MARKER_SOF3 => {
+                    return Err(Error::unsupported_feature(
+                        "lossless JPEG (SOF3) is not supported",
+                    ));
+                }
+                MARKER_SOF7 => {
+                    return Err(Error::unsupported_feature(
+                        "lossless JPEG (SOF7) is not supported",
+                    ));
+                }
+                MARKER_SOF11 => {
+                    return Err(Error::unsupported_feature(
+                        "lossless JPEG (SOF11) is not supported",
+                    ));
                 }
                 MARKER_DQT => self.parse_header_marker(|s| s.parse_quant_table())?,
                 MARKER_DHT => self.parse_header_marker(|s| s.parse_huffman_table())?,

--- a/zenjpeg/src/foundation/consts.rs
+++ b/zenjpeg/src/foundation/consts.rs
@@ -75,10 +75,16 @@ pub const MARKER_APP14: u8 = 0xEE;
 /// Comment marker
 pub const MARKER_COM: u8 = 0xFE;
 
+/// Start of Frame (Lossless Sequential)
+pub const MARKER_SOF3: u8 = 0xC3;
+/// Start of Frame (Lossless Differential)
+pub const MARKER_SOF7: u8 = 0xC7;
 /// Start of Frame (Arithmetic Sequential DCT)
 pub const MARKER_SOF9: u8 = 0xC9;
 /// Start of Frame (Arithmetic Progressive DCT)
 pub const MARKER_SOF10: u8 = 0xCA;
+/// Start of Frame (Arithmetic Lossless)
+pub const MARKER_SOF11: u8 = 0xCB;
 /// Define Arithmetic Coding conditioning
 pub const MARKER_DAC: u8 = 0xCC;
 

--- a/zenjpeg/tests/decoder_error_handling.rs
+++ b/zenjpeg/tests/decoder_error_handling.rs
@@ -939,3 +939,56 @@ fn test_extraneous_inter_marker_bytes_balanced() {
         warnings
     );
 }
+
+// ============================================================================
+// Lossless JPEG (SOF3/SOF7/SOF11) detection — issue #46
+// ============================================================================
+
+/// SOF3 (0xC3) detected via synthetic minimal marker.
+#[test]
+fn test_lossless_sof3_synthetic() {
+    // SOI + SOF3 marker (0xFF 0xC3) with minimal length
+    let data: &[u8] = &[
+        0xFF, 0xD8, 0xFF, 0xC3, 0x00, 0x0B, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11, 0x00,
+    ];
+    let decoder = Decoder::new();
+    let result = decoder.decode(data, Unstoppable);
+    let err = result.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("lossless") && msg.contains("SOF3"),
+        "got: {msg}"
+    );
+}
+
+/// SOF7 (0xC7) — lossless differential — should be rejected.
+#[test]
+fn test_lossless_sof7_synthetic() {
+    let data: &[u8] = &[
+        0xFF, 0xD8, 0xFF, 0xC7, 0x00, 0x0B, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11, 0x00,
+    ];
+    let decoder = Decoder::new();
+    let result = decoder.decode(data, Unstoppable);
+    let err = result.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("lossless") && msg.contains("SOF7"),
+        "got: {msg}"
+    );
+}
+
+/// SOF11 (0xCB) — arithmetic lossless — should be rejected.
+#[test]
+fn test_lossless_sof11_synthetic() {
+    let data: &[u8] = &[
+        0xFF, 0xD8, 0xFF, 0xCB, 0x00, 0x0B, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11, 0x00,
+    ];
+    let decoder = Decoder::new();
+    let result = decoder.decode(data, Unstoppable);
+    let err = result.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("lossless") && msg.contains("SOF11"),
+        "got: {msg}"
+    );
+}


### PR DESCRIPTION
Closes #46.

Detects lossless JPEG markers (SOF3, SOF7, SOF11) during header parsing and returns `UnsupportedFeature("lossless JPEG (SOFn) is not supported")` instead of falling through to confusing parse errors.

**Finding:** The fixture `sos_zero_components_libjpeg9b.jpg` turned out to be a progressive JPEG (SOF2) with a malformed SOS containing zero components — NOT a lossless SOF3 file. That fixture's error is correct behavior for a different defect. Three synthetic tests provide complete coverage instead.

Changes: 3 marker constants in `consts.rs`, 3 match arms in `markers.rs`, 3 synthetic tests in `decoder_error_handling.rs`.