### PR TITLE
fix(ci): clippy + fmt + macos quality_matrix race + i686 corpus skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,18 +127,7 @@ jobs:
           key: cross-i686
 
       - name: Test (i686)
-        # Skip codec-corpus-dependent tests: the cross container has no network
-        # access to fetch test corpus datasets, which would otherwise cause
-        # spurious NetworkUnavailable panics unrelated to 32-bit correctness.
-        # All other tests run normally — i686 is about pointer-width correctness,
-        # not corpus conformance (which is covered on x86_64/aarch64 runners).
-        run: |
-          cross test -p zenjpeg --target i686-unknown-linux-gnu --lib --tests -- \
-            --skip codec_corpus_conformance \
-            --skip conformance_corpus \
-            --skip crash_sweep \
-            --skip crop_corpus \
-            --skip cpp_reference_parity
+        run: cross test -p zenjpeg --target i686-unknown-linux-gnu --lib --tests
         env:
           CODEC_CORPUS_CACHE: /tmp/codec-corpus
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,15 @@ jobs:
           key: cross-i686
 
       - name: Test (i686)
-        run: cross test -p zenjpeg --target i686-unknown-linux-gnu --lib --tests
+        # Skip two tests that require sparse-cloning the full image-rs/image
+        # repo. codec-corpus bundles its own test corpora (so zune/fuzz tests
+        # work) but image-rs/tests/images is fetched from the separate
+        # image-rs/image repo, which the cross container's constrained network
+        # times out on. Unrelated to 32-bit correctness.
+        run: |
+          cross test -p zenjpeg --target i686-unknown-linux-gnu --lib --tests -- \
+            --skip codec_corpus_conformance::test_image_rs_general \
+            --skip codec_corpus_conformance::test_image_rs_progressive
         env:
           CODEC_CORPUS_CACHE: /tmp/codec-corpus
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,18 @@ jobs:
           key: cross-i686
 
       - name: Test (i686)
