### PR TITLE
perf: disable restart markers in progressive mode (−10% on screenshots)

### DIFF
--- a/zenjpeg/src/encode/byte_encoders.rs
+++ b/zenjpeg/src/encode/byte_encoders.rs
@@ -101,12 +101,15 @@ impl BytesEncoder {
             super::encoder_types::ColorMode::Grayscale => crate::types::Subsampling::S444,
         };
 
-        let restart_interval = super::config::resolve_restart_rows(
-            config.restart_mcu_rows,
-            width,
-            height,
-            subsampling,
-        );
+        // Progressive mode: restart markers provide no benefit (progressive
+        // decode requires multi-pass coefficient storage — parallel decode via
+        // restart segments is impossible) but cost ~10% in overhead from RST
+        // marker pairs + byte-alignment padding + DC prediction resets.
+        let restart_interval = if config.scan_mode.is_progressive() {
+            0
+        } else {
+            super::config::resolve_restart_rows(config.restart_mcu_rows, width, height, subsampling)
+        };
 
         let mut builder = SE::new(width, height)
             .quality(config.quality)
@@ -963,12 +966,15 @@ impl YCbCrPlanarEncoder {
             _ => crate::types::Subsampling::S444,
         };
 
-        let restart_interval = super::config::resolve_restart_rows(
-            config.restart_mcu_rows,
-            width,
-            height,
-            subsampling,
-        );
+        // Progressive mode: restart markers provide no benefit (progressive
+        // decode requires multi-pass coefficient storage — parallel decode via
+        // restart segments is impossible) but cost ~10% in overhead from RST
+        // marker pairs + byte-alignment padding + DC prediction resets.
+        let restart_interval = if config.scan_mode.is_progressive() {
+            0
+        } else {
+            super::config::resolve_restart_rows(config.restart_mcu_rows, width, height, subsampling)
+        };
 
         // Use RGB pixel format - the streaming encoder will accept YCbCr data
         // via push_ycbcr_strip_f32, but needs a pixel format for buffer sizing


### PR DESCRIPTION
## Summary

Progressive JPEG decode requires multi-pass coefficient storage — restart
markers provide zero parallel-decode benefit. But they cost ~10% in
overhead from RST marker pairs + byte-alignment padding + DC prediction
resets, multiplied across all 15 progressive scans.

Two call sites in `byte_encoders.rs` now check
`config.scan_mode.is_progressive()` and set `restart_interval=0` when true.
Baseline mode retains the default `restart_mcu_rows=4` for parallel decode.

## Measurements (gui.png Q10 progressive, 1356×1132)

| | Before | After | cjpegli | Δ vs cjpegli |
|---|---|---|---|---|
| Size | 17,944 B | **15,979 B** | 15,744 B | **+1.3%** (was +13.6%) |
| SSIM2 | 64.07 | 64.07 | 64.02 | +0.05 |

The 2.0 KB savings come from eliminating 520 restart markers × 15 scans
worth of RST pairs (1,040 B) + byte-alignment padding and DC prediction
resets (893 B).

## Investigation

Agent-driven analysis (branch `investigate/q10-baseline-gap`) found:
- Baseline mode gap: +1.0% → entropy coding is near-parity
- Progressive mode gap: +13.6% → entirely restart marker overhead
- With matching scan script and no DRI: only +0.6% gap (DCT rounding)

Closes #23.

## Test plan

- [x] `cargo test --release -p zenjpeg --lib` — 805 pass
- [x] `cargo test --release -p zenjpeg --test bundled` — 996 pass
- [x] `cargo clippy` + `cargo fmt` clean