### PR TITLE
fix(decode): detect IJG non-standard block_size=1 and block_size=16 with clear errors

### DIFF
--- a/zenjpeg/src/decode/parser/markers.rs
+++ b/zenjpeg/src/decode/parser/markers.rs
@@ -223,6 +223,39 @@ impl<'a> JpegParser<'a> {
                 ));
             }
 
+            // Detect non-standard DCT block sizes (IJG libjpeg v9+ extension).
+            //
+            // Standard JPEG uses 8x8 DCT blocks, so each DQT table has exactly 64
+            // coefficients: 64 bytes (8-bit precision) or 128 bytes (16-bit precision).
+            // IJG libjpeg v9+ with `-block N` produces N*N coefficients per table.
+            //
+            // block_size=1 → 1 entry (DQT too short for standard 64)
+            // block_size=16 → 256 entries (DQT too long for standard 64)
+            //
+            // Remaining bytes for this table's values (after the info byte):
+            let standard_value_bytes: i32 = if precision == 0 { 64 } else { 128 };
+            let remaining_for_values = length - 1; // subtract info byte already read
+
+            if remaining_for_values < standard_value_bytes {
+                // Fewer bytes than a standard 8x8 table — could be block_size < 8.
+                // Check if the count is a perfect square (N*N for some N).
+                let entry_count = if precision == 0 {
+                    remaining_for_values
+                } else {
+                    remaining_for_values / 2
+                };
+                if entry_count > 0 {
+                    let sqrt = (entry_count as u32).isqrt();
+                    if sqrt * sqrt == entry_count as u32 && sqrt != 8 {
+                        return Err(Error::unsupported_feature(
+                            "non-standard DCT block size (DQT has fewer than 64 entries, IJG libjpeg v9+ extension)",
+                        ));
+                    }
+                }
+                // Not a recognizable block size — fall through to the generic mismatch error
+                return Err(Error::invalid_jpeg_data("DQT marker length mismatch"));
+            }
+
             // Read values in zigzag order (as stored in JPEG)
             let mut zigzag_values = [0u16; DCT_BLOCK_SIZE];
 
@@ -273,7 +306,10 @@ impl<'a> JpegParser<'a> {
                 })?;
             }
 
-            // Validate DQT marker length consistency
+            // Validate DQT marker length consistency.
+            // After reading exactly 64 entries, if length < 0, the marker was too short
+            // (caught above). If length is unexpectedly large, the DQT may contain more
+            // than 64 entries per table (e.g., block_size=16 → 256 entries).
             if length < 0 {
                 return Err(Error::invalid_jpeg_data("DQT marker length mismatch"));
             }

