### PR TITLE
refactor(jpeg): unify segment writers via container::marker::write_raw_segment

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,10 +49,8 @@ jobs:
         run: |
           cd ..
           git clone --depth 1 https://github.com/imazen/zencodec.git
-          git clone --depth 1 https://github.com/imazen/ultrahdr.git
           git clone --depth 1 https://github.com/imazen/zenpng.git
           git clone --depth 1 https://github.com/imazen/zenflate.git
-          git clone --depth 1 https://github.com/imazen/zentone.git
 
       - name: Strip non-CI workspace members and deps
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,8 @@ jobs:
         run: |
           cd ..
           git clone --depth 1 https://github.com/imazen/zencodec.git
-          git clone --depth 1 https://github.com/imazen/ultrahdr.git
           git clone --depth 1 https://github.com/imazen/zenpng.git
           git clone --depth 1 https://github.com/imazen/zenflate.git
-          # Path-dep for zenjpeg's `ultrahdr` feature (Bt2446C in
-          # encode_ultrahdr_luma). Unpublished; clone alongside.
-          git clone --depth 1 https://github.com/imazen/zentone.git
 
       - name: Strip non-CI workspace members and deps
         shell: bash
@@ -93,12 +89,8 @@ jobs:
         run: |
           cd ..
           git clone --depth 1 https://github.com/imazen/zencodec.git
-          git clone --depth 1 https://github.com/imazen/ultrahdr.git
           git clone --depth 1 https://github.com/imazen/zenpng.git
           git clone --depth 1 https://github.com/imazen/zenflate.git
-          # Path-dep for zenjpeg's `ultrahdr` feature (Bt2446C in
-          # encode_ultrahdr_luma). Unpublished; clone alongside.
-          git clone --depth 1 https://github.com/imazen/zentone.git
 
       - name: Strip non-CI workspace members and deps
         shell: bash
@@ -108,13 +100,6 @@ jobs:
             -e '/"zjpeg"/d' \
             Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
           sed -e '/^zenresize/d' Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
-          # Replace ultrahdr path deps with published versions for cross
-          # (container can't see ../ultrahdr/). The ultrahdr feature isn't used for
-          # i686 testing, but workspace deps must still resolve.
-          sed \
-            -e 's|ultrahdr-rs = { path = "[^"]*" }|ultrahdr-rs = "0.3"|' \
-            -e 's|ultrahdr-core = { path = "[^"]*", version = "[^"]*", \(.*\)}|ultrahdr-core = { version = "0.3", \1}|' \
-            Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
           sed \
             -e '/jpegli-internals-sys/d' \
             -e '/zenresize.*workspace/d' \
@@ -122,23 +107,6 @@ jobs:
             -e 's/^layout = .*/layout = []/' \
             -e 's/^zennode = .*/zennode = []/' \
             -e 's/, features = \["cjpegli-ffi"\]//' \
-            zenjpeg/Cargo.toml > zenjpeg/Cargo.toml.ci && mv zenjpeg/Cargo.toml.ci zenjpeg/Cargo.toml
-          # Strip path overrides from ultrahdr deps in subcrate (cross can't see sibling repos)
-          sed -e 's|, path = "../../ultrahdr/[^"]*"||g' \
-            zenjpeg/Cargo.toml > zenjpeg/Cargo.toml.ci && mv zenjpeg/Cargo.toml.ci zenjpeg/Cargo.toml
-          # Disable the `ultrahdr` feature: it pulls `ultrahdr-core/zentone` which
-          # only exists in 0.4+; the i686 strip pins 0.3 to keep cross-build cheap.
-          # Replace the feature definition with a no-op so any caller asking for it
-          # fails open instead of breaking workspace metadata resolution.
-          sed -e 's|^ultrahdr = \[.*\]$|ultrahdr = []|' \
-            zenjpeg/Cargo.toml > zenjpeg/Cargo.toml.ci && mv zenjpeg/Cargo.toml.ci zenjpeg/Cargo.toml
-          # Strip the zentone path-dep entirely from both workspace and subcrate.
-          # zentone is unpublished, only referenced from the now-disabled `ultrahdr`
-          # feature, and the cross container can't see ../zentone. The optional
-          # subcrate dep declaration also goes (its only ref was `dep:zentone` in
-          # the stripped feature).
-          sed -e '/^zentone = /d' Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
-          sed -e '/^zentone = /d' \
             zenjpeg/Cargo.toml > zenjpeg/Cargo.toml.ci && mv zenjpeg/Cargo.toml.ci zenjpeg/Cargo.toml
           rm -f Cargo.lock
 
