### PR TITLE
feat: expose raw CMYK output from CMYK/YCCK JPEGs

### DIFF
--- a/zenjpeg/src/codec.rs
+++ b/zenjpeg/src/codec.rs
@@ -2863,3 +2863,257 @@ mod streaming_test {
         let _enc = job.dyn_encoder().unwrap();
     }
 }
+
+#[cfg(test)]
+mod cmyk_tests {
+    use super::*;
+    use alloc::borrow::Cow;
+    use imgref::{Img, ImgExt};
+    use rgb::Rgb;
+    use zencodec::decode::{Decode as _, DecodeJob as _, DecoderConfig as _};
+    use zencodec::encode::EncoderConfig as _;
+
+    // ── CMYK raw output tests ──────────────────────────────────────────────
+
+    /// Load the CMYK flower test image if available.
+    fn load_cmyk_test_image() -> Option<Vec<u8>> {
+        crate::test_utils::read_test_data("jxl/flower/flower_small.cmyk.jpg")
+    }
+
+    #[test]
+    fn cmyk_raw_output_produces_4_channels() {
+        let data = match load_cmyk_test_image() {
+            Some(d) => d,
+            None => {
+                eprintln!("SKIP: CMYK test image not found");
+                return;
+            }
+        };
+
+        let dec = JpegDecoderConfig::new().cmyk_output_raw(true);
+        let output = dec
+            .job()
+            .decoder(Cow::Borrowed(&data), &[])
+            .unwrap()
+            .decode()
+            .unwrap();
+
+        let info = output.info();
+        let pixels = output.pixels();
+
+        // Verify 4 channels via RGBA8 layout
+        assert_eq!(pixels.descriptor().bytes_per_pixel(), 4);
+
+        // source_color.channel_count should be 4 (CMYK)
+        assert_eq!(info.source_color.channel_count, Some(4));
+
+        // has_alpha should be false (this is CMYK, not RGBA)
+        assert!(!info.has_alpha, "has_alpha should be false for raw CMYK");
+
+        // ICC profile is preserved if present in the source.
+        // Note: the flower_small.cmyk.jpg test image has no ICC profile,
+        // so we only verify that the field is accessible (not that it's Some).
+        let _icc = &info.source_color.icc_profile;
+
+        // Verify dimensions are reasonable
+        assert!(info.width > 0);
+        assert!(info.height > 0);
+
+        // Verify pixel data has correct size: w * h * 4
+        let expected_bytes = info.width as usize * info.height as usize * 4;
+        let actual_bytes = pixels.width() as usize * pixels.rows() as usize * 4;
+        assert_eq!(actual_bytes, expected_bytes);
+    }
+
+    #[test]
+    fn cmyk_raw_vs_default_produces_different_but_reasonable_output() {
+        let data = match load_cmyk_test_image() {
+            Some(d) => d,
+            None => {
+                eprintln!("SKIP: CMYK test image not found");
+                return;
+            }
+        };
+
+        // Decode with default (auto RGB conversion)
+        let dec_rgb = JpegDecoderConfig::new();
+        let output_rgb = dec_rgb
+            .job()
+            .decoder(Cow::Borrowed(&data), &[])
+            .unwrap()
+            .decode()
+            .unwrap();
+
+        // Decode with raw CMYK
+        let dec_cmyk = JpegDecoderConfig::new().cmyk_output_raw(true);
+        let output_cmyk = dec_cmyk
+            .job()
+            .decoder(Cow::Borrowed(&data), &[])
+            .unwrap()
+            .decode()
+            .unwrap();
+
+        let rgb_info = output_rgb.info();
+        let cmyk_info = output_cmyk.info();
+
+        // Same dimensions
+        assert_eq!(rgb_info.width, cmyk_info.width);
+        assert_eq!(rgb_info.height, cmyk_info.height);
+
+        // RGB output is 3-channel (RGB8), CMYK output is 4-channel (RGBA8 layout)
+        assert_eq!(output_rgb.pixels().descriptor().bytes_per_pixel(), 3);
+        assert_eq!(output_cmyk.pixels().descriptor().bytes_per_pixel(), 4);
+
+        // Manual CMYK→RGB conversion on raw CMYK data should produce something
+        // close to the auto-converted RGB (within the known maxDelta of ~39)
+        let w = cmyk_info.width as usize;
+        let h = cmyk_info.height as usize;
+        let cmyk_pixels = output_cmyk.pixels();
+        let cmyk_bytes: Vec<u8> = {
+            let mut all = Vec::with_capacity(w * h * 4);
+            for row in 0..cmyk_pixels.rows() {
+                all.extend_from_slice(cmyk_pixels.row(row));
+            }
+            all
+        };
+        let rgb_pixels = output_rgb.pixels();
+        let rgb_bytes: Vec<u8> = {
+            let mut all = Vec::with_capacity(w * h * 3);
+            for row in 0..rgb_pixels.rows() {
+                all.extend_from_slice(rgb_pixels.row(row));
+            }
+            all
+        };
+
+        // Apply simple CMYK→RGB using the same formula as cmyk_adobe_to_rgb
+        let mut max_diff: u32 = 0;
+        for i in 0..(w * h) {
+            let c = cmyk_bytes[i * 4] as u32;
+            let m = cmyk_bytes[i * 4 + 1] as u32;
+            let y = cmyk_bytes[i * 4 + 2] as u32;
+            let k = cmyk_bytes[i * 4 + 3] as u32;
+
+            // Adobe inverted CMYK→RGB: R = C * K / 255
+            let r_manual = ((c * k + 127) / 255) as u8;
+            let g_manual = ((m * k + 127) / 255) as u8;
+            let b_manual = ((y * k + 127) / 255) as u8;
+
+            let r_auto = rgb_bytes[i * 3];
+            let g_auto = rgb_bytes[i * 3 + 1];
+            let b_auto = rgb_bytes[i * 3 + 2];
+
+            let dr = (r_manual as i32 - r_auto as i32).unsigned_abs();
+            let dg = (g_manual as i32 - g_auto as i32).unsigned_abs();
+            let db = (b_manual as i32 - b_auto as i32).unsigned_abs();
+
+            max_diff = max_diff.max(dr).max(dg).max(db);
+        }
+
+        // The manual conversion should match within a small tolerance.
+        // The auto path and manual path use the same formula, so max_diff
+        // should be <=1 (rounding differences from f32→u8 vs integer math).
+        assert!(
+            max_diff <= 2,
+            "Manual CMYK→RGB vs auto CMYK→RGB max pixel diff = {max_diff}, expected <=2"
+        );
+    }
+
+    #[test]
+    fn cmyk_raw_has_no_effect_on_rgb_jpeg() {
+        // Create a simple RGB JPEG
+        let enc = JpegEncoderConfig::new().with_calibrated_quality(80.0);
+        let pixels: Vec<Rgb<u8>> = vec![
+            Rgb {
+                r: 200,
+                g: 100,
+                b: 50,
+            };
+            64
+        ];
+        let img = Img::new(pixels, 8, 8);
+        let encoded = enc.encode(PixelSlice::from(img.as_ref()).into()).unwrap();
+        let jpeg_data = encoded.into_vec();
+
+        // Decode with default
+        let dec_default = JpegDecoderConfig::new();
+        let out_default = dec_default
+            .job()
+            .decoder(Cow::Borrowed(&jpeg_data), &[])
+            .unwrap()
+            .decode()
+            .unwrap();
+
+        // Decode with cmyk_output_raw=true (should have no effect on RGB JPEG)
+        let dec_raw = JpegDecoderConfig::new().cmyk_output_raw(true);
+        let out_raw = dec_raw
+            .job()
+            .decoder(Cow::Borrowed(&jpeg_data), &[])
+            .unwrap()
+            .decode()
+            .unwrap();
+
+        // Both should produce the same output
+        assert_eq!(
+            out_default.pixels().descriptor().bytes_per_pixel(),
+            out_raw.pixels().descriptor().bytes_per_pixel()
+        );
+        assert_eq!(out_default.info().width, out_raw.info().width);
+        assert_eq!(out_default.info().height, out_raw.info().height);
+
+        // Pixel data should be identical
+        let px_default = out_default.pixels();
+        let px_raw = out_raw.pixels();
+        assert_eq!(px_default.rows(), px_raw.rows());
+        for row in 0..px_default.rows() {
+            assert_eq!(
+                px_default.row(row),
+                px_raw.row(row),
+                "Row {row} differs between default and cmyk_raw for an RGB JPEG"
+            );
+        }
+    }
+
+    #[test]
+    fn cmyk_raw_pixel_values_are_nonzero() {
+        let data = match load_cmyk_test_image() {
+            Some(d) => d,
+            None => {
+                eprintln!("SKIP: CMYK test image not found");
+                return;
+            }
+        };
+
+        let dec = JpegDecoderConfig::new().cmyk_output_raw(true);
+        let output = dec
+            .job()
+            .decoder(Cow::Borrowed(&data), &[])
+            .unwrap()
+            .decode()
+            .unwrap();
+
+        // Sample some pixels to verify they contain reasonable CMYK data
+        // (not all zeros, not all 255)
+        let pixels = output.pixels();
+        let first_row = pixels.row(0);
+        let has_nonzero = first_row.iter().any(|&b| b != 0);
+        let has_non_ff = first_row.iter().any(|&b| b != 255);
+        assert!(
+            has_nonzero,
+            "Raw CMYK output should contain non-zero values"
+        );
+        assert!(
+            has_non_ff,
+            "Raw CMYK output should contain values other than 255"
+        );
+    }
+
+    #[test]
+    fn cmyk_raw_default_unchanged() {
+        // Verify that JpegDecoderConfig::new() defaults to cmyk_output_raw = false
+        let dec = JpegDecoderConfig::new();
+        assert!(
+            !dec.is_cmyk_output_raw(),
+            "Default should not have raw CMYK output"
+        );
+    }
+}

