### PR TITLE
feat(quality): EncoderConfig::chroma_distance_scale for chroma-quality feedback

### DIFF
--- a/zenjpeg/src/encode/byte_encoders.rs
+++ b/zenjpeg/src/encode/byte_encoders.rs
@@ -159,6 +159,7 @@ impl BytesEncoder {
         ));
 
         builder = builder.tiny_file_mode(config.tiny_file_mode);
+        builder = builder.chroma_distance_scale(config.chroma_distance_scale);
 
         #[cfg(feature = "parallel")]
         if config.parallel.is_some() {
@@ -1032,6 +1033,7 @@ impl YCbCrPlanarEncoder {
         ));
 
         builder = builder.tiny_file_mode(config.tiny_file_mode);
+        builder = builder.chroma_distance_scale(config.chroma_distance_scale);
 
         #[cfg(feature = "parallel")]
         if config.parallel.is_some() {

--- a/zenjpeg/src/encode/encoder_config.rs
+++ b/zenjpeg/src/encode/encoder_config.rs
@@ -434,6 +434,15 @@ pub struct EncoderConfig {
     /// byte-identical to a feature-off build.
     #[cfg(feature = "boundary-rd")]
     pub(crate) boundary_rd_mode: BoundaryRd,
+    /// Multiplier applied to the butteraugli distance for chroma (Cb, Cr)
+    /// components only, independent of luma. Default `1.0` preserves the
+    /// existing single-quality behaviour bit-for-bit.
+    ///
+    /// - `> 1.0` — chroma is encoded more aggressively (flat-chroma case).
+    /// - `< 1.0` — chroma is encoded more carefully (sharp-chroma case).
+    ///
+    /// Clamped to `[0.1, 5.0]` by the builder.
+    pub(crate) chroma_distance_scale: f32,
 }
 
 // Note: No Default impl - quality and color mode are required via constructors
@@ -590,6 +599,7 @@ impl EncoderConfig {
             tiny_file_mode: TinyFileMode::Auto,
             #[cfg(feature = "boundary-rd")]
             boundary_rd_mode: BoundaryRd::Off,
+            chroma_distance_scale: 1.0,
         }
     }
 
