### PR TITLE
fix: reduce icache pressure from #[magetypes] force-inlining (#19)

### DIFF
--- a/zenjpeg/src/color/xyb.rs
+++ b/zenjpeg/src/color/xyb.rs
@@ -517,7 +517,7 @@ pub fn xyb_planes_to_rgb_buffer(
 /// Uses `cbrt_midp()` for hardware-accelerated cube root (~3 ULP precision,
 /// better than C++ jpegli's ~6 ULP). Dispatches to AVX2+FMA on x86_64,
 /// NEON on aarch64, WASM SIMD128 on wasm32, or scalar fallback.
-#[inline(always)]
+#[inline]
 fn generic_linear_rgb_to_scaled_xyb<T: magetypes::simd::backends::F32x8Convert>(
     token: T,
     r_arr: [f32; 8],
@@ -592,7 +592,7 @@ fn generic_linear_rgb_to_scaled_xyb<T: magetypes::simd::backends::F32x8Convert>(
 }
 
 /// Generic SIMD core: linear RGB → XYB (no JPEG scaling), in-place on `[[f32; 3]]`.
-#[inline(always)]
+#[inline]
 fn generic_linear_rgb_to_xyb_inplace<T: magetypes::simd::backends::F32x8Convert>(
     token: T,
     pixels: &mut [[f32; 3]],
@@ -825,7 +825,7 @@ pub fn srgb_to_scaled_xyb_planes_simd_inplace(
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn srgb_to_scaled_xyb_planes_rgb_impl(
     token: Token,
     rgb_data: &[u8],
@@ -898,7 +898,7 @@ pub fn srgb_to_scaled_xyb_planes_simd_rgba_inplace(
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn srgb_to_scaled_xyb_planes_rgba_impl(
     token: Token,
     rgba_data: &[u8],
@@ -971,7 +971,7 @@ pub fn srgb_to_scaled_xyb_planes_simd_bgra_inplace(
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn srgb_to_scaled_xyb_planes_bgra_impl(
     token: Token,
     bgra_data: &[u8],
@@ -1034,7 +1034,7 @@ pub fn linear_rgb_to_xyb_simd(pixels: &mut [[f32; 3]]) {
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn linear_rgb_to_xyb_simd_impl(token: Token, pixels: &mut [[f32; 3]]) {
     generic_linear_rgb_to_xyb_inplace(token, pixels);
 
@@ -1055,7 +1055,7 @@ pub fn linear_rgb_to_xyb_simd_255(pixels: &mut [[f32; 3]]) {
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn linear_rgb_to_xyb_simd_255_impl(token: Token, pixels: &mut [[f32; 3]]) {
     generic_linear_rgb_to_xyb_inplace(token, pixels);
 
@@ -1101,7 +1101,7 @@ pub fn xyb_planes_to_rgb_u8_simd(plane0: &[f32], plane1: &[f32], plane2: &[f32],
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn xyb_planes_to_rgb_u8_impl(
     token: Token,
     plane0: &[f32],
@@ -1197,7 +1197,7 @@ pub fn xyb_planes_to_rgb_f32_simd(plane0: &[f32], plane1: &[f32], plane2: &[f32]
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn xyb_planes_to_rgb_f32_impl(
     token: Token,
     plane0: &[f32],

--- a/zenjpeg/src/color/ycbcr.rs
+++ b/zenjpeg/src/color/ycbcr.rs
@@ -359,7 +359,7 @@ pub fn ycbcr_planes_f32_to_rgb_u8(
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn ycbcr_planes_f32_to_rgb_u8_impl(
     token: Token,
     y_plane: &[f32],
@@ -456,7 +456,7 @@ pub fn ycbcr_planes_f32_to_rgb_f32(
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn ycbcr_planes_f32_to_rgb_f32_impl(
     token: Token,
     y_plane: &[f32],
@@ -541,7 +541,7 @@ pub fn gray_f32_to_rgb_u8(y_plane: &[f32], rgb: &mut [u8]) {
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn gray_f32_to_rgb_u8_impl(token: Token, y_plane: &[f32], rgb: &mut [u8]) {
     #[allow(non_camel_case_types)]
     type f32x8 = GenericF32x8<Token>;
@@ -593,7 +593,7 @@ pub fn gray_f32_to_rgb_f32(y_plane: &[f32], rgb: &mut [f32]) {
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn gray_f32_to_rgb_f32_impl(token: Token, y_plane: &[f32], rgb: &mut [f32]) {
     #[allow(non_camel_case_types)]
     type f32x8 = GenericF32x8<Token>;
@@ -640,7 +640,7 @@ pub fn gray_f32_to_gray_u8(y_plane: &[f32], output: &mut [u8]) {
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn gray_f32_to_gray_u8_impl(token: Token, y_plane: &[f32], output: &mut [u8]) {
     #[allow(non_camel_case_types)]
     type f32x8 = GenericF32x8<Token>;
@@ -684,7 +684,7 @@ pub fn gray_f32_to_gray_f32(y_plane: &[f32], output: &mut [f32]) {
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn gray_f32_to_gray_f32_impl(token: Token, y_plane: &[f32], output: &mut [f32]) {
     #[allow(non_camel_case_types)]
     type f32x8 = GenericF32x8<Token>;
@@ -1038,7 +1038,7 @@ fn ycbcr_to_rgb_i16_x16_scalar(
 /// fixed-point math as the scalar and AVX2 versions. Generic across
 /// all platforms (x86 AVX2, NEON, WASM128, scalar).
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn ycbcr_to_rgb_i16_x8_generic(
     token: Token,
     y: &[i16],
@@ -1729,7 +1729,7 @@ fn ycbcr_planes_i16_to_rgb_u8_avx512(
 /// Processes 4 chroma pixels → 8 output pixels per i32x4 pass.
 /// Each chroma value is duplicated horizontally (box filter).
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn fused_h2v2_box_ycbcr_to_rgb_u8_generic(
     token: Token,
     y_row: &[i16],
@@ -1918,7 +1918,7 @@ pub fn fused_h2v2_box_ycbcr_to_rgb_u8(
 /// Triangle filter for chroma (scalar, has neighbor dependencies), then
 /// vectorized i32x4 color conversion for batches of 4 output pixels.
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn fused_h2v2_hfancy_ycbcr_to_rgb_u8_generic(
     token: Token,
     y_row: &[i16],

--- a/zenjpeg/src/deblock/knusperli.rs
+++ b/zenjpeg/src/deblock/knusperli.rs
@@ -217,7 +217,7 @@ fn correct_h_row(blocks: &[f32], offsets: &mut [f32], blocks_wide: usize) {
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn correct_h_row_impl(token: Token, blocks: &[f32], offsets: &mut [f32], blocks_wide: usize) {
     #[allow(non_camel_case_types)]
     type f32x8 = GenericF32x8<Token>;
@@ -270,7 +270,7 @@ fn correct_v_between(
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn correct_v_between_impl(
     token: Token,
     top: &[f32],
@@ -373,7 +373,7 @@ fn finalize_row(
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn finalize_row_impl(
     token: Token,
     blocks: &[f32],

--- a/zenjpeg/src/encode/dct.rs
+++ b/zenjpeg/src/encode/dct.rs
@@ -266,7 +266,7 @@ pub(crate) mod simd {
     /// Generic transpose fallback using magetypes generics.
     #[cfg(test)]
     #[magetypes(v3, neon, wasm128, scalar)]
-    #[inline(always)]
+    #[inline]
     fn transpose_8x8_generic(_token: Token, input: &[f32; 64], output: &mut [f32; 64]) {
         #[allow(non_camel_case_types)]
         type f32x8 = GenericF32x8<Token>;

--- a/zenjpeg/src/encode/strip/mod.rs
+++ b/zenjpeg/src/encode/strip/mod.rs
@@ -143,7 +143,7 @@ pub(crate) fn extract_block_from_strip_wide(
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn extract_block_impl(
     token: Token,
     strip: &[f32],

--- a/zenjpeg/src/foundation/simd_types.rs
+++ b/zenjpeg/src/foundation/simd_types.rs
@@ -342,7 +342,7 @@ impl Default for Block8x8i32 {
 /// Uses f32x8 for threshold/multiply and i32x8 for blend/round.
 /// On x86 AVX2+FMA this is true 256-bit; on NEON/WASM it's polyfilled via pairs.
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn mage_quantize_block_zigzag(
     token: Token,
     block: &Block8x8f,
@@ -393,7 +393,7 @@ fn mage_quantize_block_zigzag(
 
 /// Magetypes-generic quantize, natural order output.
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn mage_quantize_block(
     token: Token,
     block: &Block8x8f,

--- a/zenjpeg/src/quant/aq/simd.rs
+++ b/zenjpeg/src/quant/aq/simd.rs
@@ -191,7 +191,7 @@ pub fn pre_erosion_row(row: &[f32], row_above: &[f32], row_below: &[f32], output
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn pre_erosion_row_impl(
     token: Token,
     row: &[f32],
@@ -321,7 +321,7 @@ pub fn pre_erosion_row_padded(
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn pre_erosion_row_padded_impl(
     token: Token,
     row: &[f32],
@@ -457,7 +457,7 @@ fn downsample_4x_sum(input: &[f32], output: &mut [f32]) {
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn downsample_4x_sum_impl(token: Token, input: &[f32], output: &mut [f32]) {
     let _ = token; // used by magetypes for autovectorization
     let width = input.len();
@@ -739,7 +739,7 @@ pub fn per_block_modulations_row(
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn per_block_modulations_row_impl(
     token: Token,
     input: &[f32],
@@ -906,7 +906,7 @@ pub fn fuzzy_erosion_row_simd(
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn fuzzy_erosion_row_simd_impl(
     token: Token,
     pre_erosion: &[f32],
@@ -1096,7 +1096,7 @@ pub fn compute_fuzzy_erosion_blocks_simd(
 }
 
 #[magetypes(v3, neon, wasm128, scalar)]
-#[inline(always)]
+#[inline]
 fn compute_fuzzy_erosion_blocks_simd_impl(
     token: Token,
     pre_erosion_buffer: &[f32],
@@ -2774,7 +2774,7 @@ fn test_ratio_of_derivatives_x8(input: [f32; 8]) -> [f32; 8] {
         incant!(test_ratio_of_derivatives_x8_impl(input))
     }
     #[magetypes(v3, neon, wasm128, scalar)]
-    #[inline(always)]
+    #[inline]
     fn test_ratio_of_derivatives_x8_impl(token: Token, input: [f32; 8]) -> [f32; 8] {
         #[allow(non_camel_case_types)]
         type f32x8 = GenericF32x8<Token>;
@@ -2791,7 +2791,7 @@ fn test_ratio_of_derivatives_inv_x8(input: [f32; 8]) -> [f32; 8] {
         incant!(test_ratio_of_derivatives_inv_x8_impl(input))
     }
     #[magetypes(v3, neon, wasm128, scalar)]
-    #[inline(always)]
+    #[inline]
     fn test_ratio_of_derivatives_inv_x8_impl(token: Token, input: [f32; 8]) -> [f32; 8] {
         #[allow(non_camel_case_types)]
         type f32x8 = GenericF32x8<Token>;
@@ -2808,7 +2808,7 @@ fn test_masking_sqrt_x8(input: [f32; 8]) -> [f32; 8] {
         incant!(test_masking_sqrt_x8_impl(input))
     }
     #[magetypes(v3, neon, wasm128, scalar)]
-    #[inline(always)]
+    #[inline]
     fn test_masking_sqrt_x8_impl(token: Token, input: [f32; 8]) -> [f32; 8] {
         #[allow(non_camel_case_types)]
         type f32x8 = GenericF32x8<Token>;
@@ -2839,7 +2839,7 @@ fn test_pre_erosion_pixel_x8(
         ))
     }
     #[magetypes(v3, neon, wasm128, scalar)]
-    #[inline(always)]
+    #[inline]
     fn test_pre_erosion_pixel_x8_impl(
         token: Token,
         pixels: [f32; 8],


### PR DESCRIPTION
## Summary

Replace `#[inline(always)]` with `#[inline]` on all 35 `#[magetypes]`-annotated functions across 7 files.

## Root cause

`#[magetypes(v3, neon, wasm128, scalar)]` generates 2+ variants per function. With `#[inline(always)]`, LLVM was forced to inline ALL variants at every call site, even dead ones (scalar on AVX2 hardware). This doubled code footprint per call site and caused L1 icache pressure.

Progressive 4:4:4 is the worst case — 3x more color conversion calls than 4:2:0, amplifying the icache effect into a measurable 6% regression.

## Fix

`#[inline]` hints the compiler to inline when profitable but doesn't force it. The hot-path v3 variant still gets inlined; the dead scalar fallback doesn't bloat every call site.

`#[inline(always)]` on non-`#[magetypes]` functions (IDCT kernels, bitstream readers) is intentionally preserved — those are small functions that genuinely need force-inlining.

## Files changed

- `color/ycbcr.rs` (9 functions) — YCbCr→RGB, grayscale, fused upsample+convert
- `color/xyb.rs` (9 functions) — XYB encode/decode
- `quant/aq/simd.rs` (10 functions) — adaptive quantization
- `deblock/knusperli.rs` (3 functions) — deblock filter
- `foundation/simd_types.rs` (2 functions) — quantize block
- `encode/strip/mod.rs` (1 function) — block extraction
- `encode/dct.rs` (1 function) — transpose (test-only)

## Test plan

- [x] All tests pass (0 failures, lib + tests + `--features decoder`)
- [ ] Benchmark: `cargo bench --bench decode -- 444_prog` (needs manual verification)

Closes #19