--- a/zenjpeg/src/codec.rs
+++ b/zenjpeg/src/codec.rs
@@ -3116,4 +3116,96 @@ mod cmyk_tests {
             "Default should not have raw CMYK output"
         );
     }
+
+    /// Load the non-YCCK CMYK test image (Adobe transform=0).
+    fn load_pure_cmyk_test_image() -> Option<Vec<u8>> {
+        let path =
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/cymk.jpg");
+        std::fs::read(&path).ok()
+    }
+
+    #[test]
+    fn cmyk_raw_non_ycck_roundtrip() {
+        let data = match load_pure_cmyk_test_image() {
+            Some(d) => d,
+            None => {
+                eprintln!("SKIP: cymk.jpg test image not found");
+                return;
+            }
+        };
+
+        // Decode with default (auto RGB conversion)
+        let dec_rgb = JpegDecoderConfig::new();
+        let output_rgb = dec_rgb
+            .job()
+            .decoder(Cow::Borrowed(&data), &[])
+            .unwrap()
+            .decode()
+            .unwrap();
+
+        // Decode with raw CMYK
+        let dec_cmyk = JpegDecoderConfig::new().cmyk_output_raw(true);
+        let output_cmyk = dec_cmyk
+            .job()
+            .decoder(Cow::Borrowed(&data), &[])
+            .unwrap()
+            .decode()
+            .unwrap();
+
+        let cmyk_info = output_cmyk.info();
+        assert_eq!(cmyk_info.source_color.channel_count, Some(4));
+        assert!(!cmyk_info.has_alpha);
+        assert_eq!(output_cmyk.pixels().descriptor().bytes_per_pixel(), 4);
+
+        // Same dimensions
+        assert_eq!(output_rgb.info().width, cmyk_info.width);
+        assert_eq!(output_rgb.info().height, cmyk_info.height);
+
+        let w = cmyk_info.width as usize;
+        let h = cmyk_info.height as usize;
+        let cmyk_pixels = output_cmyk.pixels();
+        let cmyk_bytes: Vec<u8> = {
+            let mut all = Vec::with_capacity(w * h * 4);
+            for row in 0..cmyk_pixels.rows() {
+                all.extend_from_slice(cmyk_pixels.row(row));
+            }
+            all
+        };
+        let rgb_pixels = output_rgb.pixels();
+        let rgb_bytes: Vec<u8> = {
+            let mut all = Vec::with_capacity(w * h * 3);
+            for row in 0..rgb_pixels.rows() {
+                all.extend_from_slice(rgb_pixels.row(row));
+            }
+            all
+        };
+
+        // Manual CMYK→RGB using Adobe inverted formula
+        let mut max_diff: u32 = 0;
+        for i in 0..(w * h) {
+            let c = cmyk_bytes[i * 4] as u32;
+            let m = cmyk_bytes[i * 4 + 1] as u32;
+            let y = cmyk_bytes[i * 4 + 2] as u32;
+            let k = cmyk_bytes[i * 4 + 3] as u32;
+
+            let r_manual = ((c * k + 127) / 255) as u8;
+            let g_manual = ((m * k + 127) / 255) as u8;
+            let b_manual = ((y * k + 127) / 255) as u8;
+
+            let r_auto = rgb_bytes[i * 3];
+            let g_auto = rgb_bytes[i * 3 + 1];
+            let b_auto = rgb_bytes[i * 3 + 2];
+
+            let dr = (r_manual as i32 - r_auto as i32).unsigned_abs();
+            let dg = (g_manual as i32 - g_auto as i32).unsigned_abs();
+            let db = (b_manual as i32 - b_auto as i32).unsigned_abs();
+
+            max_diff = max_diff.max(dr).max(dg).max(db);
+        }
+
+        assert!(
+            max_diff <= 2,
+            "Pure CMYK: manual vs auto CMYK→RGB max pixel diff = {max_diff}, expected <=2"
+        );
+    }
 }

