### PR TITLE
feat(encode): AqController scaffold for per-strip AQ adjustment (#113)

### DIFF
--- a/zenjpeg/src/encode/aq_controller.rs
+++ b/zenjpeg/src/encode/aq_controller.rs
@@ -1,0 +1,126 @@
+//! Per-iMCU AQ-strength controller hook (issue #113, PR-A scaffold).
+//!
+//! Sits between [`StreamingAQ`](crate::quant::aq::streaming::StreamingAQ)
+//! emitting per-iMCU AQ strengths and [`StripProcessor::quantize_prev_pending_imcu`]
+//! consuming them. A controller may scale the strengths in place; with no
+//! controller installed (the default), the strength buffer is passed through
+//! unmodified and the encode is byte-identical to the pre-controller path.
+//!
+//! This is the injection point that future layers of the target-zensim
+//! closed-loop encoder build on:
+//!
+//! - **Layer 2** (this PR): trait + injection point. No reference impl yet.
+//! - **Layer 3** (PR-C): a measurement driver pushes
+//!   [`WindowObservation`]s back to the controller via [`AqController::observe`].
+//! - **Layer 4** (PR-D): `PiAqController` reference implementation.
+//!
+//! The trait surface is intentionally `pub(crate)` until the public
+//! `Quality::TargetZensim` API lands. Reference: GitHub issue #113.
+
+use core::ops::Range;
+
+/// Observation pushed back to the controller from the per-window
+/// measurement loop (Layer 3, PR-C). Carries the iMCU range that was
+/// measured, the *predicted* zensim contribution from the controller's
+/// model, and the *actual* contribution measured from the just-quantized
+/// blocks.
+///
+/// `predicted - measured` is the controller error signal.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Fields are read by Layer 3+; PR-A only constructs/passes.
+pub(crate) struct WindowObservation {
+    /// Range of iMCU rows covered by this observation (half-open).
+    pub imcu_range: Range<usize>,
+    /// Zensim contribution this window actually produced, as accumulated
+    /// by [`zensim::PrecomputedReference`]-backed streaming math.
+    pub measured_zensim_contribution: f32,
+    /// Predicted contribution at the time the controller chose its
+    /// per-iMCU AQ scale. Used as the error baseline.
+    pub predicted_zensim_contribution: f32,
+}
+
+/// Hook for adjusting per-iMCU AQ strengths during a streaming encode.
+///
+/// `adjust` is called once per iMCU row, immediately after `StreamingAQ`
+/// finalizes that iMCU's strengths and before the strip processor
+/// quantizes the corresponding f32 DCT blocks. Implementations may
+/// scale, clamp, or otherwise mutate `strengths` in place.
+///
+/// `observe` is called by the per-window measurement driver (Layer 3,
+/// PR-C) to push measured zensim contributions back to the controller.
+/// Default no-op so simple controllers don't need to implement it.
+///
+/// Intentionally object-safe (`dyn AqController`) — controllers carry
+/// their own state (PI accumulators, classification, etc.) and
+/// `StripProcessor` holds at most one boxed instance. `Debug` is a
+/// supertrait so `StripProcessor`'s `#[derive(Debug)]` keeps working.
+pub(crate) trait AqController: Send + core::fmt::Debug {
+    /// Called once per iMCU row after `StreamingAQ` emits strengths and
+    /// before quantization consumes them.
+    ///
+    /// `strengths` is the slice the strip processor will pass directly
+    /// to `quantize_prev_pending_imcu`; mutations are reflected
+    /// downstream. `imcu_idx` is the 0-based index of the iMCU row this
+    /// call is adjusting (monotonic across the encode).
+    fn adjust(&mut self, strengths: &mut [f32], imcu_idx: usize);
+
+    /// Push a per-window measurement back to the controller. Default
+    /// implementation drops the observation; non-feedback controllers
+    /// (e.g. fixed-bias) don't need to override.
+    ///
+    /// Currently unused — Layer 3 measurement driver lands in PR-C.
+    #[allow(unused_variables, dead_code)]
+    fn observe(&mut self, window: WindowObservation) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A controller that records every `adjust` call. Used by the
+    /// scaffolding test to confirm the trait is wired correctly.
+    #[derive(Debug)]
+    struct RecordingController {
+        seen: Vec<(usize, Vec<f32>)>,
+    }
+    impl AqController for RecordingController {
+        fn adjust(&mut self, strengths: &mut [f32], imcu_idx: usize) {
+            self.seen.push((imcu_idx, strengths.to_vec()));
+        }
+    }
+
+    /// Sanity: the trait is object-safe and a boxed controller can be
+    /// driven through `&mut dyn AqController`.
+    #[test]
+    fn controller_is_object_safe() {
+        let mut ctrl: Box<dyn AqController> = Box::new(RecordingController { seen: vec![] });
+        let mut strengths = [0.1f32, 0.2, 0.3];
+        ctrl.adjust(&mut strengths, 0);
+        ctrl.adjust(&mut strengths, 1);
+        // Push an observation through the default no-op `observe`.
+        ctrl.observe(WindowObservation {
+            imcu_range: 0..2,
+            measured_zensim_contribution: 0.0,
+            predicted_zensim_contribution: 0.0,
+        });
+    }
+
+    /// A controller can scale strengths in place; the change is visible
+    /// to the caller (this is what the strip processor relies on).
+    #[test]
+    fn adjust_scales_in_place() {
+        #[derive(Debug)]
+        struct DoubleEverything;
+        impl AqController for DoubleEverything {
+            fn adjust(&mut self, strengths: &mut [f32], _imcu_idx: usize) {
+                for s in strengths {
+                    *s *= 2.0;
+                }
+            }
+        }
+        let mut ctrl: Box<dyn AqController> = Box::new(DoubleEverything);
+        let mut strengths = [0.10f32, 0.20];
+        ctrl.adjust(&mut strengths, 0);
+        assert_eq!(strengths, [0.20, 0.40]);
+    }
+}

--- a/zenjpeg/src/encode/mod.rs
+++ b/zenjpeg/src/encode/mod.rs
@@ -34,6 +34,7 @@
 // by an unrelated commit on main); wiring it in here makes the file
 // actually reachable.
 mod adaptive;
+pub(crate) mod aq_controller;
 mod blocks;
 #[doc(hidden)]
 pub mod chroma;

--- a/zenjpeg/src/encode/strip/mod.rs
+++ b/zenjpeg/src/encode/strip/mod.rs
@@ -583,6 +583,19 @@ pub struct StripProcessor {
     // === Reusable AQ strengths buffer ===
     /// Buffer for AQ strengths from process_y_strip_into (avoids per-strip allocation)
     aq_strengths_buffer: Vec<f32>,
+
+    // === Per-iMCU AQ controller hook (issue #113, PR-A) ===
+    /// Optional controller invoked between `StreamingAQ` emitting per-iMCU
+    /// strengths and `quantize_prev_pending_imcu` consuming them. `None`
+    /// (default) is the byte-identity path — locked-hash tests verify
+    /// this. Future layers (Layers 3–4 of #113) install a real controller
+    /// to drive a target-zensim closed loop.
+    ///
+    /// Counts iMCU rows for which `adjust` has been called, so the
+    /// controller sees a monotonic 0-based index even when AQ buffers
+    /// arrive in irregular shapes (e.g. zero-length flush at EOI).
+    aq_controller: Option<Box<dyn crate::encode::aq_controller::AqController>>,
+    aq_controller_imcu_idx: usize,
 }
 
 impl StripProcessor {
@@ -873,6 +886,10 @@ impl StripProcessor {
             // Reusable AQ strengths buffer (one iMCU row worth of blocks)
             // Size: blocks_per_row * v_samp_factor (max 2 for 4:2:0)
             aq_strengths_buffer: vec![0.0f32; pending_y_capacity],
+
+            // No AQ controller installed by default (#113 PR-A scaffold).
+            aq_controller: None,
+            aq_controller_imcu_idx: 0,
         })
     }
 
