### PR TITLE
deps: replace md-5 crate with inline MD5 (~60 lines, -8 transitive deps)

### DIFF
--- a/zenjpeg/Cargo.toml
+++ b/zenjpeg/Cargo.toml
@@ -54,7 +54,6 @@ enough = { workspace = true }
 zencodec = { workspace = true }
 zenpixels = { workspace = true }
 tinyvec = { workspace = true }  # Stack-allocated bounded vectors
-md-5 = "0.10.6"  # MD5 for Extended XMP GUID (spec-mandated)
 linear-srgb = { workspace = true }
 whereat = { workspace = true }  # Error tracing with location tracking
 thiserror = { workspace = true }  # Error derive macros

--- a/zenjpeg/src/encode/extras.rs
+++ b/zenjpeg/src/encode/extras.rs
@@ -438,9 +438,8 @@ impl EncoderSegments {
             // total extended length (u32 BE), and chunk offset (u32 BE).
 
             // 1. Compute MD5 GUID of the full XMP
-            use md5::{Digest, Md5};
             let guid = {
-                let hash = Md5::digest(xmp_bytes);
+                let hash = crate::foundation::md5::md5(xmp_bytes);
                 let mut hex = [0u8; 32];
                 for (i, byte) in hash.iter().enumerate() {
                     let hi = byte >> 4;

--- a/zenjpeg/src/foundation/md5.rs
+++ b/zenjpeg/src/foundation/md5.rs
@@ -1,0 +1,108 @@
+//! Minimal MD5 implementation for Extended XMP GUID computation.
+//!
+//! Only used once (XMP splitting per Adobe XMP Part 3 spec). Not performance-critical.
+//! Replaces the `md-5` crate dependency (8 transitive deps) with ~60 lines of code.
+//!
+//! Reference: RFC 1321
+
+const S: [u32; 64] = [
+    7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9,
+    14, 20, 5, 9, 14, 20, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 6, 10, 15,
+    21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21,
+];
+
+const K: [u32; 64] = [
+    0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
+    0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be, 0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
+    0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+    0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed, 0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
+    0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c, 0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
+    0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+    0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+    0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1, 0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
+];
+
+/// Compute MD5 hash of `data`, returning 16 bytes.
+pub fn md5(data: &[u8]) -> [u8; 16] {
+    let mut a0: u32 = 0x67452301;
+    let mut b0: u32 = 0xefcdab89;
+    let mut c0: u32 = 0x98badcfe;
+    let mut d0: u32 = 0x10325476;
+
+    // Pre-processing: pad message to 64-byte blocks
+    let bit_len = (data.len() as u64).wrapping_mul(8);
+    let mut padded = data.to_vec();
+    padded.push(0x80);
+    while padded.len() % 64 != 56 {
+        padded.push(0);
+    }
+    padded.extend_from_slice(&bit_len.to_le_bytes());
+
+    // Process each 64-byte block
+    for chunk in padded.chunks_exact(64) {
+        let mut m = [0u32; 16];
+        for (i, word) in m.iter_mut().enumerate() {
+            *word = u32::from_le_bytes([
+                chunk[i * 4],
+                chunk[i * 4 + 1],
+                chunk[i * 4 + 2],
+                chunk[i * 4 + 3],
+            ]);
+        }
+
+        let (mut a, mut b, mut c, mut d) = (a0, b0, c0, d0);
+
+        for i in 0..64 {
+            let (f, g) = match i {
+                0..16 => ((b & c) | (!b & d), i),
+                16..32 => ((d & b) | (!d & c), (5 * i + 1) % 16),
+                32..48 => (b ^ c ^ d, (3 * i + 5) % 16),
+                _ => (c ^ (b | !d), (7 * i) % 16),
+            };
+
+            let f = f.wrapping_add(a).wrapping_add(K[i]).wrapping_add(m[g]);
+            a = d;
+            d = c;
+            c = b;
+            b = b.wrapping_add(f.rotate_left(S[i]));
+        }
+
+        a0 = a0.wrapping_add(a);
+        b0 = b0.wrapping_add(b);
+        c0 = c0.wrapping_add(c);
+        d0 = d0.wrapping_add(d);
+    }
+
+    let mut result = [0u8; 16];
+    result[0..4].copy_from_slice(&a0.to_le_bytes());
+    result[4..8].copy_from_slice(&b0.to_le_bytes());
+    result[8..12].copy_from_slice(&c0.to_le_bytes());
+    result[12..16].copy_from_slice(&d0.to_le_bytes());
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_md5_empty() {
+        let hash = md5(b"");
+        let hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(hex, "d41d8cd98f00b204e9800998ecf8427e");
+    }
+
+    #[test]
+    fn test_md5_abc() {
+        let hash = md5(b"abc");
+        let hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(hex, "900150983cd24fb0d6963f7d28e17f72");
+    }
+
+    #[test]
+    fn test_md5_long() {
+        let hash = md5(b"The quick brown fox jumps over the lazy dog");
+        let hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(hex, "9e107d9d372bb6826bd81d3542a419d6");
+    }
+}

--- a/zenjpeg/src/foundation/mod.rs
+++ b/zenjpeg/src/foundation/mod.rs
@@ -11,6 +11,7 @@ pub mod alloc;
 pub mod bitstream;
 pub mod consts;
 pub mod instrumented_vec;
+pub(crate) mod md5;
 pub mod simd_types;
 
 // Re-export commonly used items at module level


### PR DESCRIPTION
## Summary

Replace the `md-5` crate (8 transitive deps: digest, block-buffer, crypto-common, typenum, generic-array, cfg-if, cpufeatures, libc) with a 60-line inline RFC 1321 implementation.

Used exactly once: computing the Extended XMP GUID when XMP exceeds 65502 bytes (Adobe XMP Part 3 spec mandates MD5).

## Test plan

- [x] 3 RFC test vectors (empty, "abc", fox sentence)
- [x] Extended XMP round-trip tests pass
- [x] Full test suite: 0 failures