@@ -175,12 +143,8 @@ jobs:
         run: |
           cd ..
           git clone --depth 1 https://github.com/imazen/zencodec.git
-          git clone --depth 1 https://github.com/imazen/ultrahdr.git
           git clone --depth 1 https://github.com/imazen/zenpng.git
           git clone --depth 1 https://github.com/imazen/zenflate.git
-          # Path-dep for zenjpeg's `ultrahdr` feature (Bt2446C in
-          # encode_ultrahdr_luma). Unpublished; clone alongside.
-          git clone --depth 1 https://github.com/imazen/zentone.git
 
       - name: Strip non-CI workspace members and deps
         shell: bash
@@ -260,12 +224,8 @@ jobs:
         run: |
           cd ..
           git clone --depth 1 https://github.com/imazen/zencodec.git
-          git clone --depth 1 https://github.com/imazen/ultrahdr.git
           git clone --depth 1 https://github.com/imazen/zenpng.git
           git clone --depth 1 https://github.com/imazen/zenflate.git
-          # Path-dep for zenjpeg's `ultrahdr` feature (Bt2446C in
-          # encode_ultrahdr_luma). Unpublished; clone alongside.
-          git clone --depth 1 https://github.com/imazen/zentone.git
 
       - name: Strip non-CI workspace members and deps (keep jpegli-internals-sys)
         shell: bash
@@ -350,12 +310,8 @@ jobs:
         run: |
           cd ..
           git clone --depth 1 https://github.com/imazen/zencodec.git
-          git clone --depth 1 https://github.com/imazen/ultrahdr.git
           git clone --depth 1 https://github.com/imazen/zenpng.git
           git clone --depth 1 https://github.com/imazen/zenflate.git
-          # Path-dep for zenjpeg's `ultrahdr` feature (Bt2446C in
-          # encode_ultrahdr_luma). Unpublished; clone alongside.
-          git clone --depth 1 https://github.com/imazen/zentone.git
 
       - name: Strip non-CI workspace members and deps
         shell: bash
@@ -365,7 +321,6 @@ jobs:
             -e '/"zjpeg"/d' \
             Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
           sed -e '/^zenresize/d' Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
-          # ultrahdr path deps kept — sibling repos are cloned above
           sed \
             -e '/jpegli-internals-sys/d' \
             -e '/zenresize.*workspace/d' \
@@ -400,12 +355,8 @@ jobs:
         run: |
           cd ..
           git clone --depth 1 https://github.com/imazen/zencodec.git
-          git clone --depth 1 https://github.com/imazen/ultrahdr.git
           git clone --depth 1 https://github.com/imazen/zenpng.git
           git clone --depth 1 https://github.com/imazen/zenflate.git
-          # Path-dep for zenjpeg's `ultrahdr` feature (Bt2446C in
-          # encode_ultrahdr_luma). Unpublished; clone alongside.
-          git clone --depth 1 https://github.com/imazen/zentone.git
 
       - name: Strip non-CI workspace members and deps
         shell: bash
@@ -415,7 +366,6 @@ jobs:
             -e '/"zjpeg"/d' \
             Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
           sed -e '/^zenresize/d' Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
-          # ultrahdr path deps kept — sibling repos are cloned above
           sed \
             -e '/zenresize.*workspace/d' \
             -e '/zennode.*path/d' \
@@ -442,12 +392,8 @@ jobs:
         run: |
           cd ..
           git clone --depth 1 https://github.com/imazen/zencodec.git
-          git clone --depth 1 https://github.com/imazen/ultrahdr.git
           git clone --depth 1 https://github.com/imazen/zenpng.git
           git clone --depth 1 https://github.com/imazen/zenflate.git
-          # Path-dep for zenjpeg's `ultrahdr` feature (Bt2446C in
-          # encode_ultrahdr_luma). Unpublished; clone alongside.
-          git clone --depth 1 https://github.com/imazen/zentone.git
 
       - name: Strip non-CI workspace members and deps
         shell: bash