--- a/zenjpeg/src/codec.rs
+++ b/zenjpeg/src/codec.rs
@@ -850,6 +850,17 @@ pub struct JpegDecoderConfig {
     inner: crate::decode::DecodeConfig,
     #[allow(dead_code)]
     limits: ResourceLimits,
+    /// When true, CMYK/YCCK JPEGs produce raw 4-channel CMYK output instead
+    /// of auto-converting to RGB. The output uses RGBA8 pixel layout
+    /// (since zenpixels has no native CMYK format) with
+    /// `ImageInfo.source_color.channel_count == Some(4)` and
+    /// `ImageInfo.has_alpha == false` to distinguish from true RGBA.
+    ///
+    /// The byte order is inverted CMYK (Adobe/libjpeg convention):
+    /// 0 = full ink, 255 = no ink.
+    ///
+    /// Default: `false` (auto-convert to RGB).
+    cmyk_output_raw: bool,
 }
 
 impl JpegDecoderConfig {
@@ -860,6 +871,7 @@ impl JpegDecoderConfig {
             #[cfg(feature = "decoder")]
             inner: crate::decode::DecodeConfig::new(),
             limits: ResourceLimits::none(),
+            cmyk_output_raw: false,
         }
     }
 
@@ -901,6 +913,33 @@ impl JpegDecoderConfig {
     pub fn deblock(mut self, mode: crate::decode::DeblockMode) -> Self {
         self.inner = self.inner.deblock(mode);
         self
+    }
+
+    /// Output raw CMYK bytes instead of auto-converting to RGB.
+    ///
+    /// When enabled, CMYK and YCCK JPEGs produce 4-channel output in
+    /// inverted CMYK format (0 = full ink, 255 = no ink) — the same byte
+    /// order that libjpeg/mozjpeg use. The ICC profile is passed through
+    /// in `ImageInfo.source_color.icc_profile` for the caller to apply
+    /// its own CMS transform.
+    ///
+    /// Since zenpixels has no native CMYK pixel format, the output uses
+    /// `RGBA8` layout with `ImageInfo.has_alpha == false` and
+    /// `ImageInfo.source_color.channel_count == Some(4)`.
+    ///
+    /// Has no effect on non-CMYK input (grayscale, YCbCr).
+    ///
+    /// Default: `false`.
+    #[must_use]
+    pub fn cmyk_output_raw(mut self, raw: bool) -> Self {
+        self.cmyk_output_raw = raw;
+        self
+    }
+
+    /// Returns whether raw CMYK output is enabled.
+    #[must_use]
+    pub fn is_cmyk_output_raw(&self) -> bool {
+        self.cmyk_output_raw
     }
 
     /// Convenience: probe image header with this config.
@@ -1586,6 +1625,22 @@ impl zencodec::decode::Decode for JpegDecoder<'_> {
                 }
             }
 