@@ -864,6 +874,41 @@ impl EncoderConfig {
     #[must_use]
     pub fn allow_16bit_quant_tables(mut self, enable: bool) -> Self {
         self.allow_16bit_quant_tables = enable;
+        self
+    }
+
+    /// Scale the butteraugli distance applied to chroma (Cb, Cr) relative to
+    /// luma. Default `1.0` is bit-identical to the single-quality path.
+    ///
+    /// A typical consumer is an analyzer that has already measured chroma
+    /// sharpness on the image (e.g. [`evalchroma`](https://lib.rs/crates/evalchroma))
+    /// and wants to exploit flat chroma for extra bpp savings, or preserve
+    /// sharp chroma when 4:4:4 alone isn't enough.
+    ///
+    /// - `> 1.0` — chroma encoded more aggressively (flat chroma case).
+    ///   Each step of `+0.25` applies a larger per-coefficient quant value,
+    ///   compounding onto the existing Cb/Cr base-table asymmetry.
+    /// - `< 1.0` — chroma encoded more carefully (sharp chroma case).
+    ///
+    /// Clamped to `[0.1, 5.0]`. Applied identically to Cb and Cr; the
+    /// base-table asymmetry (Cb ≈ 2× Cr in median quant) is preserved.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use zenjpeg::encoder::{EncoderConfig, ChromaSubsampling, Quality};
+    ///
+    /// // Analyzer decided chroma is flat enough to take a 30% discount.
+    /// let luma_dist   = Quality::ApproxJpegli(85.0).to_distance();
+    /// let chroma_dist = Quality::ApproxJpegli(70.0).to_distance();
+    /// let scale = chroma_dist / luma_dist;
+    ///
+    /// let config = EncoderConfig::ycbcr(85.0, ChromaSubsampling::Quarter)
+    ///     .chroma_distance_scale(scale);
+    /// ```
+    #[must_use]
+    pub fn chroma_distance_scale(mut self, scale: f32) -> Self {
+        self.chroma_distance_scale = scale.clamp(0.1, 5.0);
         self
     }
 
@@ -1793,6 +1838,12 @@ impl EncoderConfig {
     #[must_use]
     pub fn is_allow_16bit_quant_tables(&self) -> bool {
         self.allow_16bit_quant_tables
+    }
+
+    /// Returns the configured chroma-distance multiplier. `1.0` when unset.
+    #[must_use]
+    pub fn get_chroma_distance_scale(&self) -> f32 {
+        self.chroma_distance_scale
     }
 
     /// Check if adaptive quantization (AQ) is enabled.

--- a/zenjpeg/src/encode/streaming.rs
+++ b/zenjpeg/src/encode/streaming.rs
@@ -149,6 +149,14 @@ impl StreamingEncoder {
         // Generate quantization tables and zero-bias params
         let is_420 = builder.subsampling == Subsampling::S420;
         let distance = builder.quality.to_distance();
+        // Per-component distance: [Y, Cb, Cr]. The scalar
+        // `chroma_distance_scale` multiplies the chroma distances
+        // identically. `scale == 1.0` reproduces the single-distance
+        // path bit-for-bit (verified by `chroma_scale_default_identity`
+        // in the tests below).
+        let chroma_scale = builder.chroma_distance_scale;
+        let chroma_distance = distance * chroma_scale;
+        let distances_per_component = [distance, chroma_distance, chroma_distance];
         let color_space = if builder.use_xyb {
             ColorSpace::Xyb
         } else {
@@ -159,7 +167,7 @@ impl StreamingEncoder {
         let ((y_quant, cb_quant, cr_quant), (y_zero_bias, cb_zero_bias, cr_zero_bias)) =
             if let Some(ref tables) = builder.encoding_tables {
                 // Branch 1: Custom encoding tables provided explicitly
-                let quant = tables.generate_quant_tables(distance, is_420);
+                let quant = tables.generate_quant_tables(distances_per_component, is_420);
                 let zero_bias = tables.generate_zero_bias_all();
                 // Apply allow_16bit clamping if needed
                 let quant = if allow_16bit {
@@ -183,7 +191,7 @@ impl StreamingEncoder {
                     quality_u8,
                     force_baseline,
                 );
-                let quant = tables.generate_quant_tables(distance, is_420);
+                let quant = tables.generate_quant_tables(distances_per_component, is_420);
                 let zero_bias = tables.generate_zero_bias_all();
                 (quant, zero_bias)
             } else {
@@ -194,6 +202,10 @@ impl StreamingEncoder {
                 // jpegli behavior where the single chroma table uses the Cr matrix.
                 let cb_component = if builder.separate_chroma_tables { 1 } else { 2 };
 
+                // Luma uses the user's quality verbatim; chroma gets the
+                // scaled distance. When chroma_scale == 1.0 the
+                // `with_distance` call produces bit-identical tables to
+                // the old `ex`-variant (see quant_table_identity test).
                 let quant = (
                     quant::generate_quant_table_ex(
                         builder.quality,
@@ -203,16 +215,16 @@ impl StreamingEncoder {
                         is_420,
                         allow_16bit,
                     ),
-                    quant::generate_quant_table_ex(
-                        builder.quality,
+                    quant::generate_quant_table_with_distance(
+                        distances_per_component[1],
                         cb_component,
                         color_space,
                         builder.use_xyb,
                         is_420,
                         allow_16bit,
                     ),
-                    quant::generate_quant_table_ex(
-                        builder.quality,
+                    quant::generate_quant_table_with_distance(
+                        distances_per_component[2],
                         2,
                         color_space,
                         builder.use_xyb,

--- a/zenjpeg/src/encode/streaming_builder.rs
+++ b/zenjpeg/src/encode/streaming_builder.rs
@@ -72,6 +72,11 @@ pub(crate) struct StreamingEncoderBuilder {
     pub(crate) quant_source: QuantTableSource,
     /// Tiny-file optimization mode (default: Auto).
     pub(crate) tiny_file_mode: TinyFileMode,
+    /// Multiplier applied to the butteraugli distance for chroma (Cb, Cr)
+    /// components only. Default `1.0` is bit-identical to the single-
+    /// quality path. Clamped to `[0.1, 5.0]` on ingress by the public
+    /// [`EncoderConfig::chroma_distance_scale`] setter.
+    pub(crate) chroma_distance_scale: f32,
 }
 
 impl StreamingEncoderBuilder {
@@ -110,6 +115,7 @@ impl StreamingEncoderBuilder {
             trellis: None,
             quant_source: QuantTableSource::default(),
             tiny_file_mode: TinyFileMode::default(),
+            chroma_distance_scale: 1.0,
         }
     }
 
@@ -335,6 +341,16 @@ impl StreamingEncoderBuilder {
     #[must_use]
     pub(crate) fn tiny_file_mode(mut self, mode: TinyFileMode) -> Self {
         self.tiny_file_mode = mode;
+        self
+    }
+
+    /// Sets the chroma-distance multiplier. See
+    /// [`crate::encode::encoder_config::EncoderConfig::chroma_distance_scale`]
+    /// for full semantics. Default `1.0` is bit-identical to pre-existing
+    /// single-quality behaviour.
+    #[must_use]
+    pub(crate) fn chroma_distance_scale(mut self, scale: f32) -> Self {
+        self.chroma_distance_scale = scale.clamp(0.1, 5.0);
         self
     }
 

--- a/zenjpeg/src/encode/tuning.rs
+++ b/zenjpeg/src/encode/tuning.rs
@@ -522,10 +522,17 @@ impl EncodingTables {
     /// Generate quantization tables for all three components.
     ///
     /// Returns (Y/X, Cb/Y, Cr/B) quantization tables.
+    /// Generate quantization tables for all three components.
+    ///
+    /// `distances` is `[Y, Cb, Cr]` butteraugli distances. Callers that
+    /// want the pre-existing single-distance behaviour should pass
+    /// `[d, d, d]`. Per-component distances allow luma vs chroma
+    /// quality splits (see
+    /// [`crate::encode::encoder_config::EncoderConfig::chroma_distance_scale`]).
     #[must_use]
     pub fn generate_quant_tables(
         &self,
-        distance: f32,
+        distances: [f32; 3],
         is_420: bool,
     ) -> (
         crate::quant::QuantTable,
@@ -533,9 +540,9 @@ impl EncodingTables {
         crate::quant::QuantTable,
     ) {
         (
-            self.generate_quant_table(0, distance, is_420),
-            self.generate_quant_table(1, distance, is_420),
-            self.generate_quant_table(2, distance, is_420),
+            self.generate_quant_table(0, distances[0], is_420),
+            self.generate_quant_table(1, distances[1], is_420),
+            self.generate_quant_table(2, distances[2], is_420),
         )
     }
 
@@ -825,7 +832,7 @@ mod tests {
 
         for q in [50, 75, 90] {
             let distance = (100.0 - q as f32) / 10.0;
-            let (y, cb, cr) = tables.generate_quant_tables(distance, false);
+            let (y, cb, cr) = tables.generate_quant_tables([distance, distance, distance], false);
 
             assert!(y.values.iter().all(|&v| v > 0), "Y quant at q{q} has zeros");
             assert!(

--- a/zenjpeg/src/quant/mod.rs
+++ b/zenjpeg/src/quant/mod.rs
@@ -606,7 +606,27 @@ pub fn generate_quant_table_ex(
     allow_16bit: bool,
 ) -> QuantTable {
     let distance = quality.to_distance();
+    generate_quant_table_with_distance(distance, component, color_space, use_xyb, is_420, allow_16bit)
+}
 
+/// Generates a quantization table from a pre-computed butteraugli distance.
+///
+/// Bypasses [`Quality::to_distance`], allowing callers to apply
+/// per-component distance scaling (luma vs chroma) before dispatch.
+/// When called with `distance = quality.to_distance()` for every
+/// component the output is bit-identical to `generate_quant_table_ex`.
+///
+/// See [`crate::encode::encoder_config::EncoderConfig::chroma_distance_scale`]
+/// for the caller-facing API that drives this.
+#[must_use]
+pub fn generate_quant_table_with_distance(
+    distance: f32,
+    component: usize,
+    color_space: ColorSpace,
+    use_xyb: bool,
+    is_420: bool,
+    allow_16bit: bool,
+) -> QuantTable {
     if use_xyb {
         generate_xyb_quant_table(distance, component, allow_16bit)
     } else {

--- a/zenjpeg/src/quant/mod.rs
+++ b/zenjpeg/src/quant/mod.rs
@@ -606,7 +606,14 @@ pub fn generate_quant_table_ex(
     allow_16bit: bool,
 ) -> QuantTable {
     let distance = quality.to_distance();
-    generate_quant_table_with_distance(distance, component, color_space, use_xyb, is_420, allow_16bit)
+    generate_quant_table_with_distance(
+        distance,
+        component,
+        color_space,
+        use_xyb,
+        is_420,
+        allow_16bit,
+    )
 }
 
 /// Generates a quantization table from a pre-computed butteraugli distance.

--- a/zenjpeg/tests/chroma_distance_scale.rs
+++ b/zenjpeg/tests/chroma_distance_scale.rs
@@ -1,0 +1,205 @@
+//! Integration tests for `EncoderConfig::chroma_distance_scale`.
+//!
+//! Three things to verify:
+//!
+//!   1. **Identity**: `chroma_distance_scale(1.0)` produces bit-identical
+//!      output to a default-configured encoder. Critical — this says we
+//!      haven't accidentally perturbed every existing caller.
+//!
+//!   2. **Monotonicity**: with chroma content (e.g. a colourful photo),
+//!      larger `chroma_distance_scale` produces a smaller file. Smaller
+//!      values produce a larger file.
+//!
+//!   3. **No luma perturbation**: a grayscale image (no chroma signal)
+//!      encodes to byte-identical output regardless of the chroma scale,
+//!      because the per-component scaling is applied only to Cb/Cr.
+
+use enough::Unstoppable;
+use zenjpeg::encode::{ChromaSubsampling, EncoderConfig, PixelLayout};
+
+/// Sharp-chroma test image: gradient stripes that stress Cb and Cr.
+/// `width` and `height` both divisible by 16 so chroma 4:2:0 lines up.
+fn sharp_chroma_rgb(w: u32, h: u32) -> Vec<u8> {
+    let mut out = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let r = ((x * 255) / w.max(1)) as u8;
+            let g = ((y * 255) / h.max(1)) as u8;
+            let b = (((x + y) * 255) / (w + h).max(1)) as u8;
+            out.push(r);
+            out.push(g);
+            out.push(b);
+        }
+    }
+    out
+}
+
+/// Grayscale-only test image: r = g = b. Encoded chroma is flat (zero).
+fn grayscale_rgb(w: u32, h: u32) -> Vec<u8> {
+    let mut out = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let v = ((x + y) as u32 * 255 / (w + h).max(1)) as u8;
+            out.push(v);
+            out.push(v);
+            out.push(v);
+        }
+    }
+    out
+}
+
+fn encode(config: &EncoderConfig, rgb: &[u8], w: u32, h: u32) -> Vec<u8> {
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .expect("builder");
+    enc.push_packed(rgb, Unstoppable).expect("push");
+    enc.finish().expect("finish")
+}
+
+#[test]
+fn chroma_scale_default_identity() {
+    // Default-configured encoder vs explicit scale(1.0) — must be
+    // byte-identical. This is the load-bearing test for the entire PR.
+    let (w, h) = (128, 128);
+    let rgb = sharp_chroma_rgb(w, h);
+
+    for q in [40.0, 75.0, 90.0] {
+        for sub in [
+            ChromaSubsampling::None,
+            ChromaSubsampling::Quarter,
+            ChromaSubsampling::HalfHorizontal,
+        ] {
+            let cfg_default = EncoderConfig::ycbcr(q, sub);
+            let cfg_one = EncoderConfig::ycbcr(q, sub).chroma_distance_scale(1.0);
+
+            let a = encode(&cfg_default, &rgb, w, h);
+            let b = encode(&cfg_one, &rgb, w, h);
+            assert_eq!(
+                a.len(),
+                b.len(),
+                "q={}, sub={:?}: byte length differs between default and scale(1.0)",
+                q,
+                sub as u8,
+            );
+            assert_eq!(
+                a, b,
+                "q={}, sub={:?}: payload differs between default and scale(1.0)",
+                q, sub as u8,
+            );
+        }
+    }
+}
+
+#[test]
+fn chroma_scale_monotone_file_size_on_chroma_content() {
+    // Gradient RGB image has substantial Cb/Cr signal.
+    // scale=2.0 should compress chroma MORE → smaller file
+    // scale=0.5 should compress chroma LESS → larger file
+    let (w, h) = (256, 256);
+    let rgb = sharp_chroma_rgb(w, h);
+    let q = 75.0;
+
+    for sub in [ChromaSubsampling::None, ChromaSubsampling::Quarter] {
+        let sizes: Vec<(f32, usize)> = [0.5, 1.0, 2.0]
+            .iter()
+            .map(|&s| {
+                let cfg = EncoderConfig::ycbcr(q, sub).chroma_distance_scale(s);
+                (s, encode(&cfg, &rgb, w, h).len())
+            })
+            .collect();
+
+        println!(
+            "sub={:?}: sizes at scale [0.5, 1.0, 2.0] = {:?}",
+            sub as u8, sizes
+        );
+
+        // Monotone: s=0.5 >= s=1.0 >= s=2.0 (strictly larger in most
+        // cases, but could tie in edge cases where rounding kicks in).
+        assert!(
+            sizes[0].1 >= sizes[1].1,
+            "scale=0.5 should not be smaller than scale=1.0 ({} vs {})",
+            sizes[0].1,
+            sizes[1].1,
+        );
+        assert!(
+            sizes[1].1 >= sizes[2].1,
+            "scale=1.0 should not be smaller than scale=2.0 ({} vs {})",
+            sizes[1].1,
+            sizes[2].1,
+        );
+        // At least one strict inequality — otherwise the knob does
+        // nothing and we've regressed.
+        assert!(
+            sizes[0].1 > sizes[2].1,
+            "scale=0.5 ({}) should produce a strictly larger file than scale=2.0 ({})",
+            sizes[0].1,
+            sizes[2].1,
+        );
+    }
+}
+
+#[test]
+fn chroma_scale_grayscale_invariant_on_444() {
+    // At 4:4:4, a grayscale image has Cb=Cr=0 everywhere. Changing
+    // the chroma distance scale only affects the quant TABLES (not the
+    // coefficients that get quantised), so the JPEG payload for a
+    // pure-grayscale image encoded at 4:4:4 should be byte-identical
+    // except possibly for DQT bytes (different table written to file).
+    //
+    // We test the WEAK property: output size is unchanged (quant tables
+    // are always same length in bytes), and scan data is byte-identical.
+    let (w, h) = (128, 128);
+    let rgb = grayscale_rgb(w, h);
+    let q = 75.0;
+
+    let cfg_default = EncoderConfig::ycbcr(q, ChromaSubsampling::None);
+    let cfg_small = EncoderConfig::ycbcr(q, ChromaSubsampling::None).chroma_distance_scale(0.5);
+    let cfg_big = EncoderConfig::ycbcr(q, ChromaSubsampling::None).chroma_distance_scale(2.0);
+
+    let a = encode(&cfg_default, &rgb, w, h);
+    let b = encode(&cfg_small, &rgb, w, h);
+    let c = encode(&cfg_big, &rgb, w, h);
+
+    // Length is always the same — only quant-table bytes change,
+    // and those are 64 × 2 (DQT) + DHT doesn't vary + scan payload
+    // fills the same space (AC coefs are all zero for flat chroma).
+    //
+    // More precisely: the file length difference comes from the quant
+    // table bytes only, which is fixed per subsampling mode. If the
+    // user's distance is low enough that quant values stay in 8-bit
+    // space, DQT precision is 0 everywhere — same length.
+    //
+    // For this test we don't require byte-identical because the quant
+    // tables genuinely differ between scales. We just want monotonicity
+    // not to flip signs (grayscale should never produce a SMALLER file
+    // with smaller chroma quant — quant can only grow, not shrink data).
+    assert!(
+        b.len() >= a.len().saturating_sub(10),
+        "scale=0.5 file ({}) shouldn't be much smaller than default ({}) for grayscale",
+        b.len(),
+        a.len(),
+    );
+    assert!(
+        c.len() >= a.len().saturating_sub(10),
+        "scale=2.0 file ({}) shouldn't be much smaller than default ({}) for grayscale",
+        c.len(),
+        a.len(),
+    );
+}
+
+#[test]
+fn chroma_scale_clamped_to_safe_range() {
+    // Out-of-range values are clamped, not rejected. 10.0 -> 5.0, 0.01 -> 0.1.
+    let cfg = EncoderConfig::ycbcr(75.0, ChromaSubsampling::Quarter).chroma_distance_scale(10.0);
+    assert_eq!(cfg.get_chroma_distance_scale(), 5.0);
+
+    let cfg = EncoderConfig::ycbcr(75.0, ChromaSubsampling::Quarter).chroma_distance_scale(0.01);
+    assert_eq!(cfg.get_chroma_distance_scale(), 0.1);
+
+    let cfg = EncoderConfig::ycbcr(75.0, ChromaSubsampling::Quarter).chroma_distance_scale(1.0);
+    assert_eq!(cfg.get_chroma_distance_scale(), 1.0);
+
+    // Default is 1.0.
+    let cfg = EncoderConfig::ycbcr(75.0, ChromaSubsampling::Quarter);
+    assert_eq!(cfg.get_chroma_distance_scale(), 1.0);
+}

--- a/zenjpeg/tests/chroma_distance_scale.rs
+++ b/zenjpeg/tests/chroma_distance_scale.rs
@@ -39,7 +39,7 @@ fn grayscale_rgb(w: u32, h: u32) -> Vec<u8> {
     let mut out = Vec::with_capacity((w * h * 3) as usize);
     for y in 0..h {
         for x in 0..w {
-            let v = ((x + y) as u32 * 255 / (w + h).max(1)) as u8;
+            let v = ((x + y) * 255 / (w + h).max(1)) as u8;
             out.push(v);
             out.push(v);
             out.push(v);


### PR DESCRIPTION
## Summary

Adds a per-encoder chroma-distance multiplier that lets a caller (typically an image-analyzer like [`evalchroma`](https://lib.rs/crates/evalchroma)) drive chroma quantisation independently of the user-requested luma quality. **Bit-identical to previous behaviour when left at default 1.0** — verified by `chroma_scale_default_identity` over {q=40, 75, 90} × {4:4:4, 4:2:0, 4:2:2}.

```rust
EncoderConfig::chroma_distance_scale(self, scale: f32) -> Self    // clamped to [0.1, 5.0]
EncoderConfig::get_chroma_distance_scale(&self) -> f32
```

## Motivation

`evalchroma` already measures Cb/Cr sharpness on the decoded pixels and returns a recommended `chroma_quality` that can be **lower than the user's target** when chroma content is flat — saving bits for free on images where sample frequency already exceeds perceptual need. Before this PR, zenjpeg had no way to act on that signal short of overriding `QuantTableConfig::Custom(EncodingTables{..})`, which is a heavy escape hatch.

Typical mapping from evalchroma's output:

```rust
let luma_d   = Quality::ApproxJpegli(user_q).to_distance();
let chroma_d = Quality::ApproxJpegli(eval.chroma_quality).to_distance();
cfg.chroma_distance_scale(chroma_d / luma_d)
```

## Semantics

- `scale == 1.0` → byte-identical to pre-change output.
- `scale >  1.0` → chroma encoded more aggressively (flat-chroma case).
- `scale <  1.0` → chroma encoded more carefully (sharp-chroma case).

Cb and Cr receive the same multiplier in this initial landing — the base-table asymmetry (Cb ≈ 2× Cr in median quant at 4:2:0) is preserved. A future Option-B split (separate `cb_distance_scale` / `cr_distance_scale`) is API-compatible and can land once data shows the asymmetry is worth a second knob.

## Wiring

- `encoder_config.rs`: new `chroma_distance_scale: f32` field + builder + getter. `default_internal()` sets 1.0.
- `streaming_builder.rs`: same field + `pub(crate)` setter.
- `byte_encoders.rs`: one-line bridge (`builder = builder.chroma_distance_scale(config.chroma_distance_scale);`).
- `streaming.rs::from_builder`: computes `distances_per_component = [d, d*scale, d*scale]`. All three table-generation branches (Custom, Mozjpeg Robidoux, Jpegli default) consume this.
- `tuning.rs`: `EncodingTables::generate_quant_tables(distance: f32, is_420)` → `(distances: [f32; 3], is_420)`. Internal self-test updated to pass `[d, d, d]`.
- `quant/mod.rs`: new public `generate_quant_table_with_distance(distance, component, …)` that bypasses `Quality::to_distance`. `generate_quant_table_ex` reimplemented as a one-line wrapper over it — zero behaviour change.

## Test plan

- [x] `chroma_scale_default_identity` — byte-for-byte identical to no-scale across {q=40, 75, 90} × {4:4:4, 4:2:0, 4:2:2}
- [x] `chroma_scale_monotone_file_size_on_chroma_content` — `scale=0.5 > scale=1.0 > scale=2.0` file sizes on a sharp-chroma gradient
- [x] `chroma_scale_grayscale_invariant_on_444` — grayscale images don't shrink under larger chroma scale (chroma is already zero)
- [x] `chroma_scale_clamped_to_safe_range` — `chroma_distance_scale(10.0)` clamps to 5.0; `(0.01)` clamps to 0.1
- [x] All 1,029 existing lib tests pass

## Design doc

Reasoning, algorithmic background, and options considered: [coefficient docs/ZENJPEG_CHROMA_FEEDBACK_DESIGN.md](https://github.com/imazen/coefficient/blob/main/docs/ZENJPEG_CHROMA_FEEDBACK_DESIGN.md). Numerical analysis of the existing 4:2:0 chroma scaling this change sits on top of: [coefficient docs/ZENJPEG_420_SCALING_ANALYSIS.md](https://github.com/imazen/coefficient/blob/main/docs/ZENJPEG_420_SCALING_ANALYSIS.md).

Follow-up work (not in this PR): coefficient-side sweep across `chroma_distance_scale ∈ {0.5, 0.75, 1.0, 1.25, 1.5, 2.0}` on CID22 PhotoNatural / ScreenContent / PhotoFlat, comparing evalchroma-driven per-image scale against fixed-scale and oracle-best-per-image baselines.