--- a/zenjpeg/src/decode/parser/scan.rs
+++ b/zenjpeg/src/decode/parser/scan.rs
@@ -29,9 +29,19 @@ impl<'a> JpegParser<'a> {
         let length = self.read_u16()?;
         let num_components = self.read_u8()?;
 
-        // Validate num_components in scan
+        // Validate num_components in scan.
+        //
+        // IJG libjpeg v9+ with `-block 16` produces progressive JPEGs where the
+        // first SOS has num_components=0 (a non-standard extension for large DCT
+        // block sizes). Detect this and return UnsupportedFeature instead of a
+        // confusing "SOS num_components is zero" parse error.
         if num_components == 0 {
-            return Err(Error::invalid_jpeg_data("SOS num_components is zero"));
+            // SOS length=6 with Ns=0 is the IJG block_size>8 signature:
+            // the scan structure uses 0-component scans for coefficient selection
+            // ranges beyond the standard 0..63.
+            return Err(Error::unsupported_feature(
+                "non-standard DCT block size (SOS with zero components, IJG libjpeg v9+ extension)",
+            ));
         }
         if num_components > self.num_components {
             return Err(Error::invalid_jpeg_data(

--- a/zenjpeg/tests/decoder_error_handling.rs
+++ b/zenjpeg/tests/decoder_error_handling.rs
@@ -1044,6 +1044,131 @@ fn sos_se_out_of_range_ijg_block_size() {
     );
 }
 
+/// IJG libjpeg v9+ with `-block 16` produces progressive JPEGs where the
+/// first SOS marker has num_components=0 (a non-standard extension for large
+/// DCT block sizes). The decoder should return UnsupportedFeature, not the
+/// confusing "SOS num_components is zero" parse error.
+#[test]
+fn sos_zero_components_ijg_block_size_16() {
+    let data = include_bytes!("testdata/all_the_images/sos_zero_components_libjpeg9b.jpg");
+    let decoder = Decoder::new();
+    let result = decoder.decode(data, Unstoppable);
+    assert!(result.is_err(), "should reject block_size=16 JPEG");
+
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("block size") || err_msg.contains("SOS with zero components"),
+        "error should mention non-standard block size, got: {err_msg}"
+    );
+    // Must NOT be the old confusing message
+    assert!(
+        !err_msg.contains("SOS num_components is zero"),
+        "should not use the old confusing error message, got: {err_msg}"
+    );
+}
+
+/// IJG libjpeg v9+ with `-block 1` produces JPEGs where DQT tables have only
+/// 1 coefficient entry (1x1 DCT block) instead of the standard 64 entries (8x8).
+/// The decoder should return UnsupportedFeature, not "DQT marker length mismatch".
+#[test]
+fn dqt_short_table_ijg_block_size_1() {
+    // Synthetic minimal JPEG with a 1-entry DQT (block_size=1).
+    // DQT marker: FF DB 00 04 00 10
+    //   length=4 (2 bytes length + 1 byte info + 1 byte value)
+    //   info=0x00 (precision=0, table_idx=0)
+    //   value=0x10 (quant value 16)
+    // SOF0: 1x1 grayscale, 1 component
+    // SOS + minimal entropy data + EOI
+    #[rustfmt::skip]
+    let data: &[u8] = &[
+        // SOI
+        0xFF, 0xD8,
+        // DQT: 1-entry table (block_size=1)
+        0xFF, 0xDB, 0x00, 0x04, 0x00, 0x10,
+        // SOF0: 8-bit, 1x1, 1 component
+        0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11, 0x00,
+        // DHT (minimal DC table)
+        0xFF, 0xC4, 0x00, 0x1F, 0x00, 0x00, 0x01, 0x05, 0x01, 0x01, 0x01, 0x01,
+        0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02,
+        0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+        // SOS
+        0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3F, 0x00,
+        // Minimal entropy data
+        0x00,
+        // EOI
+        0xFF, 0xD9,
+    ];
+
+    let decoder = Decoder::new();
+    let result = decoder.decode(data, Unstoppable);
+    assert!(result.is_err(), "should reject block_size=1 JPEG");
+
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("block size") || err_msg.contains("fewer than 64"),
+        "error should mention non-standard block size, got: {err_msg}"
+    );
+    // Must NOT be the old confusing message
+    assert!(
+        !err_msg.contains("DQT marker length mismatch"),
+        "should not use the old confusing error message, got: {err_msg}"
+    );
+}
+
+/// Block_size=1 DQT with 16-bit precision should also be detected.
+#[test]
+fn dqt_short_table_16bit_ijg_block_size_1() {
+    // DQT with precision=1 (16-bit) and 1 entry: length = 2 + 1 + 2 = 5
+    #[rustfmt::skip]
+    let data: &[u8] = &[
+        // SOI
+        0xFF, 0xD8,
+        // DQT: 1-entry 16-bit table (block_size=1)
+        0xFF, 0xDB, 0x00, 0x05, 0x10, 0x00, 0x10,
+        // SOF1: 8-bit, 1x1, 1 component (SOF1 for 16-bit quant)
+        0xFF, 0xC1, 0x00, 0x0B, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11, 0x00,
+        // EOI
+        0xFF, 0xD9,
+    ];
+
+    let decoder = Decoder::new();
+    let result = decoder.decode(data, Unstoppable);
+    assert!(result.is_err(), "should reject 16-bit block_size=1 JPEG");
+
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("block size") || err_msg.contains("fewer than 64"),
+        "error should mention non-standard block size, got: {err_msg}"
+    );
+}
+
+/// Block_size=16 detection should work at all strictness levels.
+#[test]
+fn sos_zero_components_all_strictness_levels() {
+    let data = include_bytes!("testdata/all_the_images/sos_zero_components_libjpeg9b.jpg");
+
+    for strictness in [
+        Strictness::Strict,
+        Strictness::Balanced,
+        Strictness::Lenient,
+        Strictness::Permissive,
+    ] {
+        let result = Decoder::new()
+            .strictness(strictness)
+            .decode(data, Unstoppable);
+        assert!(
+            result.is_err(),
+            "should reject block_size=16 JPEG at {strictness:?}"
+        );
+
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("block size"),
+            "error at {strictness:?} should mention block size, got: {err_msg}"
+        );
+    }
+}
+
 // ============================================================================
 // Arithmetic coding overflow edge cases (issue #44)
 //


### PR DESCRIPTION
Addresses #45 (additional block sizes beyond 9-15).

IJG libjpeg v9+/v10 with `-block 1` and `-block 16` produced confusing errors:
- block_size=1: "DQT marker length mismatch" (3,138 files) → now `UnsupportedFeature("non-standard DCT block size (DQT has fewer than 64 entries)")`
- block_size=16: "SOS num_components is zero" (1,861 files) → now `UnsupportedFeature("non-standard DCT block size (SOS with zero components)")`

DQT detection checks if entry count is a perfect square (N×N), confirming it's an intentional block size rather than corruption. 5 new tests.