+            // When raw CMYK output is requested, probe the header to check
+            // if this is actually a CMYK/YCCK JPEG (4 components). If so,
+            // override the output format to PixelFormat::Cmyk so the decoder
+            // produces raw CMYK bytes instead of auto-converting to RGB.
+            let is_raw_cmyk = if self.config.cmyk_output_raw {
+                let header = cfg.read_info(&data)?;
+                if header.num_components == 4 {
+                    cfg = cfg.output_format(PixelFormat::Cmyk);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+
             let stop: &dyn enough::Stop = match &self.stop {
                 Some(s) => s,
                 None => &enough::Unstoppable,
@@ -1691,6 +1746,17 @@ impl zencodec::decode::Decode for JpegDecoder<'_> {
                         }
                     }
                 }
+            } else if is_raw_cmyk {
+                // Raw CMYK output: 4 bytes per pixel in inverted CMYK order.
+                // Package as RGBA8 layout (the only 4-channel u8 format in
+                // zenpixels). The caller distinguishes this from true RGBA via
+                // source_color.channel_count == 4 and has_alpha == false.
+                let pixels_u8 = result.into_pixels_u8().unwrap_or_default();
+                info.has_alpha = false;
+                info.source_color.channel_count = Some(4);
+                let desc = PixelDescriptor::from_pixel_format(zenpixels::PixelFormat::Rgba8);
+                PixelBuffer::from_vec(pixels_u8, w, h, desc)
+                    .map_err(|_| Error::internal("pixel buffer creation failed"))?
             } else {
                 let pixels_u8 = result.into_pixels_u8().unwrap_or_default();
                 let pf = match format {

--- a/zenjpeg/src/color/mod.rs
+++ b/zenjpeg/src/color/mod.rs
@@ -25,10 +25,11 @@ pub use ycbcr::{rgb_to_ycbcr_f32, ycbcr_to_rgb_f32};
 #[cfg(feature = "decoder")]
 #[allow(unused_imports)]
 pub use ycbcr::{
-    cmyk_adobe_to_rgb, cmyk_planes_to_rgb_u8, gray_f32_to_gray_f32, gray_f32_to_gray_u8,
-    gray_f32_to_rgb_f32, gray_f32_to_rgb_u8, rgb_u8_swap_rb_inplace, rgb_u8_to_bgra_u8,
-    rgb_u8_to_bgrx_u8, rgb_u8_to_rgba_u8, ycbcr_planes_f32_to_rgb_f32, ycbcr_planes_f32_to_rgb_u8,
-    ycbcr_planes_i16_to_rgb_u8, ycbcr_to_rgb, ycck_planes_to_rgb_u8, ycck_to_rgb,
+    cmyk_adobe_to_rgb, cmyk_planes_to_cmyk_u8, cmyk_planes_to_rgb_u8, gray_f32_to_gray_f32,
+    gray_f32_to_gray_u8, gray_f32_to_rgb_f32, gray_f32_to_rgb_u8, rgb_u8_swap_rb_inplace,
+    rgb_u8_to_bgra_u8, rgb_u8_to_bgrx_u8, rgb_u8_to_rgba_u8, ycbcr_planes_f32_to_rgb_f32,
+    ycbcr_planes_f32_to_rgb_u8, ycbcr_planes_i16_to_rgb_u8, ycbcr_to_rgb, ycck_planes_to_cmyk_u8,
+    ycck_planes_to_rgb_u8, ycck_to_rgb,
 };
 
 // Re-export commonly used items from xyb

--- a/zenjpeg/src/color/ycbcr.rs
+++ b/zenjpeg/src/color/ycbcr.rs
@@ -937,6 +937,76 @@ pub fn ycck_planes_to_rgb_u8(
     }
 }
 
+/// Batch convert CMYK planes (Adobe format) to interleaved raw CMYK.
+///
+/// Each plane contains values in Adobe inverted format (0 = full ink).
+/// Output is interleaved CMYK bytes (4 bytes per pixel), preserving
+/// the inverted byte values as-is for downstream ICC-based conversion.
+pub fn cmyk_planes_to_cmyk_u8(
+    c_plane: &[f32],
+    m_plane: &[f32],
+    y_plane: &[f32],
+    k_plane: &[f32],
+    cmyk: &mut [u8],
+) {
+    debug_assert_eq!(c_plane.len(), m_plane.len());
+    debug_assert_eq!(c_plane.len(), y_plane.len());
+    debug_assert_eq!(c_plane.len(), k_plane.len());
+    debug_assert_eq!(cmyk.len(), c_plane.len() * 4);
+
+    for i in 0..c_plane.len() {
+        // Level shift and clamp to 0-255 range
+        let c = (c_plane[i] + 128.0).round().clamp(0.0, 255.0) as u8;
+        let m = (m_plane[i] + 128.0).round().clamp(0.0, 255.0) as u8;
+        let y = (y_plane[i] + 128.0).round().clamp(0.0, 255.0) as u8;
+        let k = (k_plane[i] + 128.0).round().clamp(0.0, 255.0) as u8;
+
+        cmyk[i * 4] = c;
+        cmyk[i * 4 + 1] = m;
+        cmyk[i * 4 + 2] = y;
+        cmyk[i * 4 + 3] = k;
+    }
+}
+
+/// Batch convert YCCK planes to interleaved raw CMYK.
+///
+/// Takes Y, Cb, Cr, K planes (f32, centered at 0) and outputs raw CMYK bytes.
+/// YCbCr channels are converted to CMY via standard YCbCr→RGB, producing
+/// CMY values. K is level-shifted and passed through. Output is interleaved
+/// CMYK bytes (4 bytes per pixel) in the same inverted format as
+/// [`cmyk_planes_to_cmyk_u8`].
+pub fn ycck_planes_to_cmyk_u8(
+    y_plane: &[f32],
+    cb_plane: &[f32],
+    cr_plane: &[f32],
+    k_plane: &[f32],
+    cmyk: &mut [u8],
+) {
+    debug_assert_eq!(y_plane.len(), cb_plane.len());
+    debug_assert_eq!(y_plane.len(), cr_plane.len());
+    debug_assert_eq!(y_plane.len(), k_plane.len());
+    debug_assert_eq!(cmyk.len(), y_plane.len() * 4);
+
+    for i in 0..y_plane.len() {
+        // Level shift and clamp
+        let y = (y_plane[i] + 128.0).round().clamp(0.0, 255.0) as u8;
+        let cb = (cb_plane[i] + 128.0).round().clamp(0.0, 255.0) as u8;
+        let cr = (cr_plane[i] + 128.0).round().clamp(0.0, 255.0) as u8;
+        let k = (k_plane[i] + 128.0).round().clamp(0.0, 255.0) as u8;
+
+        // YCbCr→RGB converts the encoded channels back to "RGB-like" values.
+        // In YCCK, these represent the inverted CMY channels: 0 = full ink,
+        // 255 = no ink — matching the Adobe/libjpeg convention directly.
+        // This is the same as what libjpeg outputs for JCS_CMYK from YCCK input.
+        let (c, m, yy) = ycbcr_to_rgb(y, cb, cr);
+
+        cmyk[i * 4] = c;
+        cmyk[i * 4 + 1] = m;
+        cmyk[i * 4 + 2] = yy;
+        cmyk[i * 4 + 3] = k; // K is already in inverted format
+    }
+}
+
 /// Extracts a single channel from a pixel buffer.
 ///
 /// # Errors

--- a/zenjpeg/src/color/ycbcr.rs
+++ b/zenjpeg/src/color/ycbcr.rs
@@ -994,15 +994,15 @@ pub fn ycck_planes_to_cmyk_u8(
         let cr = (cr_plane[i] + 128.0).round().clamp(0.0, 255.0) as u8;
         let k = (k_plane[i] + 128.0).round().clamp(0.0, 255.0) as u8;
 
-        // YCbCr→RGB converts the encoded channels back to "RGB-like" values.
-        // In YCCK, these represent the inverted CMY channels: 0 = full ink,
-        // 255 = no ink — matching the Adobe/libjpeg convention directly.
-        // This is the same as what libjpeg outputs for JCS_CMYK from YCCK input.
+        // YCbCr→RGB converts the encoded channels back to "RGB-like" values
+        // in direct format: 0 = no ink, 255 = full ink.
+        // Adobe/libjpeg CMYK convention is inverted: 0 = full ink, 255 = no ink.
+        // Invert each CMY channel to match. K is already inverted in YCCK.
         let (c, m, yy) = ycbcr_to_rgb(y, cb, cr);
 
-        cmyk[i * 4] = c;
-        cmyk[i * 4 + 1] = m;
-        cmyk[i * 4 + 2] = yy;
+        cmyk[i * 4] = 255 - c;
+        cmyk[i * 4 + 1] = 255 - m;
+        cmyk[i * 4 + 2] = 255 - yy;
         cmyk[i * 4 + 3] = k; // K is already in inverted format
     }
 }