-        run: cross test -p zenjpeg --target i686-unknown-linux-gnu --lib --tests
+        # Skip codec-corpus-dependent tests: the cross container has no network
+        # access to fetch test corpus datasets, which would otherwise cause
+        # spurious NetworkUnavailable panics unrelated to 32-bit correctness.
+        # All other tests run normally — i686 is about pointer-width correctness,
+        # not corpus conformance (which is covered on x86_64/aarch64 runners).
+        run: |
+          cross test -p zenjpeg --target i686-unknown-linux-gnu --lib --tests -- \
+            --skip codec_corpus_conformance \
+            --skip conformance_corpus \
+            --skip crash_sweep \
+            --skip crop_corpus \
+            --skip cpp_reference_parity
         env:
           CODEC_CORPUS_CACHE: /tmp/codec-corpus
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "zencodec"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882aeed23dcf360faded3a50b468b3bc6226da46b2d62e39d72f98f68bb6835b"
+checksum = "b86a563becc403bb3e98225c5715711b87cd1c32222659b7d84282c4f5800fe3"
 dependencies = [
  "almost-enough",
  "enough",
@@ -3168,9 +3168,9 @@ dependencies = [
 
 [[package]]
 name = "zenpixels"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4ee2b04d153513b0de1bc93c19347c646975f100b01b316395877d51fc12e5"
+checksum = "a39c7b3b7b7881f6689a556ef3ab1245c1cec2f39f2cd919d92e6ce3d7dcd530"
 dependencies = [
  "bytemuck",
  "imgref",

--- a/zenjpeg/src/codec.rs
+++ b/zenjpeg/src/codec.rs
@@ -1530,6 +1530,10 @@ pub struct JpegDecoder<'a> {
 impl zencodec::decode::Decode for JpegDecoder<'_> {
     type Error = Error;
 
+    // IccMatchTolerance was deprecated in zencodec 0.1.16 as a placebo parameter.
+    // Callers must still pass a variant to descriptor_for_decoded_pixels; zencodec
+    // itself uses `#[allow(deprecated)]` internally for the same reason.
+    #[allow(deprecated)]
     fn decode(self) -> Result<DecodeOutput, Error> {
         #[cfg(feature = "decoder")]
         {
@@ -1939,6 +1943,7 @@ fn source_color_from_header(info: &crate::decode::JpegInfo) -> zencodec::decode:
 /// Uses the shared zencodec utility to map source color metadata to a
 /// descriptor that accurately reflects the pixel data's color space.
 #[cfg(feature = "decoder")]
+#[allow(deprecated)] // IccMatchTolerance placebo param — see note on impl Decode::decode
 fn decode_descriptor(
     preferred: &[PixelDescriptor],
     header: &crate::decode::JpegInfo,

--- a/zenjpeg/src/encode/streaming_builder.rs
+++ b/zenjpeg/src/encode/streaming_builder.rs
@@ -340,7 +340,6 @@ impl StreamingEncoderBuilder {
         encoder.finish()
     }
 
-
     /// Estimates the peak memory usage for this configuration.
     ///
     /// Returns the estimated peak memory in bytes based on image dimensions,

--- a/zenjpeg/tests/bundled/edge_tile_ssim2_comparison.rs
+++ b/zenjpeg/tests/bundled/edge_tile_ssim2_comparison.rs
@@ -218,6 +218,7 @@ fn encode_decode_cpp(
 }
 
 /// Calculate SSIMULACRA2 between two RGB images
+#[allow(deprecated)]
 fn calculate_ssim2(rgb1: &[u8], rgb2: &[u8], width: usize, height: usize) -> f64 {
     use fast_ssim2::{LinearRgbImage, compute_frame_ssimulacra2, srgb_u8_to_linear};
 

--- a/zenjpeg/tests/bundled/quality_matrix.rs
+++ b/zenjpeg/tests/bundled/quality_matrix.rs
@@ -393,12 +393,22 @@ fn encode_cpp_cli(
 ) -> Option<Vec<u8>> {
     use std::io::Write;
     use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
-    // Write RGB to temp file as PPM
-    let ppm_path = "/tmp/quality_matrix_input.ppm";
-    let jpg_path = "/tmp/quality_matrix_output.jpg";
+    // Unique per-call paths to avoid races when cargo runs multiple test
+    // threads concurrently (the shared-path version silently corrupted files
+    // on macos, producing zero-byte "missing SOI marker" decode failures).
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let tid = std::thread::current().id();
+    let key = format!("{}_{:?}_{}", std::process::id(), tid, seq)
+        .replace(|c: char| !c.is_alphanumeric(), "_");
+    let ppm_path_buf = std::env::temp_dir().join(format!("quality_matrix_in_{key}.ppm"));
+    let jpg_path_buf = std::env::temp_dir().join(format!("quality_matrix_out_{key}.jpg"));
+    let ppm_path = ppm_path_buf.to_string_lossy().into_owned();
+    let jpg_path = jpg_path_buf.to_string_lossy().into_owned();
 
-    let mut ppm = std::fs::File::create(ppm_path).ok()?;
+    let mut ppm = std::fs::File::create(&ppm_path).ok()?;
     writeln!(ppm, "P6").ok()?;
     writeln!(ppm, "{} {}", width, height).ok()?;
     writeln!(ppm, "255").ok()?;
@@ -423,8 +433,8 @@ fn encode_cpp_cli(
     };
 
     let mut args = vec![
-        ppm_path.to_string(),
-        jpg_path.to_string(),
+        ppm_path.clone(),
+        jpg_path.clone(),
         "-q".to_string(),
         quality.to_string(),
         "--chroma_subsampling".to_string(),
@@ -447,10 +457,15 @@ fn encode_cpp_cli(
         .ok()?;
 
     if !status.success() {
+        let _ = std::fs::remove_file(&ppm_path);
+        let _ = std::fs::remove_file(&jpg_path);
         return None;
     }
 
-    std::fs::read(jpg_path).ok()
+    let result = std::fs::read(&jpg_path).ok();
+    let _ = std::fs::remove_file(&ppm_path);
+    let _ = std::fs::remove_file(&jpg_path);
+    result
 }
 
 /// Encode via C++ jpegli - currently uses CLI for all modes.

--- a/zenyuv/src/lib.rs
+++ b/zenyuv/src/lib.rs
@@ -90,6 +90,7 @@ mod tests {
     fn ctx() -> YuvContext {
         YuvContext::new(Range::Full, Matrix::Bt601)
     }
+    #[allow(dead_code)]
     fn ctx_limited() -> YuvContext {
         YuvContext::new(Range::Limited, Matrix::Bt601)
     }
@@ -112,7 +113,7 @@ mod tests {
             for x in 0..width {
                 let i = (y * width + x) * 3;
                 rgb[i] = ((x * 7 + y * 3) & 0xff) as u8;
-                rgb[i + 1] = ((x * 3 ^ y * 11) & 0xff) as u8;
+                rgb[i + 1] = (((x * 3) ^ (y * 11)) & 0xff) as u8;
                 rgb[i + 2] = (((x + y) * 5) & 0xff) as u8;
             }
         }
@@ -902,7 +903,7 @@ mod tests {
 
         // Limited range Y should be in [16, 235]
         for &yv in y.iter() {
-            assert!(yv >= 16 && yv <= 235, "Y={yv} outside limited range");
+            assert!((16..=235).contains(&yv), "Y={yv} outside limited range");
         }
     }
 
@@ -931,7 +932,7 @@ mod tests {
 
         // Should not panic, output should be valid
         for &yv in y.iter() {
-            assert!(yv >= 16 && yv <= 235, "Y={yv} outside limited range");
+            assert!((16..=235).contains(&yv), "Y={yv} outside limited range");
         }
     }
 


### PR DESCRIPTION
Four orthogonal CI failures on main after #84 merge, all fixed here:

1. **Format** — `streaming_builder.rs` had a trailing blank line that \`cargo fmt\` removed. Pre-existing drift surfaced by the #84 checks.

2. **Clippy** — 5 errors:
   - \`zenyuv/src/lib.rs\`: dead-code \`ctx_limited\` (used only by sharp YUV limited-range tests), \`manual_range_contains\` on \`yv >= 16 && yv <= 235\` × 2, operator precedence on \`x*3 ^ y*11\`.
   - \`zenjpeg/tests/bundled/edge_tile_ssim2_comparison.rs\`: uses \`compute_frame_ssimulacra2\` (deprecated by fast-ssim2 0.8 in favour of \`compute_ssimulacra2\` with \`ToLinearRgb\`). Silenced with \`#[allow(deprecated)]\`; full migration left for a follow-up.

3. **C++ Parity (macos-latest)** — \`test_ycbcr_422_baseline\` failed with "missing SOI marker" because test threads raced on shared \`/tmp/quality_matrix_input.ppm\` + \`/tmp/quality_matrix_output.jpg\` paths. Only surfaced on macos because of test-runner scheduling differences. Fixed by giving each \`encode_cpp_cli\` invocation unique paths (pid + thread id + atomic counter) and cleaning up afterward.

4. **Test (i686)** — all 37 failures were codec-corpus network fetches (\`NetworkUnavailable { dataset: "zune" }\`) because the cross container running i686 tests has no network. i686 covers 32-bit pointer-width correctness, not corpus conformance (already covered on x86_64/aarch64/macos/windows). Added \`--skip\` arguments to the i686 test invocation for the 5 corpus-dependent modules. Skip is explicit in the CI workflow — not runtime-hidden.

## Test plan
- [x] \`cargo test --release -p zenjpeg\` — 805 lib + 996 integration pass
- [x] \`cargo clippy --workspace --all-features --tests -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean