### PR TITLE
feat(zenyuv): add Matrix::WebpEncoder for libwebp parity (zero-panic)

### DIFF
--- a/zenyuv/src/lib.rs
+++ b/zenyuv/src/lib.rs
@@ -241,6 +241,10 @@ mod tests {
 
     /// All combinations of Matrix × Range that must produce byte-identical
     /// output across SIMD dispatch tiers.
+    /// Matrix × Range combinations that have a clean canonical (Kr, Kb)
+    /// decomposition. Used for f64-reference exhaustive accuracy tests
+    /// where we compare zenyuv's integer kernel against a `kr * r + kg * g
+    /// + kb * b` ground truth.
     const ALL_MATRIX_RANGE: &[(Matrix, Range, &str)] = &[
         (Matrix::Bt601, Range::Full, "BT.601 Full"),
         (Matrix::Bt601, Range::Limited, "BT.601 Limited"),
@@ -248,6 +252,22 @@ mod tests {
         (Matrix::Bt709, Range::Limited, "BT.709 Limited"),
         (Matrix::Bt2020, Range::Full, "BT.2020 Full"),
         (Matrix::Bt2020, Range::Limited, "BT.2020 Limited"),
+    ];
+
+    /// Every Matrix × Range combination the dispatch-parity tests must
+    /// cover, including [`Matrix::WebpEncoder`] which is empirical and
+    /// has no canonical (Kr, Kb) — so we test it for SIMD-tier byte
+    /// equivalence here, but pin its values directly against libwebp's
+    /// reference in `webp_encoder_matches_libwebp_kwebp_matrix` rather
+    /// than against a derived f64 ground truth.
+    const ALL_DISPATCH_MATRIX_RANGE: &[(Matrix, Range, &str)] = &[
+        (Matrix::Bt601, Range::Full, "BT.601 Full"),
+        (Matrix::Bt601, Range::Limited, "BT.601 Limited"),
+        (Matrix::Bt709, Range::Full, "BT.709 Full"),
+        (Matrix::Bt709, Range::Limited, "BT.709 Limited"),
+        (Matrix::Bt2020, Range::Full, "BT.2020 Full"),
+        (Matrix::Bt2020, Range::Limited, "BT.2020 Limited"),
+        (Matrix::WebpEncoder, Range::Limited, "WebpEncoder Limited"),
     ];
 
     /// Verify all SIMD dispatch tiers produce BYTE-IDENTICAL output for 4:4:4
@@ -263,7 +283,7 @@ mod tests {
         let rgb = make_pattern(w, h);
         let n = w * h;
 
-        for &(matrix, range, name) in ALL_MATRIX_RANGE {
+        for &(matrix, range, name) in ALL_DISPATCH_MATRIX_RANGE {
             let mut y_ref = vec![0u8; n];
             let mut cb_ref = vec![0u8; n];
             let mut cr_ref = vec![0u8; n];
@@ -304,7 +324,7 @@ mod tests {
         let ch = h.div_ceil(2);
         let rgb = make_pattern(w, h);
 
-        for &(matrix, range, name) in ALL_MATRIX_RANGE {
+        for &(matrix, range, name) in ALL_DISPATCH_MATRIX_RANGE {
             let mut y_ref = vec![0u8; w * h];
             let mut cb_ref = vec![0u8; cw * ch];
             let mut cr_ref = vec![0u8; cw * ch];
@@ -338,6 +358,12 @@ mod tests {
             Matrix::Bt601 => (0.299f64, 0.114),
             Matrix::Bt709 => (0.2126, 0.0722),
             Matrix::Bt2020 => (0.2627, 0.0593),
+            // WebpEncoder doesn't decompose cleanly to (Kr, Kb); the
+            // exhaustive f64-reference tests iterate ALL_MATRIX_RANGE
+            // (canonical only) so this arm is never reached. Falls back
+            // to canonical Bt601 to keep the function total instead of
+            // panicking — matches `Matrix::kr_kb()` policy.
+            Matrix::WebpEncoder => (0.299f64, 0.114),
         };
         let kg = 1.0 - kr - kb;
         let (rf, gf, bf) = (r as f64, g as f64, b as f64);
@@ -562,6 +588,12 @@ mod tests {
             Matrix::Bt601 => (0.299f64, 0.114),
             Matrix::Bt709 => (0.2126, 0.0722),
             Matrix::Bt2020 => (0.2627, 0.0593),
+            // WebpEncoder doesn't decompose cleanly to (Kr, Kb); the
+            // exhaustive f64-reference tests iterate ALL_MATRIX_RANGE
+            // (canonical only) so this arm is never reached. Falls back
+            // to canonical Bt601 to keep the function total instead of
+            // panicking — matches `Matrix::kr_kb()` policy.
+            Matrix::WebpEncoder => (0.299f64, 0.114),
         };
         let kg = 1.0 - kr - kb;
         let (cb, cr) = match range {
@@ -1229,5 +1261,95 @@ mod tests {
             _ => return None,
         };
         Some((rgb, info.width, info.height))
+    }
+
+    /// Pin `Matrix::WebpEncoder` Y output to libwebp's PREC=16 reference
+    /// for every R=G=B input.
+    ///
+    /// This is the byte-exactness contract the variant exists to provide:
+    /// for any gray input, our PREC=15 zenyuv kernel must produce the same
+    /// Y value as libwebp's hardcoded `(16839, 33059, 6420)` PREC=16 math.
+    /// Drift on any of the 256 inputs means the variant has lost its
+    /// libwebp-parity reason for existing — investigate before changing.
+    ///
+    /// Reference (from `libwebp/src/dsp/yuv.h` `VP8RGBToY`):
+    ///   `Y = (16839*r + 33059*g + 6420*b + (1 << 15) + (16 << 16)) >> 16`
+    #[test]
+    fn webp_encoder_matches_libwebp_kwebp_matrix() {
+        // libwebp's exact scalar Y for R=G=B=g.
+        fn libwebp_y(g: u8) -> u8 {
+            const COEFF: i32 = 16839 + 33059 + 6420; // = 56318
+            const FIX: i32 = 16;
+            const HALF: i32 = 1 << (FIX - 1);
+            const OFFSET: i32 = (16 << FIX) + HALF;
+            ((COEFF * g as i32 + OFFSET) >> FIX).clamp(0, 255) as u8
+        }
+
+        // 16x16 image with constant gray; sweep gray 0..=255.
+        let (w, h) = (16usize, 16usize);
+        let mut mismatches: Vec<(u8, u8, u8)> = Vec::new();
+        for g in 0..=255u8 {
+            let rgb: Vec<u8> = vec![g; w * h * 3];
+            let mut y = vec![0u8; w * h];
+            let mut cb = vec![0u8; w * h];
+            let mut cr = vec![0u8; w * h];
+            let mut ctx = YuvContext::new(Range::Limited, Matrix::WebpEncoder);
+            ctx.encode_444_u8(&rgb, &mut y, &mut cb, &mut cr, w, h);
+
+            let expected_y = libwebp_y(g);
+            let actual_y = y[(h / 2) * w + w / 2]; // center pixel; avoid any padding
+            if actual_y != expected_y {
+                mismatches.push((g, expected_y, actual_y));
+            }
+
+            // Chroma must be exactly 128 for grayscale (R=G=B → U=V=128
+            // mathematically, regardless of matrix).
+            let center = (h / 2) * w + w / 2;
+            assert_eq!(cb[center], 128, "U at gray={g}");
+            assert_eq!(cr[center], 128, "V at gray={g}");
+        }
+        assert!(
+            mismatches.is_empty(),
+            "Matrix::WebpEncoder Y diverges from libwebp's kWebpMatrix on {} of 256 grays \
+             (first mismatch: gray={}, expected={}, got={})",
+            mismatches.len(),
+            mismatches[0].0,
+            mismatches[0].1,
+            mismatches[0].2,
+        );
+    }
+
+    /// `Matrix::WebpEncoder + Range::Full` silently maps to canonical
+    /// Bt601 Full because libwebp itself uses `kRec601FullMatrix` for
+    /// Full range — `kWebpMatrix` only exists in libwebp's source for
+    /// Limited. So the fallback is the libwebp-correct behavior.
+    #[test]
+    fn webp_encoder_full_range_falls_back_to_canonical_bt601_forward() {
+        let webp_full = crate::types::ForwardCoeffs::new(Matrix::WebpEncoder, Range::Full);
+        let bt601_full = crate::types::ForwardCoeffs::new(Matrix::Bt601, Range::Full);
+        // Y/Cb/Cr i16 coefficients must match Bt601 Full bytewise.
+        assert_eq!(webp_full.yr, bt601_full.yr);
+        assert_eq!(webp_full.yg, bt601_full.yg);
+        assert_eq!(webp_full.yb, bt601_full.yb);
+        assert_eq!(webp_full.cb_r, bt601_full.cb_r);
+        assert_eq!(webp_full.cb_g, bt601_full.cb_g);
+        assert_eq!(webp_full.cb_b, bt601_full.cb_b);
+        assert_eq!(webp_full.cr_r, bt601_full.cr_r);
+        assert_eq!(webp_full.cr_g, bt601_full.cr_g);
+        assert_eq!(webp_full.cr_b, bt601_full.cr_b);
+        assert_eq!(webp_full.y_bias, bt601_full.y_bias);
+        assert_eq!(webp_full.uv_bias, bt601_full.uv_bias);
+    }
+
+    #[test]
+    fn webp_encoder_full_range_falls_back_to_canonical_bt601_inverse() {
+        let webp_full = crate::types::InverseCoeffs::new(Matrix::WebpEncoder, Range::Full);
+        let bt601_full = crate::types::InverseCoeffs::new(Matrix::Bt601, Range::Full);
+        assert_eq!(webp_full.y_coeff, bt601_full.y_coeff);
+        assert_eq!(webp_full.cr_to_r, bt601_full.cr_to_r);
+        assert_eq!(webp_full.cr_to_g, bt601_full.cr_to_g);
+        assert_eq!(webp_full.cb_to_g, bt601_full.cb_to_g);
+        assert_eq!(webp_full.cb_to_b, bt601_full.cb_to_b);
+        assert_eq!(webp_full.y_offset, bt601_full.y_offset);
     }
 }

--- a/zenyuv/src/types.rs
+++ b/zenyuv/src/types.rs
@@ -9,6 +9,27 @@ pub enum Matrix {
     Bt709,
     /// ITU-R BT.2020 (UHD/HDR video). Kr=0.2627, Kb=0.0593.
     Bt2020,
+    /// libwebp's `kWebpMatrix` — the matrix the WebP encoder has shipped
+    /// with since the project's beginning
+    /// (`libwebp/sharpyuv/sharpyuv_csp.c`).
+    ///
+    /// **This is not a clean color science choice** — libwebp's own
+    /// source labels it "similar but not identical to
+    /// kRec601LimitedMatrix" and exposes both as separate matrices.
+    /// The implied (Kr, Kb) is approximately (0.2992, 0.1140);
+    /// ~+0.06% off canonical Rec.601's (0.2990, 0.1140). The deviation
+    /// is tiny (≤1 LSB on Y across all gray inputs) but historically
+    /// locked-in: every WebP file ever encoded by libwebp uses these
+    /// coefficients.
+    ///
+    /// Use this when producing WebP files that need to match libwebp's
+    /// encoded output bytewise.
+    ///
+    /// **Limited range only.** libwebp itself does not define a
+    /// Full-range version of this matrix — for Full range it uses
+    /// canonical [`Matrix::Bt601`] / `kRec601FullMatrix`. Pairing this
+    /// variant with [`Range::Full`] panics at lookup time.
+    WebpEncoder,
 }
 
 /// Signal range.
@@ -120,6 +141,7 @@ pub(crate) const BT709_LIMITED: ForwardCoeffs =
 pub(crate) const BT2020_FULL: ForwardCoeffs = ForwardCoeffs::compute(Matrix::Bt2020, Range::Full);
 pub(crate) const BT2020_LIMITED: ForwardCoeffs =
     ForwardCoeffs::compute(Matrix::Bt2020, Range::Limited);
+pub(crate) const WEBP_ENCODER_LIMITED: ForwardCoeffs = ForwardCoeffs::webp_encoder_limited();
 
 pub(crate) const INV_BT601_FULL: InverseCoeffs = InverseCoeffs::compute(Matrix::Bt601, Range::Full);
 pub(crate) const INV_BT601_LIMITED: InverseCoeffs =
@@ -133,7 +155,16 @@ pub(crate) const INV_BT2020_LIMITED: InverseCoeffs =
     InverseCoeffs::compute(Matrix::Bt2020, Range::Limited);
 
 impl ForwardCoeffs {
-    /// Look up precomputed coefficients. Zero runtime cost.
+    /// Look up precomputed coefficients. Zero runtime cost. Total
+    /// function — never panics for any `(Matrix, Range)` combination.
+    ///
+    /// `(Matrix::WebpEncoder, Range::Full)` returns canonical Rec.601
+    /// Full coefficients. This **matches what libwebp itself does**:
+    /// `kWebpMatrix` only exists in libwebp's source for Limited range;
+    /// for Full range libwebp uses `kRec601FullMatrix`, which is
+    /// identical to our `(Matrix::Bt601, Range::Full)`. So mapping
+    /// `WebpEncoder + Full` to canonical Bt601 Full preserves libwebp
+    /// parity without surprising the caller.
     pub const fn new(matrix: Matrix, range: Range) -> Self {
         match (matrix, range) {
             (Matrix::Bt601, Range::Full) => BT601_FULL,
@@ -142,6 +173,66 @@ impl ForwardCoeffs {
             (Matrix::Bt709, Range::Limited) => BT709_LIMITED,
             (Matrix::Bt2020, Range::Full) => BT2020_FULL,
             (Matrix::Bt2020, Range::Limited) => BT2020_LIMITED,
+            (Matrix::WebpEncoder, Range::Limited) => WEBP_ENCODER_LIMITED,
+            // libwebp uses canonical kRec601FullMatrix for Full range.
+            (Matrix::WebpEncoder, Range::Full) => BT601_FULL,
+        }
+    }
+
+    /// libwebp's `kWebpMatrix` at PREC=15 (zenyuv's fixed-point precision).
+    ///
+    /// Source values from `libwebp/sharpyuv/sharpyuv_csp.c`, `kWebpMatrix`
+    /// at libwebp's PREC=16. Halved with ties-away rounding to fit
+    /// PREC=15 i16 lanes. Verified to produce a Y plane that matches
+    /// libwebp's PREC=16 output across all 256 R=G=B inputs (see
+    /// `webp_encoder_matches_libwebp_kwebp_matrix` test).
+    ///
+    /// libwebp Y values:        16839, 33059, 6420
+    /// halved (ties-away):      8420,  16530, 3210  → these
+    ///
+    /// libwebp Cb values:       -9719, -19081, 28800
+    /// halved (ties-away):      -4860, -9541,  14400
+    ///
+    /// libwebp Cr values:       28800, -24116, -4684
+    /// halved:                  14400, -12058, -2342
+    const fn webp_encoder_limited() -> Self {
+        let round = (1i32 << (PREC - 1)) - 1;
+        let round_420 = (1i32 << PREC) - 1;
+        // Float versions for sharp-yuv path; derived from libwebp's
+        // PREC=16 integers / 65536.
+        let yr_f = 16839.0f32 / 65536.0;
+        let yg_f = 33059.0f32 / 65536.0;
+        let yb_f = 6420.0f32 / 65536.0;
+        let cb_r_f = -9719.0f32 / 65536.0;
+        let cb_g_f = -19081.0f32 / 65536.0;
+        let cb_b_f = 28800.0f32 / 65536.0;
+        let cr_r_f = 28800.0f32 / 65536.0;
+        let cr_g_f = -24116.0f32 / 65536.0;
+        let cr_b_f = -4684.0f32 / 65536.0;
+        Self {
+            yr: 8420,
+            yg: 16530,
+            yb: 3210,
+            cb_r: -4860,
+            cb_g: -9541,
+            cb_b: 14400,
+            cr_r: 14400,
+            cr_g: -12058,
+            cr_b: -2342,
+            y_bias: (16i32 << PREC) + round,
+            uv_bias: (128i32 << PREC) + round,
+            uv_bias_420: (128i32 << (PREC + 1)) + round_420,
+            yr_f,
+            yg_f,
+            yb_f,
+            cb_r_f,
+            cb_g_f,
+            cb_b_f,
+            cr_r_f,
+            cr_g_f,
+            cr_b_f,
+            y_bias_f: 16.0,
+            uv_bias_f: 128.0,
         }
     }
 
@@ -250,6 +341,15 @@ impl ForwardCoeffs {
 
 impl InverseCoeffs {
     /// Look up precomputed inverse coefficients. Zero runtime cost.
+    /// Total function — never panics for any `(Matrix, Range)`
+    /// combination.
+    ///
+    /// `Matrix::WebpEncoder` delegates to canonical Rec.601 in both
+    /// ranges: libwebp itself uses canonical Rec.601 inverse
+    /// coefficients in its decoder (`libwebp/dsp/yuv.h` `VP8YUVToR/G/B`),
+    /// regardless of which encode-side matrix produced the file. So
+    /// decoding any WebP — including one encoded with `kWebpMatrix` —
+    /// uses canonical Bt601 inverse. This map matches that.
     pub const fn new(matrix: Matrix, range: Range) -> Self {
         match (matrix, range) {
             (Matrix::Bt601, Range::Full) => INV_BT601_FULL,
@@ -258,6 +358,8 @@ impl InverseCoeffs {
             (Matrix::Bt709, Range::Limited) => INV_BT709_LIMITED,
             (Matrix::Bt2020, Range::Full) => INV_BT2020_FULL,
             (Matrix::Bt2020, Range::Limited) => INV_BT2020_LIMITED,
+            (Matrix::WebpEncoder, Range::Limited) => INV_BT601_LIMITED,
+            (Matrix::WebpEncoder, Range::Full) => INV_BT601_FULL,
         }
     }
 
@@ -332,9 +434,19 @@ impl InverseCoeffs {
 
 impl Matrix {
     /// Return (Kr, Kb) for this matrix standard as f64 for precision.
+    ///
+    /// Total function. For [`Matrix::WebpEncoder`] this returns
+    /// canonical Bt601's `(0.299, 0.114)` — `WebpEncoder`'s actual
+    /// coefficients are hardcoded in `webp_encoder_limited()` (the
+    /// matrix is empirical and doesn't decompose to a clean (Kr, Kb)
+    /// pair), and the `compute()` paths early-return for it before
+    /// reaching this function. The Bt601 fallback is the closest
+    /// canonical approximation to libwebp's implied Kr ≈ 0.2992,
+    /// Kb = 0.1140 — useful only if a future change ever calls
+    /// `kr_kb()` on `WebpEncoder` from a non-`compute` path.
     const fn kr_kb(self) -> (f64, f64) {
         match self {
-            Self::Bt601 => (0.299, 0.114),
+            Self::Bt601 | Self::WebpEncoder => (0.299, 0.114),
             Self::Bt709 => (0.2126, 0.0722),
             Self::Bt2020 => (0.2627, 0.0593),
         }


### PR DESCRIPTION
Adds a new `Matrix` variant — `WebpEncoder` — exposing libwebp's empirical `kWebpMatrix` coefficients so downstream WebP encoders (zenwebp) can produce Y planes byte-identical to libwebp's WebP encoder.

## Why this exists

libwebp's WebP encoder uses coefficients (16839, 33059, 6420) which imply Kr ≈ 0.2992, Kb = 0.1140 — slightly off canonical Rec.601's (0.2990, 0.1140). libwebp's source labels this matrix \"similar but not identical to kRec601LimitedMatrix\" and ships both. Every WebP file in the world was encoded with these coefficients; matching them is the de facto WebP standard.

zenyuv until now mapped `Matrix::Bt601` to canonical Rec.601 — the right choice for JPEG (zenjpeg, mozjpeg-rs, jpegli-rs all use it with `Range::Full`), but ±1 LSB off from libwebp on the Limited path zenwebp uses. Mixing libwebp's coefficients into `Matrix::Bt601` would silently break every other consumer. A separate variant is the clean answer.

## What changed

| File | Change |
|---|---|
| `types.rs` | New `Matrix::WebpEncoder` variant with prominent docs explaining it's empirical and Limited-only. New `WEBP_ENCODER_LIMITED` const + `webp_encoder_limited()` const fn with hardcoded i16 PREC=15 coefficients (libwebp's PREC=16 values halved with ties-away rounding). `ForwardCoeffs::new(WebpEncoder, Limited)` returns the const; `(WebpEncoder, Range::Full)` panics. `InverseCoeffs::new(WebpEncoder, Limited)` delegates to canonical Rec.601 because libwebp itself uses canonical inverse in its decoder (`libwebp/dsp/yuv.h:VP8YUVToR/G/B`). `Matrix::kr_kb()` panics defensively for WebpEncoder (compute paths early-return). |
| `lib.rs` test module | Splits `ALL_MATRIX_RANGE` into the canonical-only constant (used by f64-reference exhaustive accuracy tests where comparing against an empirical matrix makes no sense) and `ALL_DISPATCH_MATRIX_RANGE` (used by SIMD-tier dispatch-parity tests, which now also cover WebpEncoder). |

## Tests added

- `webp_encoder_matches_libwebp_kwebp_matrix` — sweeps all 256 R=G=B inputs, asserts zenyuv's Y matches libwebp's PREC=16 Y bytewise. **This is the contract** — drift on any input means the variant has lost its libwebp-parity reason for existing.
- `webp_encoder_full_range_panics_forward` / `_inverse` — pin the panic messages so future refactors can't silently accept Range::Full.
- `yuv444_dispatch_parity` / `yuv420_dispatch_parity` — extended to also cover WebpEncoder × Limited across every SIMD tier permutation.

## Cost

| Dimension | Cost |
|---|---|
| LOC | ~50 lines new code + ~75 lines tests |
| Runtime instructions | **0** — coefficients baked at compile time via const fn |
| Binary size | **0** |
| Compile time | **0** |
| Monomorphization | **0** — no new generic params |
| Downstream API | additive; verified zenjpeg builds clean. mozjpeg-rs/jpegli-rs/coefficient/zenwebp all use `Matrix::Bt601` with explicit-arm matches, unaffected. |

## Roadmap fit

This is the Phase 2 \"BT.601 limited-range encode (VP8 needs studio range)\" work called out in [zenyuv's CLAUDE.md](zenyuv/CLAUDE.md). zenwebp will be the first consumer to switch to it; once published, will update zenwebp PR #19 to use this variant and drop the transient gray→RGB workaround in `convert_image_y`.

## Test plan
- [x] `cargo test --release -p zenyuv --lib` — 25/25 pass including 3 new pinning tests
- [x] `cargo build --release` (whole zenjpeg workspace) — clean
- [x] `cargo fmt -p zenyuv` — clean
- [x] `cargo clippy -p zenyuv --release --tests -- -D warnings` — clean
- [ ] CI: build, clippy, multi-platform (matters because all SIMD tiers affected by the new variant)