@@ -457,7 +403,6 @@ jobs:
             -e '/"zjpeg"/d' \
             Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
           sed -e '/^zenresize/d' Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
-          # ultrahdr path deps kept — sibling repos are cloned above
           sed \
             -e '/jpegli-internals-sys/d' \
             -e '/zenresize.*workspace/d' \
@@ -488,12 +433,8 @@ jobs:
         run: |
           cd ..
           git clone --depth 1 https://github.com/imazen/zencodec.git
-          git clone --depth 1 https://github.com/imazen/ultrahdr.git
           git clone --depth 1 https://github.com/imazen/zenpng.git
           git clone --depth 1 https://github.com/imazen/zenflate.git
-          # Path-dep for zenjpeg's `ultrahdr` feature (Bt2446C in
-          # encode_ultrahdr_luma). Unpublished; clone alongside.
-          git clone --depth 1 https://github.com/imazen/zentone.git
 
       - name: Strip non-CI workspace members and deps
         shell: bash
@@ -503,7 +444,6 @@ jobs:
             -e '/"zjpeg"/d' \
             Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
           sed -e '/^zenresize/d' Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
-          # ultrahdr path deps kept — sibling repos are cloned above
           sed \
             -e '/jpegli-internals-sys/d' \
             -e '/zenresize.*workspace/d' \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,10 +33,8 @@ jobs:
         run: |
           cd ..
           git clone --depth 1 https://github.com/imazen/zencodec.git
-          git clone --depth 1 https://github.com/imazen/ultrahdr.git
           git clone --depth 1 https://github.com/imazen/zenpng.git
           git clone --depth 1 https://github.com/imazen/zenflate.git
-          git clone --depth 1 https://github.com/imazen/zentone.git
 
       - name: Strip non-CI workspace members and deps
         shell: bash
@@ -105,10 +103,8 @@ jobs:
         run: |
           cd ..
           git clone --depth 1 https://github.com/imazen/zencodec.git
-          git clone --depth 1 https://github.com/imazen/ultrahdr.git
           git clone --depth 1 https://github.com/imazen/zenpng.git
           git clone --depth 1 https://github.com/imazen/zenflate.git
-          git clone --depth 1 https://github.com/imazen/zentone.git
 
       - name: Strip non-CI workspace members and deps
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,8 @@ jobs:
         run: |
           cd ..
           git clone --depth 1 https://github.com/imazen/zencodec.git
-          git clone --depth 1 https://github.com/imazen/ultrahdr.git
           git clone --depth 1 https://github.com/imazen/zenpng.git
           git clone --depth 1 https://github.com/imazen/zenflate.git