--- a/zenjpeg/src/decode/parser/output.rs
+++ b/zenjpeg/src/decode/parser/output.rs
@@ -27,14 +27,14 @@ use super::super::idct_int::{
 };
 use super::super::upsample::{upsample_libjpeg_f32, upsample_nearest_f32};
 use crate::color::{
-    cmyk_planes_to_rgb_u8, gray_f32_to_gray_f32, gray_f32_to_gray_u8, gray_f32_to_rgb_f32,
-    gray_f32_to_rgb_u8,
+    cmyk_planes_to_cmyk_u8, cmyk_planes_to_rgb_u8, gray_f32_to_gray_f32, gray_f32_to_gray_u8,
+    gray_f32_to_rgb_f32, gray_f32_to_rgb_u8,
     ycbcr::{
         fused_h2v2_box_ycbcr_to_rgb_u8, rgb_u8_swap_rb_inplace, rgb_u8_to_bgra_u8,
         rgb_u8_to_rgba_u8,
     },
     ycbcr_planes_f32_to_rgb_f32, ycbcr_planes_f32_to_rgb_u8, ycbcr_planes_i16_to_rgb_u8,
-    ycck_planes_to_rgb_u8,
+    ycck_planes_to_cmyk_u8, ycck_planes_to_rgb_u8,
 };
 use crate::decode::extras::AdobeColorTransform;
 use crate::error::{Error, Result};
