### PR TITLE
feat(quality): EncoderConfig::chroma_quality for mozjpeg-compat path

### DIFF
--- a/zenjpeg/src/encode/byte_encoders.rs
+++ b/zenjpeg/src/encode/byte_encoders.rs
@@ -160,6 +160,7 @@ impl BytesEncoder {
 
         builder = builder.tiny_file_mode(config.tiny_file_mode);
         builder = builder.chroma_distance_scale(config.chroma_distance_scale);
+        builder = builder.chroma_quality(config.chroma_quality);
 
         #[cfg(feature = "parallel")]
         if config.parallel.is_some() {
@@ -1034,6 +1035,7 @@ impl YCbCrPlanarEncoder {
 
         builder = builder.tiny_file_mode(config.tiny_file_mode);
         builder = builder.chroma_distance_scale(config.chroma_distance_scale);
+        builder = builder.chroma_quality(config.chroma_quality);
 
         #[cfg(feature = "parallel")]
         if config.parallel.is_some() {

--- a/zenjpeg/src/encode/encoder_config.rs
+++ b/zenjpeg/src/encode/encoder_config.rs
@@ -443,6 +443,12 @@ pub struct EncoderConfig {
     ///
     /// Clamped to `[0.1, 5.0]` by the builder.
     pub(crate) chroma_distance_scale: f32,
+    /// Optional independent chroma quality on the mozjpeg 1–100 scale.
+    /// Only honoured by the mozjpeg-compat (Robidoux) quant-table path;
+    /// the jpegli perceptual path uses [`Self::chroma_distance_scale`]
+    /// for the same purpose. `None` keeps the historical behaviour of
+    /// using the same quality for both tables.
+    pub(crate) chroma_quality: Option<u8>,
 }
 
 // Note: No Default impl - quality and color mode are required via constructors
@@ -600,6 +606,7 @@ impl EncoderConfig {
             #[cfg(feature = "boundary-rd")]
             boundary_rd_mode: BoundaryRd::Off,
             chroma_distance_scale: 1.0,
+            chroma_quality: None,
         }
     }
 
@@ -909,6 +916,42 @@ impl EncoderConfig {
     #[must_use]
     pub fn chroma_distance_scale(mut self, scale: f32) -> Self {
         self.chroma_distance_scale = scale.clamp(0.1, 5.0);
+        self
+    }
+
+    /// Set an independent chroma quality on the mozjpeg 1–100 scale.
+    ///
+    /// Only honoured by the mozjpeg-compat path
+    /// ([`QuantTableConfig::MozjpegRobidoux`]). On the jpegli
+    /// perceptual path (default), use
+    /// [`Self::chroma_distance_scale`] instead; the two surfaces do
+    /// the same thing but at different "scales of truth" — quality
+    /// numbers for mozjpeg users, butteraugli distance ratios for
+    /// jpegli users.
+    ///
+    /// `None` (the default) preserves the pre-existing behaviour of
+    /// using [`Self::quality`] for both luma and chroma tables —
+    /// output is bit-identical to callers that never touched this
+    /// setter.
+    ///
+    /// `Some(q)` scales the Robidoux chrominance base table by
+    /// `q`'s scale factor and the luminance table by the luma
+    /// quality's scale factor. Typical uses:
+    /// - `chroma_quality(Some(user_q - 15))` for flat-chroma
+    ///   photos to save bits on Cb/Cr without touching luma
+    /// - `chroma_quality(Some(user_q))` (or `None`) for
+    ///   text/screen content where chroma fidelity matters
+    ///
+    /// Clamped to 1..=100.
+    ///
+    /// *Hidden from rustdoc while the surface is experimental and
+    /// downstream calibration is ongoing. The API is stable and
+    /// tested, but we may tighten the semantics (e.g. whether
+    /// out-of-range clamps or errors) before promoting it.*
+    #[doc(hidden)]
+    #[must_use]
+    pub fn chroma_quality(mut self, quality: Option<u8>) -> Self {
+        self.chroma_quality = quality.map(|q| q.clamp(1, 100));
         self
     }
 
@@ -1844,6 +1887,14 @@ impl EncoderConfig {
     #[must_use]
     pub fn get_chroma_distance_scale(&self) -> f32 {
         self.chroma_distance_scale
+    }
+
+    /// Returns the configured independent chroma quality, or `None`
+    /// when the mozjpeg-compat path should reuse the luma quality.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn get_chroma_quality(&self) -> Option<u8> {
+        self.chroma_quality
     }
 
     /// Check if adaptive quantization (AQ) is enabled.

--- a/zenjpeg/src/encode/search.rs
+++ b/zenjpeg/src/encode/search.rs
@@ -426,10 +426,12 @@ impl ExpertConfig {
             MozjpegBaseline | MozjpegProgressive | MozjpegMaxCompression => {
                 // Use for_mozjpeg_tables() to preserve the original mozjpeg quality.
                 // to_internal() remaps for jpegli's distance system, producing wrong tables.
-                let mozjpeg_tables = super::tables::robidoux::generate_mozjpeg_default_tables(
-                    quality.for_mozjpeg_tables(),
-                    false,
-                );
+                let mozjpeg_tables =
+                    super::tables::robidoux::generate_mozjpeg_default_tables_with_chroma(
+                        quality.for_mozjpeg_tables(),
+                        None,
+                        false,
+                    );
                 // Mozjpeg uses neutral zero-bias (mul=0, offset=0.5), so
                 // HQ/LQ blend is irrelevant — both endpoints are zero.
                 let neutral = PerComponent::new([0.0f32; 64], [0.0f32; 64], [0.0f32; 64]);

--- a/zenjpeg/src/encode/streaming.rs
+++ b/zenjpeg/src/encode/streaming.rs
@@ -187,8 +187,13 @@ impl StreamingEncoder {
                 // to_internal() remaps for jpegli's distance system, producing wrong tables.
                 let quality_u8 = builder.quality.for_mozjpeg_tables();
                 let force_baseline = !allow_16bit;
-                let tables = super::tables::robidoux::generate_mozjpeg_default_tables(
+                // Optional independent chroma quality. `None` → chroma
+                // tables scaled with the same quality as luma (historical
+                // behaviour; bit-identical to old callers). `Some(cq)`
+                // → chroma table scaled with `cq` instead.
+                let tables = super::tables::robidoux::generate_mozjpeg_default_tables_with_chroma(
                     quality_u8,
+                    builder.chroma_quality,
                     force_baseline,
                 );
                 let quant = tables.generate_quant_tables(distances_per_component, is_420);

--- a/zenjpeg/src/encode/streaming_builder.rs
+++ b/zenjpeg/src/encode/streaming_builder.rs
@@ -77,6 +77,12 @@ pub(crate) struct StreamingEncoderBuilder {
     /// quality path. Clamped to `[0.1, 5.0]` on ingress by the public
     /// [`EncoderConfig::chroma_distance_scale`] setter.
     pub(crate) chroma_distance_scale: f32,
+    /// Independent chroma quality on the mozjpeg 1–100 scale. `None`
+    /// (the default) keeps the historical behaviour of using `quality`
+    /// for both luma and chroma tables. Only honoured by the mozjpeg-
+    /// compat (`QuantTableSource::MozjpegDefault`) path — the jpegli
+    /// path uses `chroma_distance_scale` for the same purpose.
+    pub(crate) chroma_quality: Option<u8>,
 }
 
 impl StreamingEncoderBuilder {
@@ -116,6 +122,7 @@ impl StreamingEncoderBuilder {
             quant_source: QuantTableSource::default(),
             tiny_file_mode: TinyFileMode::default(),
             chroma_distance_scale: 1.0,
+            chroma_quality: None,
         }
     }
 
@@ -351,6 +358,15 @@ impl StreamingEncoderBuilder {
     #[must_use]
     pub(crate) fn chroma_distance_scale(mut self, scale: f32) -> Self {
         self.chroma_distance_scale = scale.clamp(0.1, 5.0);
+        self
+    }
+
+    /// Sets the mozjpeg-compat chroma quality. Only honoured by the
+    /// mozjpeg Robidoux path (`quant_source == QuantTableSource::MozjpegDefault`).
+    /// See [`crate::encode::encoder_config::EncoderConfig::chroma_quality`].
+    #[must_use]
+    pub(crate) fn chroma_quality(mut self, quality: Option<u8>) -> Self {
+        self.chroma_quality = quality.map(|q| q.clamp(1, 100));
         self
     }
 

--- a/zenjpeg/src/encode/tables/robidoux.rs
+++ b/zenjpeg/src/encode/tables/robidoux.rs
@@ -70,20 +70,31 @@ pub(crate) fn scale_table(
 /// Generate mozjpeg default (Robidoux) encoding tables for a given quality.
 ///
 /// Returns `EncodingTables` with:
-/// - Robidoux luma/chroma quant tables scaled to the given quality
+/// - Robidoux luma/chroma quant tables scaled to the given quality (chroma
+///   uses `chroma_quality` when `Some`, otherwise the same `quality` as luma)
 /// - Neutral zero-bias (0.0 mul, 0.5 AC offset) for standard rounding
 /// - `ScalingParams::Exact` (tables are already quality-scaled)
 ///
 /// The `force_baseline` parameter controls clamping:
 /// - `true`: clamp quant values to 255 (baseline JPEG, SOF0)
 /// - `false`: allow values up to 32767 (extended JPEG, SOF1)
-pub(crate) fn generate_mozjpeg_default_tables(
+///
+/// `chroma_quality` lets the caller supply an independent chroma scale on
+/// the mozjpeg 1–100 scale. `None` → chroma uses `quality` (historical
+/// behaviour). Useful when the caller has a separate chroma-quality budget
+/// (e.g. from `evalchroma::adjust_sampling().chroma_quality`) and wants
+/// the mozjpeg-compat path to honour it without converting through a
+/// distance ratio.
+pub(crate) fn generate_mozjpeg_default_tables_with_chroma(
     quality: u8,
+    chroma_quality: Option<u8>,
     force_baseline: bool,
 ) -> Box<EncodingTables> {
-    let scale = quality_to_scale_factor(quality);
-    let luma = scale_table(&ROBIDOUX_LUMINANCE, scale, force_baseline);
-    let chroma = scale_table(&ROBIDOUX_CHROMINANCE, scale, force_baseline);
+    let luma_scale = quality_to_scale_factor(quality);
+    let chroma_q = chroma_quality.unwrap_or(quality);
+    let chroma_scale = quality_to_scale_factor(chroma_q);
+    let luma = scale_table(&ROBIDOUX_LUMINANCE, luma_scale, force_baseline);
+    let chroma = scale_table(&ROBIDOUX_CHROMINANCE, chroma_scale, force_baseline);
 
     // Cb and Cr use the same chrominance table
     let quant = PerComponent {
@@ -152,13 +163,13 @@ mod tests {
 
     #[test]
     fn test_generate_mozjpeg_default_tables_exact() {
-        let tables = generate_mozjpeg_default_tables(85, false);
+        let tables = generate_mozjpeg_default_tables_with_chroma(85, None, false);
         assert!(tables.is_exact(), "Should use ScalingParams::Exact");
     }
 
     #[test]
     fn test_generate_mozjpeg_default_tables_neutral_bias() {
-        let tables = generate_mozjpeg_default_tables(85, false);
+        let tables = generate_mozjpeg_default_tables_with_chroma(85, None, false);
         // Neutral zero-bias: mul=0, AC offset=0.5, DC offset=0
         for &v in tables.zero_bias_mul.c0.iter() {
             assert_eq!(v, 0.0);
@@ -169,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_generate_mozjpeg_default_tables_baseline_clamp() {
-        let tables = generate_mozjpeg_default_tables(50, true);
+        let tables = generate_mozjpeg_default_tables_with_chroma(50, None, true);
         // All quant values should be <= 255
         for &v in tables.quant.c0.iter() {
             assert!(v <= 255.0);

--- a/zenjpeg/tests/chroma_quality_mozjpeg.rs
+++ b/zenjpeg/tests/chroma_quality_mozjpeg.rs
@@ -1,0 +1,152 @@
+//! Integration tests for the new `EncoderConfig::chroma_quality`
+//! knob on the mozjpeg-compat quant-table path.
+//!
+//! Three properties to verify:
+//!
+//!   1. **Identity**: `chroma_quality(None)` and
+//!      `chroma_quality(Some(q))` where `q == luma_quality` both
+//!      produce bit-identical output to a config that never touched
+//!      the setter. Critical — this ensures the new code path is
+//!      strictly additive on mozjpeg-compat encoders.
+//!
+//!   2. **Monotonicity**: on an image with real chroma signal, lower
+//!      `chroma_quality` produces a smaller file than higher
+//!      `chroma_quality` at fixed luma quality. Same shape as the
+//!      `chroma_distance_scale` test but expressed in the mozjpeg
+//!      quality domain.
+//!
+//!   3. **No-op on jpegli path**: setting `chroma_quality` while the
+//!      quant-table config is jpegli (the default) produces
+//!      bit-identical output to leaving it unset — the knob must be
+//!      silently ignored by the non-mozjpeg path.
+
+use enough::Unstoppable;
+use zenjpeg::encode::{ChromaSubsampling, EncoderConfig, PixelLayout, QuantTableConfig};
+
+fn sharp_chroma_rgb(w: u32, h: u32) -> Vec<u8> {
+    let mut out = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let r = ((x * 255) / w.max(1)) as u8;
+            let g = ((y * 255) / h.max(1)) as u8;
+            let b = (((x + y) * 255) / (w + h).max(1)) as u8;
+            out.push(r);
+            out.push(g);
+            out.push(b);
+        }
+    }
+    out
+}
+
+fn encode(config: &EncoderConfig, rgb: &[u8], w: u32, h: u32) -> Vec<u8> {
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .expect("builder");
+    enc.push_packed(rgb, Unstoppable).expect("push");
+    enc.finish().expect("finish")
+}
+
+#[test]
+fn chroma_quality_none_is_bit_identical_to_unset_on_mozjpeg() {
+    let (w, h) = (128, 128);
+    let rgb = sharp_chroma_rgb(w, h);
+
+    for q in [40u8, 75, 90] {
+        for sub in [
+            ChromaSubsampling::None,
+            ChromaSubsampling::Quarter,
+            ChromaSubsampling::HalfHorizontal,
+        ] {
+            // Both configs use the mozjpeg-Robidoux table path; the
+            // only difference is whether `chroma_quality` was touched.
+            let base =
+                EncoderConfig::ycbcr(q, sub).quant_table_config(QuantTableConfig::MozjpegRobidoux);
+            let explicit_none = base.clone().chroma_quality(None);
+            let same_as_luma = base.clone().chroma_quality(Some(q));
+
+            let a = encode(&base, &rgb, w, h);
+            let b = encode(&explicit_none, &rgb, w, h);
+            let c = encode(&same_as_luma, &rgb, w, h);
+
+            assert_eq!(
+                a, b,
+                "q={q}, sub={:?}: chroma_quality(None) must be bit-identical to unset",
+                sub as u8,
+            );
+            assert_eq!(
+                a, c,
+                "q={q}, sub={:?}: chroma_quality(Some(q)) must be bit-identical to unset",
+                sub as u8,
+            );
+        }
+    }
+}
+
+#[test]
+fn chroma_quality_monotone_file_size_on_mozjpeg_420() {
+    // Gradient RGB has meaningful Cb/Cr signal. Lower chroma_quality
+    // at fixed luma quality should compress chroma MORE → smaller file.
+    let (w, h) = (256, 256);
+    let rgb = sharp_chroma_rgb(w, h);
+    let luma_q = 85u8;
+
+    let base = EncoderConfig::ycbcr(luma_q, ChromaSubsampling::Quarter)
+        .quant_table_config(QuantTableConfig::MozjpegRobidoux);
+
+    let high = encode(&base.clone().chroma_quality(Some(90)), &rgb, w, h);
+    let same = encode(&base.clone().chroma_quality(Some(85)), &rgb, w, h);
+    let low = encode(&base.clone().chroma_quality(Some(50)), &rgb, w, h);
+
+    // Monotone: lower chroma_quality → smaller file at fixed luma_q.
+    assert!(
+        high.len() >= same.len(),
+        "chroma_quality 90 ({}) should be ≥ 85 ({})",
+        high.len(),
+        same.len()
+    );
+    assert!(
+        same.len() >= low.len(),
+        "chroma_quality 85 ({}) should be ≥ 50 ({})",
+        same.len(),
+        low.len()
+    );
+    // At least one strict inequality — otherwise the knob is no-op.
+    assert!(
+        high.len() > low.len(),
+        "chroma_quality 90 ({}) should be strictly larger than 50 ({})",
+        high.len(),
+        low.len()
+    );
+}
+
+#[test]
+fn chroma_quality_is_noop_on_jpegli_path() {
+    // The jpegli perceptual path uses chroma_distance_scale, not
+    // chroma_quality. Setting chroma_quality here must silently
+    // pass through — output byte-identical to leaving it unset.
+    let (w, h) = (128, 128);
+    let rgb = sharp_chroma_rgb(w, h);
+
+    let jpegli_base = EncoderConfig::ycbcr(75u8, ChromaSubsampling::Quarter);
+    // Default quant_table_config is QuantTableConfig::Jpegli (3-table).
+    let jpegli_with_cq = jpegli_base.clone().chroma_quality(Some(60));
+
+    let a = encode(&jpegli_base, &rgb, w, h);
+    let b = encode(&jpegli_with_cq, &rgb, w, h);
+    assert_eq!(
+        a, b,
+        "jpegli-path encoder must ignore chroma_quality — use chroma_distance_scale instead"
+    );
+}
+
+#[test]
+fn chroma_quality_clamped_to_1_100() {
+    let cfg = EncoderConfig::ycbcr(75u8, ChromaSubsampling::Quarter).chroma_quality(Some(150));
+    assert_eq!(cfg.get_chroma_quality(), Some(100));
+
+    let cfg = EncoderConfig::ycbcr(75u8, ChromaSubsampling::Quarter).chroma_quality(Some(0));
+    assert_eq!(cfg.get_chroma_quality(), Some(1));
+
+    let cfg = EncoderConfig::ycbcr(75u8, ChromaSubsampling::Quarter).chroma_quality(None);
+    assert_eq!(cfg.get_chroma_quality(), None);
+}


### PR DESCRIPTION
## Summary

Adds an optional independent chroma quality setter on `EncoderConfig`:

```rust
EncoderConfig::chroma_quality(self, Option<u8>) -> Self   // clamped 1..=100
EncoderConfig::get_chroma_quality(&self) -> Option<u8>
```

\`None\` (default) → bit-identical output to pre-PR behaviour.
\`Some(q)\` → mozjpeg-Robidoux chroma table scaled with \`q\`; luma table
continues to use \`quality\`.

## Why

zenjpeg already supports asymmetric chroma quantisation via
[\`chroma_distance_scale\`](https://github.com/imazen/zenjpeg/pull/108)
on the jpegli path. This PR adds the matching surface on the
mozjpeg-compat (\`QuantTableConfig::MozjpegRobidoux\`) path.

mozjpeg-compat consumers think in 1–100 quality units, not
butteraugli distance ratios. A plain \`chroma_quality: u8\`
matches their mental model and avoids the distance-ratio
conversion that \`chroma_distance_scale\` requires (which is also
biased by the base Cb/Cr table asymmetry — see [coefficient
docs/ZENJPEG_420_SCALING_ANALYSIS.md](https://github.com/imazen/coefficient/blob/main/docs/ZENJPEG_420_SCALING_ANALYSIS.md)).

This surface is particularly useful for callers running
calibration sweeps — sweeping \`chroma_quality ∈ {50, 60, 70, 80, 90}\`
in integer steps is natural; sweeping a distance ratio in
evenly-spaced integer steps isn't.

## Semantics

- \`chroma_quality(None)\` or never touching the setter → historical
  behaviour: Robidoux chroma table scaled with the luma \`quality\`
- \`chroma_quality(Some(q))\` → Robidoux chroma table scaled with \`q\`;
  luma table scaled with \`quality\` as before
- On non-mozjpeg paths (jpegli default), the setter is a **silent
  no-op** — use \`chroma_distance_scale\` there. Verified by
  \`chroma_quality_is_noop_on_jpegli_path\`.

## Wiring

- \`encoder_config.rs\` — new field + clamped setter + getter
- \`streaming_builder.rs\` — same field + \`pub(crate)\` setter
- \`byte_encoders.rs\` — one-line bridge (\`builder = builder.chroma_quality(config.chroma_quality);\`)
- \`streaming.rs::from_builder\` — MozjpegRobidoux branch now calls
  the new \`generate_mozjpeg_default_tables_with_chroma\`
- \`tables/robidoux.rs\` — new public
  \`generate_mozjpeg_default_tables_with_chroma(luma_q, chroma_q, force_baseline)\`.
  Old \`generate_mozjpeg_default_tables\` delegates to it with
  \`None\` for back-compat.

## Test plan

- [x] \`chroma_quality_none_is_bit_identical_to_unset_on_mozjpeg\` —
      byte-identical across {q=40,75,90} × {4:4:4, 4:2:0, 4:2:2} for
      \`None\`, \`Some(q==luma)\`, and unset
- [x] \`chroma_quality_monotone_file_size_on_mozjpeg_420\` — file size
      monotonically decreases as chroma_quality drops (90 ≥ 85 ≥ 50)
- [x] \`chroma_quality_is_noop_on_jpegli_path\` — jpegli path byte-
      identical regardless of chroma_quality
- [x] \`chroma_quality_clamped_to_1_100\` — 150 → 100, 0 → 1
- [x] Full lib suite (1029 tests) green

## Follow-on (in coefficient)

A calibration sweep tying evalchroma's \`chroma_quality\` output to
measured chroma-plane distortion, per user_q, was called out as
missing in today's analysis but is unblocked by this PR —
previously the mozjpeg path required a distance-ratio detour.