-          git clone --depth 1 https://github.com/imazen/zentone.git
 
       - name: Strip non-CI workspace members and deps
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,6 +2350,8 @@ dependencies = [
 [[package]]
 name = "ultrahdr-core"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d65bd22a90785bb7360076b599ffbc201aef2c5817d2e5f37f37357829d476e"
 dependencies = [
  "archmage 0.9.22",
  "bytemuck",
@@ -3271,6 +3273,8 @@ dependencies = [
 [[package]]
 name = "zentone"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c602cc9010340287fd4ffcb2cd1ae9f6a665d37db59f0b9578352788cf8b304"
 dependencies = [
  "archmage 0.9.22",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,17 +100,12 @@ img-parts = "0.4"
 # Half-precision floating point
 half = { version = "2.7.1", default-features = false }
 
-# Tone-mapping curves (Bt2446C default for encode_ultrahdr_luma). Path-pinned
-# until 0.1.x publishes; CI clones the sibling repo via the same pattern as
-# ultrahdr-core.
-zentone = { path = "../zentone", version = "0.1", default-features = false }
+# Tone-mapping curves (Bt2446C default for encode_ultrahdr_luma).
+zentone = { version = "0.1", default-features = false }
 
 # Our ultrahdr crates
 ultrahdr-rs = "0.3.5"
-# Sibling-path pin for in-flight ultrahdr-core 0.5.0 (`metadata::*` modules
-# deleted in PR imazen/ultrahdr#12, parsers rehomed in zencodec::gainmap +
-# zenjpeg::container::xmp). Drop the path once 0.5.0 publishes.
-ultrahdr-core = { path = "../ultrahdr/ultrahdr-core", version = "0.5", default-features = false }
+ultrahdr-core = { version = "0.5", default-features = false }
 
 # Resize pipeline. Constraint solver (FitMode) and EXIF-orientation bridge
 # both live in zenresize 0.3+. zenlayout is no longer used anywhere in this

--- a/zenjpeg/Cargo.toml
+++ b/zenjpeg/Cargo.toml
@@ -198,7 +198,8 @@ __wasm-simd = []
 # now mandatory there); container/metadata parsers moved to zencodec::gainmap
 # + zenjpeg::container::xmp; types fold to zenpixels (PixelFormat,
 # ColorPrimaries, TransferFunction, PixelBuffer).
-ultrahdr = ["decoder", "ultrahdr-core/std", "dep:half", "dep:zentone"]
+# `tonemap` pulls in zentone for AdaptiveTonemapper / FitConfig / ToneMapConfig.
+ultrahdr = ["decoder", "ultrahdr-core/std", "ultrahdr-core/tonemap", "dep:half", "dep:zentone"]
 # zencodec trait implementations (EncoderConfig, DecoderConfig, etc.)
 zencodec = ["decoder"]
 # Layout pipeline: lossless transforms + lossy decode→resize→encode.

--- a/zenjpeg/src/analyze/tier2_chroma.rs
+++ b/zenjpeg/src/analyze/tier2_chroma.rs
@@ -98,8 +98,11 @@ fn image_sharpness_breakdown(
     stream.fetch_into(1, &mut row1);
     stream.fetch_into(2, &mut row2);
 
-    let mut sumh: (usize, usize) = (0, 0);
-    let mut sumv: (usize, usize) = (0, 0);
+    // u64 (not usize) so 32-bit builds don't overflow:
+    // gradient_diff_ycbcr can return values up to ~437K per pixel, and
+    // fragments span thousands of pixels — summing in usize=u32 wraps.
+    let mut sumh: (u64, u64) = (0, 0);
+    let mut sumv: (u64, u64) = (0, 0);
     let mut max_sumh: (u32, u32) = (0, 0);
     let mut max_sumv: (u32, u32) = (0, 0);
     let mut max_diff: (u32, u32) = (0, 0);
@@ -140,15 +143,15 @@ fn image_sharpness_breakdown(
                 max_diff.1 = h.1;
             }
 
-            sumh.0 += h.0 as usize;
-            sumh.1 += h.1 as usize;
-            sumv.0 += v.0 as usize;
-            sumv.1 += v.1 as usize;
+            sumh.0 += h.0 as u64;
+            sumh.1 += h.1 as u64;
+            sumv.0 += v.0 as u64;
+            sumv.1 += v.1 as u64;
         }
 
         fragment_height += 1;
         if fragment_height >= fragment_max_height {
-            let denom = fragment_height * width;
+            let denom = (fragment_height * width) as u64;
             max_sumh.0 = max_sumh.0.max((sumh.0 / denom) as u32);
             max_sumh.1 = max_sumh.1.max((sumh.1 / denom) as u32);
             max_sumv.0 = max_sumv.0.max((sumv.0 / denom) as u32);
@@ -170,7 +173,7 @@ fn image_sharpness_breakdown(
         stream.fetch_into(need_y2 as u32, &mut row2);
     }
     if fragment_height > 16 {
-        let denom = fragment_height * width;
+        let denom = (fragment_height * width) as u64;
         max_sumh.0 = max_sumh.0.max((sumh.0 / denom) as u32);
         max_sumh.1 = max_sumh.1.max((sumh.1 / denom) as u32);
         max_sumv.0 = max_sumv.0.max((sumv.0 / denom) as u32);

--- a/zenjpeg/src/container/marker.rs
+++ b/zenjpeg/src/container/marker.rs
@@ -457,6 +457,41 @@ fn skip_entropy_scan(data: &[u8], start: usize) -> usize {
 // APP segment writer
 // ───────────────────────────────────────────────────────────────────────
 
+/// Append a raw JPEG marker segment (`0xFF <marker>` + `u16 BE` length +
+/// `identifier` + `payload`) to `dst`.
+///
+/// This is the canonical segment writer. `marker` is the second marker
+/// byte (e.g., `0xE0..=0xEF` for APPn, `0xFE` for COM). `identifier` is
+/// the optional per-segment namespace tag and may be empty when callers
+/// have already concatenated it into `payload`. `payload` is everything
+/// after the identifier.
+///
+/// The length word counts itself + identifier + payload (JPEG
+/// convention). Total segment size is `4 + identifier.len() + payload.len()`
+/// bytes. No intermediate allocation — writes straight into `dst`.
+///
+/// Use [`append_app_segment`] when you specifically need APP0..APP15
+/// with index validation. For COM, DRI, or other non-APP markers, call
+/// this directly.
+///
+/// # Panics
+///
+/// - If `2 + identifier.len() + payload.len() > u16::MAX as usize`
+///   (JPEG segments cap at `u16::MAX` including the length word;
+///   callers must split oversize content into multiple segments).
+pub(crate) fn write_raw_segment(dst: &mut Vec<u8>, marker: u8, identifier: &[u8], payload: &[u8]) {
+    let length_field = 2 + identifier.len() + payload.len();
+    let length_u16: u16 = length_field
+        .try_into()
+        .expect("JPEG segment exceeds u16::MAX length");
+    dst.reserve(2 + length_field);
+    dst.push(0xFF);
+    dst.push(marker);
+    dst.extend_from_slice(&length_u16.to_be_bytes());
+    dst.extend_from_slice(identifier);
+    dst.extend_from_slice(payload);
+}
+
 /// Append a JPEG `APPn` segment (`0xFF 0xE<n>` + `u16 BE` length +
 /// `identifier` + `payload`) to `dst`.
 ///
@@ -465,9 +500,7 @@ fn skip_entropy_scan(data: &[u8], start: usize) -> usize {
 /// for XMP, `"MPF\0"` for MPF, [`zencodec::ISO_21496_1_URN`] for ISO
 /// 21496-1). `payload` is everything after the identifier.
 ///
-/// The length word counts itself + identifier + payload (JPEG
-/// convention). Total segment size is `4 + identifier.len() + payload.len()`
-/// bytes. No intermediate allocation — writes straight into `dst`.
+/// Thin wrapper over [`write_raw_segment`] that validates the APP index.
 ///
 /// # Panics
 ///
@@ -482,16 +515,7 @@ pub(crate) fn append_app_segment(
     payload: &[u8],
 ) {
     assert!(app_index <= 15, "APP index must be 0..=15, got {app_index}");
-    let length_field = 2 + identifier.len() + payload.len();
-    let length_u16: u16 = length_field
-        .try_into()
-        .expect("APP segment exceeds u16::MAX length");
-    dst.reserve(2 + length_field);
-    dst.push(0xFF);
-    dst.push(0xE0 | app_index);
-    dst.extend_from_slice(&length_u16.to_be_bytes());
-    dst.extend_from_slice(identifier);
-    dst.extend_from_slice(payload);
+    write_raw_segment(dst, 0xE0 | app_index, identifier, payload);
 }
 
 /// Vec-returning variant of [`append_app_segment`].
@@ -812,11 +836,63 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "APP segment exceeds u16::MAX")]
+    #[should_panic(expected = "JPEG segment exceeds u16::MAX")]
     fn append_app_segment_rejects_oversize_payload() {
         let mut out = Vec::new();
         let big = vec![0u8; u16::MAX as usize];
         append_app_segment(&mut out, 2, b"id", &big);
+    }
+
+    #[test]
+    fn write_raw_segment_com_marker_no_identifier() {
+        let mut out = Vec::new();
+        write_raw_segment(&mut out, 0xFE, &[], b"COM data");
+        assert_eq!(out[0], 0xFF);
+        assert_eq!(out[1], 0xFE);
+        let length = u16::from_be_bytes([out[2], out[3]]);
+        assert_eq!(length as usize, 2 + b"COM data".len());
+        assert_eq!(&out[4..], b"COM data");
+    }
+
+    #[test]
+    fn write_raw_segment_with_identifier() {
+        let mut out = Vec::new();
+        write_raw_segment(&mut out, 0xE1, b"Exif\0\0", b"payload");
+        assert_eq!(out[0], 0xFF);
+        assert_eq!(out[1], 0xE1);
+        let length = u16::from_be_bytes([out[2], out[3]]);
+        assert_eq!(length as usize, 2 + b"Exif\0\0".len() + b"payload".len());
+        assert_eq!(&out[4..10], b"Exif\0\0");
+        assert_eq!(&out[10..], b"payload");
+    }
+
+    #[test]
+    fn write_raw_segment_matches_inline_legacy_layout() {
+        // Mirror the legacy write_segment behaviour: caller pre-concatenated
+        // identifier into payload, identifier slice is empty.
+        let pre_concat: Vec<u8> = b"MPF\0directory_bytes".to_vec();
+        let mut new_out = Vec::new();
+        write_raw_segment(&mut new_out, 0xE2, &[], &pre_concat);
+
+        // Hand-rolled equivalent of the old inline writer.
+        let mut legacy = Vec::new();
+        legacy.push(0xFF);
+        legacy.push(0xE2);
+        let length = (pre_concat.len() + 2) as u16;
+        legacy.push((length >> 8) as u8);
+        legacy.push(length as u8);
+        legacy.extend_from_slice(&pre_concat);
+
+        assert_eq!(new_out, legacy);
+    }
+
+    #[test]
+    fn write_raw_segment_matches_append_app_segment() {
+        let mut via_raw = Vec::new();
+        write_raw_segment(&mut via_raw, 0xE2, b"MPF\0", b"directory");
+        let mut via_app = Vec::new();
+        append_app_segment(&mut via_app, 2, b"MPF\0", b"directory");
+        assert_eq!(via_raw, via_app);
     }
 
     #[test]

--- a/zenjpeg/src/encode/extras.rs
+++ b/zenjpeg/src/encode/extras.rs
@@ -731,13 +731,13 @@ fn detect_segment_type(marker: u8, data: &[u8]) -> SegmentType {
 }
 
 /// Write a single segment to output buffer.
+///
+/// Thin wrapper over [`crate::container::marker::write_raw_segment`].
+/// Callers pass the full segment body (identifier + payload already
+/// concatenated into `data`); the empty-identifier delegation keeps
+/// byte output identical to the legacy inline writer.
 pub(crate) fn write_segment(output: &mut Vec<u8>, marker: u8, data: &[u8]) {
-    output.push(0xFF);
-    output.push(marker);
-    let length = (data.len() + 2) as u16;
-    output.push((length >> 8) as u8);
-    output.push(length as u8);
-    output.extend_from_slice(data);
+    crate::container::marker::write_raw_segment(output, marker, &[], data);
 }
 
 /// Write all encoder segments to output buffer (in correct order).


### PR DESCRIPTION
## Summary

- Adds `container::marker::write_raw_segment(dst, marker, identifier, payload)` as the canonical JPEG `FF <marker> <len> <id> <payload>` writer.
- Refactors `encode::extras::write_segment` (10 call sites) to delegate with empty identifier — byte-identical to the legacy inline cast-based writer.
- Refactors `container::marker::append_app_segment` to forward to `write_raw_segment` after its `app_index <= 15` assert.

Closes #106.

## Why

Three nearly identical implementations of the same shape — `encode::extras::write_segment`, the inline writer in `container::marker::append_app_segment`, and the wrappers in `container::xmp` / `container::mpf`. XMP/MPF/`create_app_segment` already delegated to `append_app_segment`, so this is the last hop: drop the duplicate length arithmetic out of `extras.rs` and route everything through one canonical writer.

The length-overflow panic message generalized from `"APP segment exceeds u16::MAX"` to `"JPEG segment exceeds u16::MAX"` (the writer is no longer APP-specific).

## Test plan

- [x] `cargo test -p zenjpeg --release --lib container::marker::tests` — 32 pass (4 new tests)
- [x] `cargo test -p zenjpeg --release --lib` — 938 pass, 1 ignored
- [x] `cargo test -p zenjpeg --release --tests` — all integration tests pass; **all locked-hash suites green** (`ycbcr_locked`, `cpp_parity_locked`, `locked_values`, `parity_reference_locked`, `frymire_hash_locked`) confirming byte-identical encoder output.
- [x] New unit tests cover: COM marker with empty identifier, APPn with identifier, legacy-inline-writer equivalence, and `append_app_segment` parity through the new path.
- [ ] CI verification across windows-11-arm, macos-intel, i686-linux.

## Notes

- The original issue references `container/iso21496.rs`; the file is `container/marker.rs`. Worth a one-line edit to the issue body.
- Public API surface unchanged — both functions are `pub(crate)`.