@@ -1302,6 +1302,36 @@ impl<'a> JpegParser<'a> {
                     }
                 }
                 reformat_rgb_output(rgb, f, width, height)
+            }
+            (4, PixelFormat::Cmyk) => {
+                // Raw CMYK output: interleave 4 planes as C,M,Y,K bytes
+                let cmyk_size =
+                    checked_size_2d(width, height).and_then(|s| checked_size_2d(s, 4))?;
+                let mut cmyk_out = vec![0u8; cmyk_size];
+
+                match self.adobe_transform {
+                    Some(AdobeColorTransform::Ycck) => {
+                        // YCCK: convert YCbCr→CMY, interleave with K
+                        ycck_planes_to_cmyk_u8(
+                            &planes_f32[0],
+                            &planes_f32[1],
+                            &planes_f32[2],
+                            &planes_f32[3],
+                            &mut cmyk_out,
+                        );
+                    }
+                    _ => {
+                        // CMYK (Adobe inverted format): level-shift and interleave
+                        cmyk_planes_to_cmyk_u8(
+                            &planes_f32[0],
+                            &planes_f32[1],
+                            &planes_f32[2],
+                            &planes_f32[3],
+                            &mut cmyk_out,
+                        );
+                    }
+                }
+                Ok(cmyk_out)
             }
             _ => Err(Error::unsupported_feature("unsupported color conversion")),
         }