@@ -954,6 +971,30 @@ impl StripProcessor {
     #[cfg(feature = "boundary-rd")]
     pub(crate) fn set_boundary_rd(&mut self, flat: Option<BoundaryRdFlat>) {
         self.boundary_rd = flat.map(BoundaryRdState::new);
+    }
+
+    /// Install a per-iMCU AQ-strength controller (#113 PR-A scaffold).
+    ///
+    /// `Some(ctrl)` enables the hook in `process_strip_common`: the
+    /// controller's `adjust` is invoked once per iMCU row, immediately
+    /// after `StreamingAQ` finalizes that iMCU's strengths and before
+    /// quantization consumes them. `None` (the default) leaves the
+    /// strength buffer untouched — encode is byte-identical to the
+    /// pre-controller path.
+    ///
+    /// The iMCU index passed to `adjust` is reset whenever a new
+    /// controller is installed.
+    ///
+    /// Currently unused inside the crate — wired up by external callers
+    /// in PR-D (target-zensim closed loop). The compiler's dead-code lint
+    /// is silenced until then.
+    #[allow(dead_code)]
+    pub(crate) fn set_aq_controller(
+        &mut self,
+        ctrl: Option<Box<dyn crate::encode::aq_controller::AqController>>,
+    ) {
+        self.aq_controller = ctrl;
+        self.aq_controller_imcu_idx = 0;
     }
 
     /// Sets trellis quantization configuration.
@@ -1211,7 +1252,17 @@ impl StripProcessor {
         // This is the key optimization: quantize to i16 immediately instead of storing f32.
         if let Some(count) = aq_count {
             // Use mem::take to avoid borrow conflict (moves buffer, no allocation)
-            let temp_buffer = std::mem::take(&mut self.aq_strengths_buffer);
+            let mut temp_buffer = std::mem::take(&mut self.aq_strengths_buffer);
+
+            // Per-iMCU AQ controller hook (#113 PR-A). Default is `None`,
+            // which leaves `temp_buffer` untouched — encode is byte-identical
+            // to the pre-controller path. Locked-hash regression tests verify
+            // this is preserved (see tests/bundled/locked_values.rs).
+            if let Some(ctrl) = self.aq_controller.as_mut() {
+                ctrl.adjust(&mut temp_buffer[..count], self.aq_controller_imcu_idx);
+                self.aq_controller_imcu_idx += 1;
+            }
+
             self.quantize_prev_pending_imcu(&temp_buffer[..count]);
             self.aq_strengths_buffer = temp_buffer;
             self.pending.clear_prev();
@@ -2358,6 +2409,70 @@ mod tests {
                 psnr,
                 height
             );
+        }
+    }
+
+    /// AqController scaffold (#113 PR-A): the hook is invoked once per
+    /// iMCU row with a monotonic index. The trait requires `Send`, so
+    /// the test stashes its log in a thread_local instead of `Rc<RefCell>`.
+    /// We exercise the live encode path via `process_strip` and verify
+    /// the controller saw at least one call with monotonic indices and
+    /// non-empty strength slices.
+    #[test]
+    fn aq_controller_hook_is_called_per_imcu() {
+        use crate::encode::aq_controller::AqController;
+        use core::cell::RefCell;
+
+        thread_local! {
+            static LOG: RefCell<Vec<(usize, usize)>> = const { RefCell::new(Vec::new()) };
+        }
+
+        #[derive(Debug)]
+        struct Recorder;
+        impl AqController for Recorder {
+            fn adjust(&mut self, strengths: &mut [f32], imcu_idx: usize) {
+                LOG.with(|l| l.borrow_mut().push((imcu_idx, strengths.len())));
+            }
+        }
+
+        LOG.with(|l| l.borrow_mut().clear());
+
+        let width = 64usize;
+        let height = 64usize;
+        let mut rgb = vec![0u8; width * height * 3];
+        for y in 0..height {
+            for x in 0..width {
+                let idx = (y * width + x) * 3;
+                rgb[idx] = ((x * 4) & 0xFF) as u8;
+                rgb[idx + 1] = ((y * 4) & 0xFF) as u8;
+                rgb[idx + 2] = (((x + y) * 2) & 0xFF) as u8;
+            }
+        }
+
+        let mut processor = StripProcessor::new(width, height, Subsampling::S420, PixelFormat::Rgb)
+            .expect("processor creation");
+        processor.set_aq_controller(Some(Box::new(Recorder)));
+
+        let strip_h = processor.strip_height();
+        for strip_y in (0..height).step_by(strip_h) {
+            let h = strip_h.min(height - strip_y);
+            let row_size = width * 3;
+            let strip = &rgb[strip_y * row_size..(strip_y + h) * row_size];
+            processor
+                .process_strip(strip, strip_y)
+                .expect("process_strip");
+        }
+
+        let log = LOG.with(|l| l.borrow().clone());
+        // 64-row 4:2:0 image is 4 iMCU rows (16 px per iMCU). StreamingAQ
+        // holds back the first iMCU as lookahead for fuzzy erosion, so
+        // the trailing emission lands at flush time (not exercised by
+        // process_strip alone). What this test pins down: the hook
+        // fires, indices are monotonic from 0, slices are non-empty.
+        assert!(!log.is_empty(), "controller adjust never called");
+        for (n, (idx, len)) in log.iter().enumerate() {
+            assert_eq!(*idx, n, "imcu_idx must be monotonic from 0");
+            assert!(*len > 0, "strength slice must not be empty");
         }
     }
 }


