### PR TITLE
fix(decode): clear error message for IJG non-standard block sizes (Se > 63)

### DIFF
--- a/zenjpeg/src/decode/parser/scan.rs
+++ b/zenjpeg/src/decode/parser/scan.rs
@@ -106,14 +106,14 @@ impl<'a> JpegParser<'a> {
         let al = ah_al & 0x0F;
 
         // Validate spectral selection (must be 0-63, and Ss <= Se)
-        if ss > 63 {
-            return Err(Error::invalid_jpeg_data(
-                "SOS Ss (spectral start) out of range",
-            ));
-        }
-        if se > 63 {
-            return Err(Error::invalid_jpeg_data(
-                "SOS Se (spectral end) out of range",
+        //
+        // IJG libjpeg v9+ with `-block N` (N > 8) produces non-standard JPEGs
+        // where Se can be up to N*N-1 (e.g., block 16 → Se up to 255). These
+        // require fundamentally different DCT sizes and are not supported by any
+        // decoder except IJG's own.
+        if ss > 63 || se > 63 {
+            return Err(Error::unsupported_feature(
+                "non-standard DCT block size (Ss or Se > 63, IJG libjpeg v9+ extension)",
             ));
         }
         if ss > se {

--- a/zenjpeg/tests/decoder_error_handling.rs
+++ b/zenjpeg/tests/decoder_error_handling.rs
@@ -1015,5 +1015,28 @@ fn test_lossless_sof11_synthetic() {
     assert!(
         msg.contains("lossless") && msg.contains("SOF11"),
         "got: {msg}"
+// Non-standard IJG libjpeg v9+ block size rejection
+// ============================================================================
+
+/// IJG libjpeg v9+ with `-block N` (N > 8) produces non-standard JPEGs where
+/// Se (spectral selection end) exceeds 63. These require fundamentally different
+/// DCT sizes and are not decodable by standard JPEG decoders.
+///
+/// The decoder should return an `UnsupportedFeature` error with a clear message
+/// mentioning the non-standard block size, not a confusing "out of range" error.
+#[test]
+fn sos_se_out_of_range_ijg_block_size() {
+    let data = include_bytes!("testdata/all_the_images/sos_se_outofrange_libjpeg9b.jpg");
+    let decoder = Decoder::new();
+    let result = decoder.decode(data, Unstoppable);
+    assert!(
+        result.is_err(),
+        "should reject non-standard block size JPEG"
+    );
+
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("block size") || err_msg.contains("Se > 63"),
+        "error should mention non-standard block size or Se > 63, got: {err_msg}"
     );
 }


### PR DESCRIPTION
Closes #45. Replaces #49. Returns UnsupportedFeature for IJG libjpeg v9+ block sizes >8 instead of confusing 'out of range' error.