### PR TITLE
perf: optimize Huffman decoding with wider lookup tables and 8-byte refill

### DIFF
--- a/zenjpeg/Cargo.toml
+++ b/zenjpeg/Cargo.toml
@@ -252,6 +252,11 @@ harness = false
 required-features = ["decoder"]
 
 [[bench]]
+name = "huffman_decode"
+harness = false
+required-features = ["decoder"]
+
+[[bench]]
 name = "decode_mozjpeg"
 harness = false
 required-features = ["decoder"]

--- a/zenjpeg/benches/huffman_decode.rs
+++ b/zenjpeg/benches/huffman_decode.rs
@@ -1,0 +1,444 @@
+//! Focused Huffman decode benchmark for measuring entropy decoding throughput.
+//!
+//! Uses CLIC 2025 photographs from codec-corpus for realistic coefficient
+//! distributions. Falls back to noise+patches synthetic images if the corpus
+//! is unavailable (no network / CI).
+//!
+//! Tests baseline and progressive at multiple quality levels to exercise
+//! different Huffman code length distributions:
+//! - Q85: typical web quality, moderate AC density
+//! - Q50: lower quality, sparser AC coefficients (more EOBs, fast_ac hits)
+//!
+//! Run:
+//! ```sh
+//! cargo bench -p zenjpeg --bench huffman_decode --features decoder
+//! ```
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use enough::Unstoppable;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use zenjpeg::decode::Decoder;
+use zenjpeg::decoder::PixelFormat;
+use zenjpeg::encode::{ChromaSubsampling, EncoderConfig, PixelLayout};
+
+// ── Image loading ──────────────────────────────────────────────────────────
+
+/// Load a PNG file to flat RGB bytes.
+fn load_png_rgb(path: &Path) -> Option<(Vec<u8>, u32, u32)> {
+    let file = std::fs::File::open(path).ok()?;
+    let dec = png::Decoder::new(std::io::BufReader::new(file));
+    let mut reader = dec.read_info().ok()?;
+    let mut buf = vec![0u8; reader.output_buffer_size()?];
+    let info = reader.next_frame(&mut buf).ok()?;
+    let (w, h) = (info.width, info.height);
+
+    let rgb = match info.color_type {
+        png::ColorType::Rgb => buf[..info.buffer_size()].to_vec(),
+        png::ColorType::Rgba => {
+            let src = &buf[..info.buffer_size()];
+            let mut rgb = Vec::with_capacity((w * h * 3) as usize);
+            for chunk in src.chunks_exact(4) {
+                rgb.extend_from_slice(&chunk[..3]);
+            }
+            rgb
+        }
+        png::ColorType::Grayscale => {
+            let src = &buf[..info.buffer_size()];
+            let mut rgb = Vec::with_capacity((w * h * 3) as usize);
+            for &g in src {
+                rgb.extend_from_slice(&[g, g, g]);
+            }
+            rgb
+        }
+        _ => return None,
+    };
+
+    Some((rgb, w, h))
+}
+
+/// Collect all PNG files from a directory, sorted by name.
+fn collect_pngs(dir: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<_> = std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .is_some_and(|x| x.eq_ignore_ascii_case("png"))
+        })
+        .map(|e| e.path())
+        .collect();
+    files.sort();
+    files
+}
+
+/// Generate noise+patches pixel data (fallback when corpus is unavailable).
+fn generate_photo_like_pixels(width: u32, height: u32) -> Vec<u8> {
+    let mut data = vec![0u8; (width * height * 3) as usize];
+    for y in 0..height as usize {
+        for x in 0..width as usize {
+            let idx = (y * width as usize + x) * 3;
+            let bx = (x / 8) as u32;
+            let by = (y / 8) as u32;
+            let block_hash = bx
+                .wrapping_mul(2654435761)
+                .wrapping_add(by.wrapping_mul(40503));
+            let block_type = block_hash % 4;
+
+            let px = x as u32;
+            let py = y as u32;
+            let mut h = px
+                .wrapping_mul(374761393)
+                .wrapping_add(py.wrapping_mul(668265263));
+            h = (h ^ (h >> 13)).wrapping_mul(1274126177);
+            let noise = (h >> 24) as u8;
+
+            match block_type {
+                0 => {
+                    let bias = ((bx.wrapping_mul(17) ^ by.wrapping_mul(31)) & 0xFF) as u8;
+                    data[idx] = bias.wrapping_add(noise >> 2);
+                    data[idx + 1] = bias.wrapping_add(noise >> 1);
+                    data[idx + 2] = bias.wrapping_add(noise >> 3);
+                }
+                1 => {
+                    data[idx] = ((x * 255) / width as usize) as u8;
+                    data[idx + 1] = ((y * 255) / height as usize) as u8;
+                    data[idx + 2] = noise >> 2;
+                }
+                2 => {
+                    let edge = if (x % 8 < 4) ^ (y % 8 < 4) {
+                        200u8
+                    } else {
+                        55u8
+                    };
+                    data[idx] = edge;
+                    data[idx + 1] = edge.wrapping_add(noise >> 4);
+                    data[idx + 2] = 255 - edge;
+                }
+                _ => {
+                    data[idx] = noise;
+                    data[idx + 1] = noise.wrapping_mul(3);
+                    data[idx + 2] = noise.wrapping_mul(7);
+                }
+            }
+        }
+    }
+    data
+}
+
+// ── JPEG encoding ──────────────────────────────────────────────────────────
+
+fn encode_jpeg(
+    pixels: &[u8],
+    width: u32,
+    height: u32,
+    quality: f32,
+    subsampling: ChromaSubsampling,
+    progressive: bool,
+) -> Vec<u8> {
+    let mut config = EncoderConfig::ycbcr(quality, subsampling).progressive(progressive);
+    if progressive {
+        config = config.restart_mcu_rows(0);
+    }
+    let mut enc = config
+        .encode_from_bytes(width, height, PixelLayout::Rgb8Srgb)
+        .expect("encoder creation");
+    enc.push_packed(pixels, Unstoppable)
+        .expect("push_packed");
+    enc.finish().expect("finish")
+}
+
+// ── Test image set ─────────────────────────────────────────────────────────
+
+struct SourceImage {
+    name: String,
+    pixels: Vec<u8>,
+    width: u32,
+    height: u32,
+}
+
+struct EncodedImage {
+    label: String,
+    jpeg: Vec<u8>,
+    pixels: u64,
+}
+
+struct TestSet {
+    baseline_q85: Vec<EncodedImage>,
+    baseline_q50: Vec<EncodedImage>,
+    progressive_q85: Vec<EncodedImage>,
+    baseline_444_q85: Vec<EncodedImage>,
+    #[allow(dead_code)]
+    source_tag: &'static str,
+}
+
+/// Try loading CLIC 2025 images from codec-corpus. Returns up to `max` images.
+fn load_clic_images(max: usize) -> Option<Vec<SourceImage>> {
+    let corpus = codec_corpus::Corpus::new().ok()?;
+
+    // Try CLIC 2025 final-test first, then training
+    let dir = corpus
+        .get("clic2025/final-test")
+        .or_else(|_| corpus.get("clic2025/training"))
+        .ok()?;
+
+    let pngs = collect_pngs(&dir);
+    if pngs.is_empty() {
+        return None;
+    }
+
+    let images: Vec<SourceImage> = pngs
+        .iter()
+        .take(max)
+        .filter_map(|p| {
+            let (pixels, w, h) = load_png_rgb(p)?;
+            let name = p.file_stem()?.to_string_lossy().into_owned();
+            Some(SourceImage {
+                name,
+                pixels,
+                width: w,
+                height: h,
+            })
+        })
+        .collect();
+
+    if images.is_empty() {
+        None
+    } else {
+        Some(images)
+    }
+}
+
+/// Fall back to CID22 512px corpus.
+fn load_cid22_images(max: usize) -> Option<Vec<SourceImage>> {
+    let corpus = codec_corpus::Corpus::new().ok()?;
+    let dir = corpus.get("CID22/CID22-512/training").ok()?;
+    let pngs = collect_pngs(&dir);
+    if pngs.is_empty() {
+        return None;
+    }
+
+    let images: Vec<SourceImage> = pngs
+        .iter()
+        .take(max)
+        .filter_map(|p| {
+            let (pixels, w, h) = load_png_rgb(p)?;
+            let name = p.file_stem()?.to_string_lossy().into_owned();
+            Some(SourceImage {
+                name,
+                pixels,
+                width: w,
+                height: h,
+            })
+        })
+        .collect();
+
+    if images.is_empty() {
+        None
+    } else {
+        Some(images)
+    }
+}
+
+/// Generate synthetic fallback images at fixed sizes.
+fn generate_synthetic_images() -> Vec<SourceImage> {
+    [(1024, 1024, "synth_1024"), (2048, 2048, "synth_2048")]
+        .iter()
+        .map(|&(w, h, name)| SourceImage {
+            name: name.to_string(),
+            pixels: generate_photo_like_pixels(w, h),
+            width: w,
+            height: h,
+        })
+        .collect()
+}
+
+fn build_test_set() -> TestSet {
+    // Try CLIC 2025 → CID22 → synthetic fallback
+    let (sources, tag) = if let Some(images) = load_clic_images(8) {
+        eprintln!(
+            "Loaded {} CLIC 2025 images for Huffman decode benchmark",
+            images.len()
+        );
+        for img in &images {
+            eprintln!("  {} ({}x{})", img.name, img.width, img.height);
+        }
+        (images, "CLIC2025")
+    } else if let Some(images) = load_cid22_images(10) {
+        eprintln!(
+            "CLIC unavailable, loaded {} CID22 images (512x512)",
+            images.len()
+        );
+        (images, "CID22")
+    } else {
+        eprintln!("No corpus available, using synthetic noise+patches images");
+        (generate_synthetic_images(), "synthetic")
+    };
+
+    let mut baseline_q85 = Vec::new();
+    let mut baseline_q50 = Vec::new();
+    let mut progressive_q85 = Vec::new();
+    let mut baseline_444_q85 = Vec::new();
+
+    for src in &sources {
+        let pixels = (src.width as u64) * (src.height as u64);
+        let label = format!("{}({}x{})", src.name, src.width, src.height);
+
+        baseline_q85.push(EncodedImage {
+            label: label.clone(),
+            jpeg: encode_jpeg(
+                &src.pixels,
+                src.width,
+                src.height,
+                85.0,
+                ChromaSubsampling::Quarter,
+                false,
+            ),
+            pixels,
+        });
+        baseline_q50.push(EncodedImage {
+            label: label.clone(),
+            jpeg: encode_jpeg(
+                &src.pixels,
+                src.width,
+                src.height,
+                50.0,
+                ChromaSubsampling::Quarter,
+                false,
+            ),
+            pixels,
+        });
+        progressive_q85.push(EncodedImage {
+            label: label.clone(),
+            jpeg: encode_jpeg(
+                &src.pixels,
+                src.width,
+                src.height,
+                85.0,
+                ChromaSubsampling::Quarter,
+                true,
+            ),
+            pixels,
+        });
+        baseline_444_q85.push(EncodedImage {
+            label,
+            jpeg: encode_jpeg(
+                &src.pixels,
+                src.width,
+                src.height,
+                85.0,
+                ChromaSubsampling::None,
+                false,
+            ),
+            pixels,
+        });
+    }
+
+    // Print stats
+    let total_bytes: usize = baseline_q85.iter().map(|e| e.jpeg.len()).sum();
+    let total_pixels: u64 = baseline_q85.iter().map(|e| e.pixels).sum();
+    eprintln!(
+        "Test set ({tag}): {} images, {:.1}MP total, {:.1}MB baseline Q85 JPEG",
+        sources.len(),
+        total_pixels as f64 / 1e6,
+        total_bytes as f64 / (1024.0 * 1024.0),
+    );
+
+    TestSet {
+        baseline_q85,
+        baseline_q50,
+        progressive_q85,
+        baseline_444_q85,
+        source_tag: match tag {
+            "CLIC2025" => "CLIC2025",
+            "CID22" => "CID22",
+            _ => "synthetic",
+        },
+    }
+}
+
+static TEST_SET: std::sync::OnceLock<TestSet> = std::sync::OnceLock::new();
+
+fn get_test_set() -> &'static TestSet {
+    TEST_SET.get_or_init(build_test_set)
+}
+
+// ── Benchmark groups ───────────────────────────────────────────────────────
+
+fn bench_group(
+    c: &mut Criterion,
+    group_name: &str,
+    images: &[EncodedImage],
+) {
+    let mut group = c.benchmark_group(group_name);
+
+    // Aggregate benchmark: decode all images in one iteration
+    let total_bytes: u64 = images.iter().map(|e| e.jpeg.len() as u64).sum();
+    let total_pixels: u64 = images.iter().map(|e| e.pixels).sum();
+    group.throughput(Throughput::Bytes(total_bytes));
+
+    group.bench_function("zenjpeg_all", |b| {
+        let decoder = Decoder::new().output_format(PixelFormat::Rgb);
+        b.iter(|| {
+            for img in images {
+                decoder.decode(black_box(&img.jpeg), Unstoppable).unwrap();
+            }
+        });
+    });
+
+    eprintln!(
+        "  {group_name}: {:.1}MP total, {:.1}MB JPEG, {:.2} bpp",
+        total_pixels as f64 / 1e6,
+        total_bytes as f64 / (1024.0 * 1024.0),
+        (total_bytes * 8) as f64 / total_pixels as f64,
+    );
+
+    // Per-image benchmarks for the largest images (skip tiny ones)
+    for img in images {
+        if img.pixels < 200_000 {
+            continue; // Skip images too small for reliable measurement
+        }
+        group.throughput(Throughput::Bytes(img.jpeg.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("zenjpeg", &img.label),
+            &img.jpeg,
+            |b, data| {
+                let decoder = Decoder::new().output_format(PixelFormat::Rgb);
+                b.iter(|| decoder.decode(black_box(data), Unstoppable).unwrap());
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_baseline_420_q85(c: &mut Criterion) {
+    let ts = get_test_set();
+    bench_group(c, "huffdec/baseline_420_Q85", &ts.baseline_q85);
+}
+
+fn bench_baseline_420_q50(c: &mut Criterion) {
+    let ts = get_test_set();
+    bench_group(c, "huffdec/baseline_420_Q50", &ts.baseline_q50);
+}
+
+fn bench_progressive_420_q85(c: &mut Criterion) {
+    let ts = get_test_set();
+    bench_group(c, "huffdec/progressive_420_Q85", &ts.progressive_q85);
+}
+
+fn bench_baseline_444_q85(c: &mut Criterion) {
+    let ts = get_test_set();
+    bench_group(c, "huffdec/baseline_444_Q85", &ts.baseline_444_q85);
+}
+
+criterion_group!(
+    benches,
+    bench_baseline_420_q85,
+    bench_baseline_420_q50,
+    bench_progressive_420_q85,
+    bench_baseline_444_q85,
+);
+criterion_main!(benches);

--- a/zenjpeg/benches/huffman_decode.rs
+++ b/zenjpeg/benches/huffman_decode.rs
@@ -1,8 +1,7 @@
 //! Focused Huffman decode benchmark for measuring entropy decoding throughput.
 //!
-//! Uses CLIC 2025 photographs from codec-corpus for realistic coefficient
-//! distributions. Falls back to noise+patches synthetic images if the corpus
-//! is unavailable (no network / CI).
+//! Uses CLIC 2025 photographs from codec-corpus. Requires the corpus to be
+//! available (auto-downloaded on first run). Panics if no images are found.
 //!
 //! Tests baseline and progressive at multiple quality levels to exercise
 //! different Huffman code length distributions:
@@ -14,17 +13,15 @@
 //! cargo bench -p zenjpeg --bench huffman_decode --features decoder
 //! ```
 
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use enough::Unstoppable;
-use std::hint::black_box;
 use std::path::{Path, PathBuf};
+use zenbench::prelude::*;
 use zenjpeg::decode::Decoder;
 use zenjpeg::decoder::PixelFormat;
 use zenjpeg::encode::{ChromaSubsampling, EncoderConfig, PixelLayout};
 
 // ── Image loading ──────────────────────────────────────────────────────────
 
-/// Load a PNG file to flat RGB bytes.
 fn load_png_rgb(path: &Path) -> Option<(Vec<u8>, u32, u32)> {
     let file = std::fs::File::open(path).ok()?;
     let dec = png::Decoder::new(std::io::BufReader::new(file));
@@ -57,7 +54,6 @@ fn load_png_rgb(path: &Path) -> Option<(Vec<u8>, u32, u32)> {
     Some((rgb, w, h))
 }
 
-/// Collect all PNG files from a directory, sorted by name.
 fn collect_pngs(dir: &Path) -> Vec<PathBuf> {
     let mut files: Vec<_> = std::fs::read_dir(dir)
         .into_iter()
@@ -72,60 +68,6 @@ fn collect_pngs(dir: &Path) -> Vec<PathBuf> {
         .collect();
     files.sort();
     files
-}
-
-/// Generate noise+patches pixel data (fallback when corpus is unavailable).
-fn generate_photo_like_pixels(width: u32, height: u32) -> Vec<u8> {
-    let mut data = vec![0u8; (width * height * 3) as usize];
-    for y in 0..height as usize {
-        for x in 0..width as usize {
-            let idx = (y * width as usize + x) * 3;
-            let bx = (x / 8) as u32;
-            let by = (y / 8) as u32;
-            let block_hash = bx
-                .wrapping_mul(2654435761)
-                .wrapping_add(by.wrapping_mul(40503));
-            let block_type = block_hash % 4;
-
-            let px = x as u32;
-            let py = y as u32;
-            let mut h = px
-                .wrapping_mul(374761393)
-                .wrapping_add(py.wrapping_mul(668265263));
-            h = (h ^ (h >> 13)).wrapping_mul(1274126177);
-            let noise = (h >> 24) as u8;
-
-            match block_type {
-                0 => {
-                    let bias = ((bx.wrapping_mul(17) ^ by.wrapping_mul(31)) & 0xFF) as u8;
-                    data[idx] = bias.wrapping_add(noise >> 2);
-                    data[idx + 1] = bias.wrapping_add(noise >> 1);
-                    data[idx + 2] = bias.wrapping_add(noise >> 3);
-                }
-                1 => {
-                    data[idx] = ((x * 255) / width as usize) as u8;
-                    data[idx + 1] = ((y * 255) / height as usize) as u8;
-                    data[idx + 2] = noise >> 2;
-                }
-                2 => {
-                    let edge = if (x % 8 < 4) ^ (y % 8 < 4) {
-                        200u8
-                    } else {
-                        55u8
-                    };
-                    data[idx] = edge;
-                    data[idx + 1] = edge.wrapping_add(noise >> 4);
-                    data[idx + 2] = 255 - edge;
-                }
-                _ => {
-                    data[idx] = noise;
-                    data[idx + 1] = noise.wrapping_mul(3);
-                    data[idx + 2] = noise.wrapping_mul(7);
-                }
-            }
-        }
-    }
-    data
 }
 
 // ── JPEG encoding ──────────────────────────────────────────────────────────
@@ -145,12 +87,11 @@ fn encode_jpeg(
     let mut enc = config
         .encode_from_bytes(width, height, PixelLayout::Rgb8Srgb)
         .expect("encoder creation");
-    enc.push_packed(pixels, Unstoppable)
-        .expect("push_packed");
+    enc.push_packed(pixels, Unstoppable).expect("push_packed");
     enc.finish().expect("finish")
 }
 
-// ── Test image set ─────────────────────────────────────────────────────────
+// ── Corpus loading ─────────────────────────────────────────────────────────
 
 struct SourceImage {
     name: String,
@@ -159,35 +100,33 @@ struct SourceImage {
     height: u32,
 }
 
-struct EncodedImage {
-    label: String,
-    jpeg: Vec<u8>,
-    pixels: u64,
+struct EncodedSet {
+    label: &'static str,
+    images: Vec<(String, Vec<u8>, u64)>, // (name, jpeg, pixel_count)
 }
 
 struct TestSet {
-    baseline_q85: Vec<EncodedImage>,
-    baseline_q50: Vec<EncodedImage>,
-    progressive_q85: Vec<EncodedImage>,
-    baseline_444_q85: Vec<EncodedImage>,
-    #[allow(dead_code)]
-    source_tag: &'static str,
+    baseline_q85: EncodedSet,
+    baseline_q50: EncodedSet,
+    progressive_q85: EncodedSet,
+    baseline_444_q85: EncodedSet,
 }
 
-/// Try loading CLIC 2025 images from codec-corpus. Returns up to `max` images.
-fn load_clic_images(max: usize) -> Option<Vec<SourceImage>> {
-    let corpus = codec_corpus::Corpus::new().ok()?;
+fn load_corpus_images(max: usize) -> Vec<SourceImage> {
+    let corpus = codec_corpus::Corpus::new().expect("codec-corpus init failed");
 
-    // Try CLIC 2025 final-test first, then training
+    // Try CLIC 2025 final-test, then training, then CID22
     let dir = corpus
         .get("clic2025/final-test")
         .or_else(|_| corpus.get("clic2025/training"))
-        .ok()?;
+        .or_else(|_| corpus.get("CID22/CID22-512/training"))
+        .expect("No corpus available (need clic2025 or CID22)");
 
     let pngs = collect_pngs(&dir);
-    if pngs.is_empty() {
-        return None;
-    }
+    assert!(
+        !pngs.is_empty(),
+        "No PNG files found in corpus directory: {dir:?}"
+    );
 
     let images: Vec<SourceImage> = pngs
         .iter()
@@ -195,8 +134,14 @@ fn load_clic_images(max: usize) -> Option<Vec<SourceImage>> {
         .filter_map(|p| {
             let (pixels, w, h) = load_png_rgb(p)?;
             let name = p.file_stem()?.to_string_lossy().into_owned();
+            // Truncate hash names for readable output
+            let short_name = if name.len() > 12 {
+                format!("{}..{}", &name[..6], &name[name.len() - 6..])
+            } else {
+                name
+            };
             Some(SourceImage {
-                name,
+                name: short_name,
                 pixels,
                 width: w,
                 height: h,
@@ -204,146 +149,83 @@ fn load_clic_images(max: usize) -> Option<Vec<SourceImage>> {
         })
         .collect();
 
-    if images.is_empty() {
-        None
-    } else {
-        Some(images)
-    }
+    assert!(!images.is_empty(), "Failed to load any images from corpus");
+    images
 }
 
-/// Fall back to CID22 512px corpus.
-fn load_cid22_images(max: usize) -> Option<Vec<SourceImage>> {
-    let corpus = codec_corpus::Corpus::new().ok()?;
-    let dir = corpus.get("CID22/CID22-512/training").ok()?;
-    let pngs = collect_pngs(&dir);
-    if pngs.is_empty() {
-        return None;
-    }
-
-    let images: Vec<SourceImage> = pngs
+fn encode_set(
+    sources: &[SourceImage],
+    quality: f32,
+    subsampling: ChromaSubsampling,
+    progressive: bool,
+    label: &'static str,
+) -> EncodedSet {
+    let images: Vec<_> = sources
         .iter()
-        .take(max)
-        .filter_map(|p| {
-            let (pixels, w, h) = load_png_rgb(p)?;
-            let name = p.file_stem()?.to_string_lossy().into_owned();
-            Some(SourceImage {
-                name,
-                pixels,
-                width: w,
-                height: h,
-            })
+        .map(|src| {
+            let pixels = (src.width as u64) * (src.height as u64);
+            let jpeg = encode_jpeg(
+                &src.pixels,
+                src.width,
+                src.height,
+                quality,
+                subsampling,
+                progressive,
+            );
+            let name = format!("{}({}x{})", src.name, src.width, src.height);
+            (name, jpeg, pixels)
         })
         .collect();
-
-    if images.is_empty() {
-        None
-    } else {
-        Some(images)
-    }
-}
-
-/// Generate synthetic fallback images at fixed sizes.
-fn generate_synthetic_images() -> Vec<SourceImage> {
-    [(1024, 1024, "synth_1024"), (2048, 2048, "synth_2048")]
-        .iter()
-        .map(|&(w, h, name)| SourceImage {
-            name: name.to_string(),
-            pixels: generate_photo_like_pixels(w, h),
-            width: w,
-            height: h,
-        })
-        .collect()
+    EncodedSet { label, images }
 }
 
 fn build_test_set() -> TestSet {
-    // Try CLIC 2025 → CID22 → synthetic fallback
-    let (sources, tag) = if let Some(images) = load_clic_images(8) {
-        eprintln!(
-            "Loaded {} CLIC 2025 images for Huffman decode benchmark",
-            images.len()
-        );
-        for img in &images {
-            eprintln!("  {} ({}x{})", img.name, img.width, img.height);
-        }
-        (images, "CLIC2025")
-    } else if let Some(images) = load_cid22_images(10) {
-        eprintln!(
-            "CLIC unavailable, loaded {} CID22 images (512x512)",
-            images.len()
-        );
-        (images, "CID22")
-    } else {
-        eprintln!("No corpus available, using synthetic noise+patches images");
-        (generate_synthetic_images(), "synthetic")
-    };
+    let sources = load_corpus_images(8);
 
-    let mut baseline_q85 = Vec::new();
-    let mut baseline_q50 = Vec::new();
-    let mut progressive_q85 = Vec::new();
-    let mut baseline_444_q85 = Vec::new();
-
-    for src in &sources {
-        let pixels = (src.width as u64) * (src.height as u64);
-        let label = format!("{}({}x{})", src.name, src.width, src.height);
-
-        baseline_q85.push(EncodedImage {
-            label: label.clone(),
-            jpeg: encode_jpeg(
-                &src.pixels,
-                src.width,
-                src.height,
-                85.0,
-                ChromaSubsampling::Quarter,
-                false,
-            ),
-            pixels,
-        });
-        baseline_q50.push(EncodedImage {
-            label: label.clone(),
-            jpeg: encode_jpeg(
-                &src.pixels,
-                src.width,
-                src.height,
-                50.0,
-                ChromaSubsampling::Quarter,
-                false,
-            ),
-            pixels,
-        });
-        progressive_q85.push(EncodedImage {
-            label: label.clone(),
-            jpeg: encode_jpeg(
-                &src.pixels,
-                src.width,
-                src.height,
-                85.0,
-                ChromaSubsampling::Quarter,
-                true,
-            ),
-            pixels,
-        });
-        baseline_444_q85.push(EncodedImage {
-            label,
-            jpeg: encode_jpeg(
-                &src.pixels,
-                src.width,
-                src.height,
-                85.0,
-                ChromaSubsampling::None,
-                false,
-            ),
-            pixels,
-        });
+    eprintln!(
+        "Loaded {} corpus images for Huffman decode benchmark:",
+        sources.len()
+    );
+    for img in &sources {
+        eprintln!("  {} ({}x{})", img.name, img.width, img.height);
     }
 
-    // Print stats
-    let total_bytes: usize = baseline_q85.iter().map(|e| e.jpeg.len()).sum();
-    let total_pixels: u64 = baseline_q85.iter().map(|e| e.pixels).sum();
+    let baseline_q85 = encode_set(
+        &sources,
+        85.0,
+        ChromaSubsampling::Quarter,
+        false,
+        "baseline_420_Q85",
+    );
+    let baseline_q50 = encode_set(
+        &sources,
+        50.0,
+        ChromaSubsampling::Quarter,
+        false,
+        "baseline_420_Q50",
+    );
+    let progressive_q85 = encode_set(
+        &sources,
+        85.0,
+        ChromaSubsampling::Quarter,
+        true,
+        "progressive_420_Q85",
+    );
+    let baseline_444_q85 = encode_set(
+        &sources,
+        85.0,
+        ChromaSubsampling::None,
+        false,
+        "baseline_444_Q85",
+    );
+
+    let total_bytes: usize = baseline_q85.images.iter().map(|(_, j, _)| j.len()).sum();
+    let total_pixels: u64 = baseline_q85.images.iter().map(|(_, _, p)| p).sum();
     eprintln!(
-        "Test set ({tag}): {} images, {:.1}MP total, {:.1}MB baseline Q85 JPEG",
-        sources.len(),
+        "Test set: {:.1}MP total, {:.1}MB baseline Q85 JPEG, {:.2} bpp",
         total_pixels as f64 / 1e6,
         total_bytes as f64 / (1024.0 * 1024.0),
+        (total_bytes as f64 * 8.0) / total_pixels as f64,
     );
 
     TestSet {
@@ -351,11 +233,6 @@ fn build_test_set() -> TestSet {
         baseline_q50,
         progressive_q85,
         baseline_444_q85,
-        source_tag: match tag {
-            "CLIC2025" => "CLIC2025",
-            "CID22" => "CID22",
-            _ => "synthetic",
-        },
     }
 }
 
@@ -365,80 +242,49 @@ fn get_test_set() -> &'static TestSet {
     TEST_SET.get_or_init(build_test_set)
 }
 
-// ── Benchmark groups ───────────────────────────────────────────────────────
+// ── Benchmark ──────────────────────────────────────────────────────────────
 
-fn bench_group(
-    c: &mut Criterion,
-    group_name: &str,
-    images: &[EncodedImage],
-) {
-    let mut group = c.benchmark_group(group_name);
+fn bench_set(suite: &mut Suite, set: &'static EncodedSet) {
+    let total_bytes: u64 = set.images.iter().map(|(_, j, _)| j.len() as u64).sum();
 
-    // Aggregate benchmark: decode all images in one iteration
-    let total_bytes: u64 = images.iter().map(|e| e.jpeg.len() as u64).sum();
-    let total_pixels: u64 = images.iter().map(|e| e.pixels).sum();
-    group.throughput(Throughput::Bytes(total_bytes));
+    // Aggregate benchmark: decode all images per iteration
+    suite.group(format!("huffdec/{}", set.label), |g| {
+        g.throughput(Throughput::Bytes(total_bytes));
 
-    group.bench_function("zenjpeg_all", |b| {
-        let decoder = Decoder::new().output_format(PixelFormat::Rgb);
-        b.iter(|| {
-            for img in images {
-                decoder.decode(black_box(&img.jpeg), Unstoppable).unwrap();
-            }
+        g.bench("zenjpeg", |b| {
+            let decoder = Decoder::new().output_format(PixelFormat::Rgb);
+            b.iter(|| {
+                for (_, jpeg, _) in &set.images {
+                    decoder.decode(jpeg, Unstoppable).unwrap();
+                }
+            });
         });
     });
 
-    eprintln!(
-        "  {group_name}: {:.1}MP total, {:.1}MB JPEG, {:.2} bpp",
-        total_pixels as f64 / 1e6,
-        total_bytes as f64 / (1024.0 * 1024.0),
-        (total_bytes * 8) as f64 / total_pixels as f64,
-    );
+    // Per-image benchmarks
+    for (name, jpeg, _pixels) in &set.images {
+        suite.group(format!("huffdec/{}/{name}", set.label), |g| {
+            g.throughput(Throughput::Bytes(jpeg.len() as u64));
 
-    // Per-image benchmarks for the largest images (skip tiny ones)
-    for img in images {
-        if img.pixels < 200_000 {
-            continue; // Skip images too small for reliable measurement
-        }
-        group.throughput(Throughput::Bytes(img.jpeg.len() as u64));
-        group.bench_with_input(
-            BenchmarkId::new("zenjpeg", &img.label),
-            &img.jpeg,
-            |b, data| {
-                let decoder = Decoder::new().output_format(PixelFormat::Rgb);
-                b.iter(|| decoder.decode(black_box(data), Unstoppable).unwrap());
-            },
-        );
+            g.bench("zenjpeg", {
+                let jpeg = jpeg.clone();
+                move |b| {
+                    let decoder = Decoder::new().output_format(PixelFormat::Rgb);
+                    b.iter(|| {
+                        decoder.decode(&jpeg, Unstoppable).unwrap();
+                    });
+                }
+            });
+        });
     }
-
-    group.finish();
 }
 
-fn bench_baseline_420_q85(c: &mut Criterion) {
+fn bench_all(suite: &mut Suite) {
     let ts = get_test_set();
-    bench_group(c, "huffdec/baseline_420_Q85", &ts.baseline_q85);
+    bench_set(suite, &ts.baseline_q85);
+    bench_set(suite, &ts.baseline_q50);
+    bench_set(suite, &ts.progressive_q85);
+    bench_set(suite, &ts.baseline_444_q85);
 }
 
-fn bench_baseline_420_q50(c: &mut Criterion) {
-    let ts = get_test_set();
-    bench_group(c, "huffdec/baseline_420_Q50", &ts.baseline_q50);
-}
-
-fn bench_progressive_420_q85(c: &mut Criterion) {
-    let ts = get_test_set();
-    bench_group(c, "huffdec/progressive_420_Q85", &ts.progressive_q85);
-}
-
-fn bench_baseline_444_q85(c: &mut Criterion) {
-    let ts = get_test_set();
-    bench_group(c, "huffdec/baseline_444_Q85", &ts.baseline_444_q85);
-}
-
-criterion_group!(
-    benches,
-    bench_baseline_420_q85,
-    bench_baseline_420_q50,
-    bench_progressive_420_q85,
-    bench_baseline_444_q85,
-);
-criterion_main!(benches);
+zenbench::main!(bench_all);

--- a/zenjpeg/src/entropy/decoder.rs
+++ b/zenjpeg/src/entropy/decoder.rs
@@ -1602,16 +1602,16 @@ impl<'data, 'tables> EntropyDecoder<'data, 'tables> {
 
                 let mut k = ss as usize;
                 'block: while k <= se_usize {
-                    // Peek 9 bits for Huffman lookup. peek_bits_refill handles
+                    // Peek FAST_BITS for Huffman lookup. peek_bits_refill handles
                     // refill internally and returns None only when truly exhausted
                     // (unlike ensure_bits which demands 32 bits).
-                    // Peek 9 bits for Huffman + fast_ac lookup.
-                    // When <9 bits remain after refill, use peek_top(9) with
+                    // When <FAST_BITS bits remain after refill, use peek_top with
                     // available-bits validation (the MSB-aligned zero-padding
                     // still gives a valid fast_lookup index for codes ≤ avail bits).
+                    let fast_bits = HuffmanDecodeTable::FAST_BITS as u8;
                     let bits9;
                     let partial_peek;
-                    match self.reader.peek_bits_refill(9) {
+                    match self.reader.peek_bits_refill(fast_bits) {
                         Some(b) => {
                             bits9 = b;
                             partial_peek = false;
@@ -1621,12 +1621,12 @@ impl<'data, 'tables> EntropyDecoder<'data, 'tables> {
                             if avail == 0 {
                                 return Ok(false);
                             }
-                            bits9 = self.reader.peek_top(9);
+                            bits9 = self.reader.peek_top(fast_bits);
                             partial_peek = true;
                         }
                     };
 
-                    // Try fast_ac combined lookup first (9-bit → symbol + value)
+                    // Try fast_ac combined lookup first (FAST_BITS → symbol + value)
                     if !partial_peek && let Some(fast_ac_arr) = fast_ac {
                         let entry = fast_ac_arr[bits9 as usize];
                         if entry != 0 {
@@ -1750,20 +1750,21 @@ impl<'data, 'tables> EntropyDecoder<'data, 'tables> {
     /// bit-by-bit (any count). Returns `Some(symbol)` or `None` to signal
     /// "can't decode, break the outer loop."
     ///
-    /// Extracted so the bit-by-bit fallback isn't duplicated for the ≥9 and <9
-    /// entry points — one copy serves both, reducing icache pressure in the
-    /// 12KB `decode_progressive_scan` function.
+    /// Extracted so the bit-by-bit fallback isn't duplicated for the ≥FAST_BITS
+    /// and <FAST_BITS entry points — one copy serves both, reducing icache
+    /// pressure in the 12KB `decode_progressive_scan` function.
     #[inline(always)]
     fn decode_refine_symbol(&mut self, ac_table: &HuffmanDecodeTable) -> Option<u8> {
-        if self.reader.bits_available() >= 9 {
-            let bits9 = self.reader.peek_top(9) as usize;
-            let lookup = ac_table.fast_lookup[bits9];
+        let fast_bits = HuffmanDecodeTable::FAST_BITS as u8;
+        if self.reader.bits_available() >= fast_bits {
+            let bits_fb = self.reader.peek_top(fast_bits) as usize;
+            let lookup = ac_table.fast_lookup[bits_fb];
             if lookup >= 0 {
                 let code_len = (lookup >> 8) as u8;
                 self.reader.skip_bits_fast(code_len);
                 return Some((lookup & 0xFF) as u8);
             }
-            // Code is > 9 bits — try slow path with 16-bit peek
+            // Code is > FAST_BITS — try slow path with 16-bit peek
             if self.reader.bits_available() < 16 {
                 let _ = self.reader.refill();
             }
@@ -1777,7 +1778,7 @@ impl<'data, 'tables> EntropyDecoder<'data, 'tables> {
                 };
             }
         }
-        // < 9 bits after refill, or < 16 after fast lookup miss: bit-by-bit.
+        // < FAST_BITS after refill, or < 16 after fast lookup miss: bit-by-bit.
         let mut code = 0u32;
         for len in 1..=16usize {
             let bit = self.reader.read_bit_refine();

--- a/zenjpeg/src/foundation/bitstream.rs
+++ b/zenjpeg/src/foundation/bitstream.rs
@@ -504,6 +504,30 @@ impl<'a> BitReader<'a> {
             return true;
         }
 
+        // Try fast 8-byte path first when we have room for 5+ bytes.
+        // Load 8 bytes, SWAR-check for 0xFF, then consume as many complete
+        // bytes as fit. This nearly doubles the bits loaded per refill vs
+        // the 4-byte path, reducing refill frequency in the decode hot loop.
+        if self.bits_in_buffer <= 24 {
+            if let Some(chunk) = self.data.get(self.position..self.position + 8) {
+                let bytes: [u8; 8] = chunk.try_into().unwrap();
+                let word = u64::from_be_bytes(bytes);
+
+                if !has_byte_0xff_u64(word) {
+                    let load_bytes = ((64 - self.bits_in_buffer) / 8) as usize; // 5-8 bytes
+                    let load_bits = (load_bytes as u8) * 8;
+                    self.position += load_bytes;
+                    // Extract the top `load_bytes` bytes from word and place
+                    // them in the freed positions of aligned_buffer.
+                    let loaded = word >> (64 - load_bits);
+                    self.aligned_buffer |= loaded << (64 - self.bits_in_buffer - load_bits);
+                    self.bits_in_buffer += load_bits;
+                    return true;
+                }
+                // Has 0xFF — fall through to 4-byte or slow path
+            }
+        }
+
         // Try fast 4-byte path (no 0xFF bytes)
         // Use get() + try_into to give compiler a single bounds check and u32 load
         if let Some(chunk) = self.data.get(self.position..self.position + 4) {

--- a/zenjpeg/src/foundation/bitstream.rs
+++ b/zenjpeg/src/foundation/bitstream.rs
@@ -508,24 +508,24 @@ impl<'a> BitReader<'a> {
         // Load 8 bytes, SWAR-check for 0xFF, then consume as many complete
         // bytes as fit. This nearly doubles the bits loaded per refill vs
         // the 4-byte path, reducing refill frequency in the decode hot loop.
-        if self.bits_in_buffer <= 24 {
-            if let Some(chunk) = self.data.get(self.position..self.position + 8) {
-                let bytes: [u8; 8] = chunk.try_into().unwrap();
-                let word = u64::from_be_bytes(bytes);
+        if self.bits_in_buffer <= 24
+            && let Some(chunk) = self.data.get(self.position..self.position + 8)
+        {
+            let bytes: [u8; 8] = chunk.try_into().unwrap();
+            let word = u64::from_be_bytes(bytes);
 
-                if !has_byte_0xff_u64(word) {
-                    let load_bytes = ((64 - self.bits_in_buffer) / 8) as usize; // 5-8 bytes
-                    let load_bits = (load_bytes as u8) * 8;
-                    self.position += load_bytes;
-                    // Extract the top `load_bytes` bytes from word and place
-                    // them in the freed positions of aligned_buffer.
-                    let loaded = word >> (64 - load_bits);
-                    self.aligned_buffer |= loaded << (64 - self.bits_in_buffer - load_bits);
-                    self.bits_in_buffer += load_bits;
-                    return true;
-                }
-                // Has 0xFF — fall through to 4-byte or slow path
+            if !has_byte_0xff_u64(word) {
+                let load_bytes = ((64 - self.bits_in_buffer) / 8) as usize; // 5-8 bytes
+                let load_bits = (load_bytes as u8) * 8;
+                self.position += load_bytes;
+                // Extract the top `load_bytes` bytes from word and place
+                // them in the freed positions of aligned_buffer.
+                let loaded = word >> (64 - load_bits);
+                self.aligned_buffer |= loaded << (64 - self.bits_in_buffer - load_bits);
+                self.bits_in_buffer += load_bits;
+                return true;
             }
+            // Has 0xFF — fall through to 4-byte or slow path
         }
 
         // Try fast 4-byte path (no 0xFF bytes)

--- a/zenjpeg/src/huffman/encode.rs
+++ b/zenjpeg/src/huffman/encode.rs
@@ -269,7 +269,7 @@ pub struct HuffmanDecodeTable {
 
 impl HuffmanDecodeTable {
     /// Number of bits for fast lookup table.
-    pub const FAST_BITS: usize = 9;
+    pub const FAST_BITS: usize = 10;
 
     /// Creates a new empty decode table.
     #[must_use]


### PR DESCRIPTION
Two optimizations that together speed up JPEG decoding by ~5% on typical
web-quality content and ~9% on Q100, with the gap widening as coefficient
density increases:

1. Widen FAST_BITS from 9 to 10: The primary Huffman lookup table grows
   from 512 to 1024 entries. This raises the fast-path hit rate and halves
   slow-path (maxcode_16bit linear scan) invocations when codes are 10 bits.
   The fast_ac combined table widens too, resolving more AC coefficients in
   one operation. Total L1 cache footprint for 4 tables: 8KB.

2. Add 8-byte fast refill path in BitReader: When bits_in_buffer <= 24,
   load 8 bytes at once (SWAR-checked for 0xFF via existing
   has_byte_0xff_u64). Consumes 5-8 complete bytes per call, roughly
   doubling the bits loaded per refill vs the 4-byte path. Falls back to
   4-byte and byte-by-byte paths when 0xFF is present.

Benchmark results (8 CLIC 2025 photographs, 22.6MP total, zenbench
interleaved paired stats, 2 runs averaged; WSL2 on Ryzen 9 7950X):

  baseline 4:2:0 Q100:   95.9ms → 87.3ms  (-9.0%)
  baseline 4:2:0 Q85:    41.3ms → 39.0ms  (-5.7%)
  baseline 4:2:0 Q50:    29.1ms → 29.0ms  (-0.3%)
  baseline 4:2:0 Q5:     21.9ms → 21.6ms  (-1.1%)
  progressive 4:2:0 Q85: 65.4ms → 62.5ms  (-4.5%)
  baseline 4:4:4 Q85:    45.9ms → 43.8ms  (-4.6%)

The improvement scales with AC coefficient density: Q100 preserves the
most coefficients and sees the biggest gain, while at Q5 most blocks
terminate at EOB after 1-2 coefficients so the wider lookup and refill
provide little benefit.

FAST_BITS=11 was tested and gains an additional ~1% on Q100/Q85, but
doubles fast-table memory from 16KB to 32KB (fills a typical 32KB L1d
with Huffman tables alone). Not worth the portability risk on i686/ARM;
FB=10 chosen.

Correctness:
- All 811 library tests + 1170 integration tests pass (1981 total, 0 failed)
- Replayed 5,764 inputs across fuzz_decode / fuzz_decode_paths /
  fuzz_push_decode / fuzz_read_info corpora: 0 crashes, 0 new artifacts

Also adds huffman_decode benchmark (benches/huffman_decode.rs) using
zenbench + codec-corpus CLIC 2025 images.