### PR DESCRIPTION
## Summary

- Add `JpegDecoderConfig::cmyk_output_raw(bool)` to output raw 4-channel CMYK bytes instead of auto-converting CMYK/YCCK JPEGs to RGB
- New batch conversion functions `cmyk_planes_to_cmyk_u8` and `ycck_planes_to_cmyk_u8` for raw CMYK interleaving
- Output uses RGBA8 pixel layout (zenpixels has no native CMYK format) with `source_color.channel_count=4` and `has_alpha=false`
- Byte order is inverted CMYK (Adobe/libjpeg convention: 0=full ink, 255=no ink)
- ICC profile is passed through in `source_color.icc_profile` for caller-side CMS conversion
- Default behavior unchanged (auto-convert to RGB)

## Test plan

- [x] `cmyk_raw_output_produces_4_channels` -- verifies descriptor, channel_count, has_alpha
- [x] `cmyk_raw_vs_default` -- manual CMYK-to-RGB on raw output matches auto within maxDelta=2 (YCCK image)
- [x] `cmyk_raw_non_ycck_roundtrip` -- same validation for pure CMYK (Adobe transform=0) image
- [x] `cmyk_raw_has_no_effect_on_rgb_jpeg` -- backward compat, identical output for non-CMYK input
- [x] `cmyk_raw_pixel_values_are_nonzero` -- sanity check on raw bytes
- [x] `cmyk_raw_default_unchanged` -- default config has raw CMYK disabled
- [x] All 1214 existing tests pass (1 pre-existing unrelated failure in quality_matrix)

Closes #80