### PR TITLE
Upgrade codec-corpus to 1.1.0, enable on wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,12 +533,14 @@ dependencies = [
 
 [[package]]
 name = "codec-corpus"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bca18d8c762ea5837d394966f3fe3194bf84fae968d8639058c3d845d212d9f"
+checksum = "37821f76b23825d00364b26f2df079f23e3fb3703fad2de344e8cbb8741fa38d"
 dependencies = [
  "dirs",
  "fd-lock",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/zenjpeg/Cargo.toml
+++ b/zenjpeg/Cargo.toml
@@ -97,6 +97,7 @@ sha2 = "0.10"
 jpeg-decoder = "0.3.2"
 zune-jpeg.workspace = true
 zune-core = "0.5.1"
+codec-corpus = "1.1.0"
 tempfile = "3"
 
 
@@ -109,8 +110,6 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 
 # Native-only dev dependencies (don't compile for WASM)
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-# Corpus loader pulls fd-lock (file locking) which doesn't build on WASM
-codec-corpus = "1"
 # C++ jpegli FFI for parity benchmarks (uses jpegli_* symbols directly)
 zenjpeg-bench-utils = { path = "../zenjpeg-bench-utils", default-features = false, features = ["cjpegli-ffi"] }
 # mozjpeg/libjpeg-turbo with NASM SIMD for decode speed comparison


### PR DESCRIPTION
## Summary

- Upgrade `codec-corpus` from 1.0.3 to 1.1.0 (just published)
- Move `codec-corpus` from `cfg(not(target_arch = "wasm32"))` dev-dep back to unconditional `[dev-dependencies]`

## Why

codec-corpus 1.1.0 ([changelog](https://github.com/imazen/codec-corpus/blob/main/crate/CHANGELOG.md)) gates `fd-lock` behind `cfg(not(wasm32))` and returns `Error::DownloadUnsupported` on wasm instead of failing to compile. This means wasm tests can now use `Corpus::with_cache_root()` for pre-populated caches, and corpus-driven wasm benchmarks become possible (see #79).

Previously we had to guard `codec-corpus` behind `cfg(not(wasm32))` because `fd-lock` 4.x didn't compile on wasip1 (commit b2e9a678).

## Test plan

- [x] `cargo build -p zenjpeg --release` (native)
- [x] `RUSTFLAGS="-C target-feature=+simd128" cargo build -p zenjpeg --target wasm32-wasip1 --no-default-features --features decoder` (wasm lib)
- [x] `cargo build --release -p zenjpeg --target wasm32-wasip1 --example wasm_bench --no-default-features --features decoder` (wasm example)
- [x] `cargo test -p zenjpeg --release --lib encode::streaming` (native tests)
- [x] `cargo semver-checks` on codec-corpus: no breaking changes