### PR DESCRIPTION
PR-A of the target-zensim closed-loop encoder (issue #113). Smallest valuable change — adds the injection point only, no policy yet.

## What

- New `pub(crate)` trait `AqController` in `encode/aq_controller.rs` with `adjust(&mut [f32], imcu_idx)` and a default no-op `observe(WindowObservation)`.
- New field `Option<Box<dyn AqController>>` on `StripProcessor`, plus a monotonic iMCU index.
- `set_aq_controller` setter (also `pub(crate)`).
- Hook fires in `process_strip_common` between `StreamingAQ::process_y_strip_into` and `quantize_prev_pending_imcu`. With `None` (the default), the strength buffer is untouched and encode is byte-identical to today.

## Verification

- 30 locked-hash regression tests pass unchanged with default features.
- `bundled` integration tests pass with default features (1007/1007) and with `parallel,trellis,boundary-rd` (1053/1053).
- Library tests pass with full features (1059/1059).
- Three new tests (`encode::aq_controller::tests::*`, `encode::strip::tests::aq_controller_hook_is_called_per_imcu`) pin: the trait is object-safe, `adjust` mutations flow through, and the hook fires once per iMCU with monotonic indices on the live encode path.

## What this is NOT

- No controller implementation. `PiAqController` lands in PR-D.
- No public API. The trait stays `pub(crate)` until PR-E adds `Quality::TargetZensim`.
- No measurement plumbing. `WindowObservation::observe` exists but is never called yet — PR-C wires the per-window measurement driver.
- No fused parallel encode wiring. That path (`encode/fused_parallel_encode.rs`) has its own AQ pipeline and needs separate design (segments encode out of order, so the controller's per-iMCU monotonic index doesn't apply directly). Out of scope for the streaming controller.

## Diff size

3 files changed, 237 insertions, 1 deletion. Most of it is doc comments + the test.

Closes-as-scoped: part of #113 (full closure on PR-F).