### PR TITLE
feat(encode): Quality::Zq target-perceptual-quality API + AqController (#113)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ zune-jpeg = "0.5"      # Reference decoder for comparison (fastest pure Rust)
 # Quality metrics
 dssim-core = "3.4"
 fast-ssim2 = { version = "0.8.0", features = ["imgref"] }
+# Used by zenjpeg's Quality::Zq target-perceptual-quality closed loop and
+# by various dev-only test/measurement examples.
+zensim = { version = "0.2.6" }
 rayon = "1.10"
 
 # Color conversion (for benchmarking/comparison - faster than libyuv)

--- a/zenjpeg/Cargo.toml
+++ b/zenjpeg/Cargo.toml
@@ -93,6 +93,9 @@ zentone = { workspace = true, optional = true }
 zenresize = { workspace = true, optional = true }
 # Self-documenting node definitions for pipeline integration
 # zennode = { path = "../../zennode/zennode", optional = true, default-features = false, features = ["derive"] }
+# Perceptual metric used by Quality::Zq target-perceptual-quality variants
+# (issue #113). Pulled in only when the `target-zq` feature is enabled.
+zensim = { workspace = true, optional = true }
 
 [dev-dependencies]
 wide = { workspace = true }
@@ -207,6 +210,11 @@ __wasm-simd = []
 ultrahdr = ["decoder", "ultrahdr-core/std", "ultrahdr-core/tonemap", "dep:half", "dep:zentone"]
 # zencodec trait implementations (EncoderConfig, DecoderConfig, etc.)
 zencodec = ["decoder"]
+# Target-perceptual-quality (`Quality::Zq` / `Quality::ZqExplicit`) closed-loop
+# encoder. Iterates encode + decode + zensim diffmap to land at a perceptual
+# score target (issue #113). Pulls in `decoder` (for re-decoding each pass)
+# and the zensim crate (for the perceptual metric).
+target-zq = ["decoder", "dep:zensim"]
 # Layout pipeline: lossless transforms + lossy decode→resize→encode.
 # Geometry/constraint solving (FitMode) and EXIF-orientation bridge live in
 # zenresize itself; orientation group algebra comes from zenpixels (re-exported

--- a/zenjpeg/src/encode/adaptive.rs
+++ b/zenjpeg/src/encode/adaptive.rs
@@ -320,9 +320,14 @@ impl AdaptiveMetric {
     fn from_quality(q: &Quality) -> Self {
         match q {
             Quality::ApproxButteraugli(_) => AdaptiveMetric::Butter,
-            Quality::ApproxSsim2(_) | Quality::ApproxJpegli(_) | Quality::ApproxMozjpeg(_) => {
-                AdaptiveMetric::Ssim2
-            }
+            // Zq is calibrated against zensim, which is the same family
+            // as ssim2 (multi-scale perceptual). The adaptive oracle's
+            // ssim2 trees are the closest behavioral match.
+            Quality::ApproxSsim2(_)
+            | Quality::ApproxJpegli(_)
+            | Quality::ApproxMozjpeg(_)
+            | Quality::Zq(_)
+            | Quality::ZqExplicit(_) => AdaptiveMetric::Ssim2,
         }
     }
 }

--- a/zenjpeg/src/encode/aq_controller.rs
+++ b/zenjpeg/src/encode/aq_controller.rs
@@ -1,0 +1,126 @@
+//! Per-iMCU AQ-strength controller hook (issue #113, PR-A scaffold).
+//!
+//! Sits between [`StreamingAQ`](crate::quant::aq::streaming::StreamingAQ)
+//! emitting per-iMCU AQ strengths and [`StripProcessor::quantize_prev_pending_imcu`]
+//! consuming them. A controller may scale the strengths in place; with no
+//! controller installed (the default), the strength buffer is passed through
+//! unmodified and the encode is byte-identical to the pre-controller path.
+//!
+//! This is the injection point that future layers of the target-zensim
+//! closed-loop encoder build on:
+//!
+//! - **Layer 2** (this PR): trait + injection point. No reference impl yet.
+//! - **Layer 3** (PR-C): a measurement driver pushes
+//!   [`WindowObservation`]s back to the controller via [`AqController::observe`].
+//! - **Layer 4** (PR-D): `PiAqController` reference implementation.
+//!
+//! The trait surface is intentionally `pub(crate)` until the public
+//! `Quality::TargetZensim` API lands. Reference: GitHub issue #113.
+
+use core::ops::Range;
+
+/// Observation pushed back to the controller from the per-window
+/// measurement loop (Layer 3, PR-C). Carries the iMCU range that was
+/// measured, the *predicted* zensim contribution from the controller's
+/// model, and the *actual* contribution measured from the just-quantized
+/// blocks.
+///
+/// `predicted - measured` is the controller error signal.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Fields are read by Layer 3+; PR-A only constructs/passes.
+pub(crate) struct WindowObservation {
+    /// Range of iMCU rows covered by this observation (half-open).
+    pub imcu_range: Range<usize>,
+    /// Zensim contribution this window actually produced, as accumulated
+    /// by [`zensim::PrecomputedReference`]-backed streaming math.
+    pub measured_zensim_contribution: f32,
+    /// Predicted contribution at the time the controller chose its
+    /// per-iMCU AQ scale. Used as the error baseline.
+    pub predicted_zensim_contribution: f32,
+}
+
+/// Hook for adjusting per-iMCU AQ strengths during a streaming encode.
+///
+/// `adjust` is called once per iMCU row, immediately after `StreamingAQ`
+/// finalizes that iMCU's strengths and before the strip processor
+/// quantizes the corresponding f32 DCT blocks. Implementations may
+/// scale, clamp, or otherwise mutate `strengths` in place.
+///
+/// `observe` is called by the per-window measurement driver (Layer 3,
+/// PR-C) to push measured zensim contributions back to the controller.
+/// Default no-op so simple controllers don't need to implement it.
+///
+/// Intentionally object-safe (`dyn AqController`) — controllers carry
+/// their own state (PI accumulators, classification, etc.) and
+/// `StripProcessor` holds at most one boxed instance. `Debug` is a
+/// supertrait so `StripProcessor`'s `#[derive(Debug)]` keeps working.
+pub(crate) trait AqController: Send + core::fmt::Debug {
+    /// Called once per iMCU row after `StreamingAQ` emits strengths and
+    /// before quantization consumes them.
+    ///
+    /// `strengths` is the slice the strip processor will pass directly
+    /// to `quantize_prev_pending_imcu`; mutations are reflected
+    /// downstream. `imcu_idx` is the 0-based index of the iMCU row this
+    /// call is adjusting (monotonic across the encode).
+    fn adjust(&mut self, strengths: &mut [f32], imcu_idx: usize);
+
+    /// Push a per-window measurement back to the controller. Default
+    /// implementation drops the observation; non-feedback controllers
+    /// (e.g. fixed-bias) don't need to override.
+    ///
+    /// Currently unused — Layer 3 measurement driver lands in PR-C.
+    #[allow(unused_variables, dead_code)]
+    fn observe(&mut self, window: WindowObservation) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A controller that records every `adjust` call. Used by the
+    /// scaffolding test to confirm the trait is wired correctly.
+    #[derive(Debug)]
+    struct RecordingController {
+        seen: Vec<(usize, Vec<f32>)>,
+    }
+    impl AqController for RecordingController {
+        fn adjust(&mut self, strengths: &mut [f32], imcu_idx: usize) {
+            self.seen.push((imcu_idx, strengths.to_vec()));
+        }
+    }
+
+    /// Sanity: the trait is object-safe and a boxed controller can be
+    /// driven through `&mut dyn AqController`.
+    #[test]
+    fn controller_is_object_safe() {
+        let mut ctrl: Box<dyn AqController> = Box::new(RecordingController { seen: vec![] });
+        let mut strengths = [0.1f32, 0.2, 0.3];
+        ctrl.adjust(&mut strengths, 0);
+        ctrl.adjust(&mut strengths, 1);
+        // Push an observation through the default no-op `observe`.
+        ctrl.observe(WindowObservation {
+            imcu_range: 0..2,
+            measured_zensim_contribution: 0.0,
+            predicted_zensim_contribution: 0.0,
+        });
+    }
+
+    /// A controller can scale strengths in place; the change is visible
+    /// to the caller (this is what the strip processor relies on).
+    #[test]
+    fn adjust_scales_in_place() {
+        #[derive(Debug)]
+        struct DoubleEverything;
+        impl AqController for DoubleEverything {
+            fn adjust(&mut self, strengths: &mut [f32], _imcu_idx: usize) {
+                for s in strengths {
+                    *s *= 2.0;
+                }
+            }
+        }
+        let mut ctrl: Box<dyn AqController> = Box::new(DoubleEverything);
+        let mut strengths = [0.10f32, 0.20];
+        ctrl.adjust(&mut strengths, 0);
+        assert_eq!(strengths, [0.20, 0.40]);
+    }
+}

--- a/zenjpeg/src/encode/byte_encoders.rs
+++ b/zenjpeg/src/encode/byte_encoders.rs
@@ -15,7 +15,13 @@ use crate::error::{Error, Result};
 /// Encoder for raw byte input with explicit pixel layout.
 ///
 /// This encoder wraps `StreamingEncoder` to provide true streaming encoding
-/// without buffering the entire image in memory.
+/// without buffering the entire image in memory — except when the
+/// configured [`super::encoder_types::Quality`] is a target-perceptual-
+/// quality variant ([`super::encoder_types::Quality::Zq`] or
+/// [`super::encoder_types::Quality::ZqExplicit`]). In those modes the
+/// encoder must re-encode the same image multiple times to converge on
+/// the perceptual target, so it buffers all incoming pixels until
+/// [`Self::finish_with_metrics`] is called.
 pub struct BytesEncoder {
     /// v2 config (no longer holds metadata)
     config: EncoderConfig,
@@ -24,7 +30,7 @@ pub struct BytesEncoder {
     /// Image dimensions
     width: u32,
     height: u32,
-    /// Inner streaming encoder (handles actual encoding)
+    /// Inner streaming encoder (handles actual encoding when NOT in Zq mode).
     inner: StreamingEncoder,
     /// ICC profile (per-image metadata)
     icc_profile: Option<alloc::vec::Vec<u8>>,
@@ -32,6 +38,12 @@ pub struct BytesEncoder {
     exif_data: Option<super::exif::Exif>,
     /// XMP data (per-image metadata)
     xmp_data: Option<alloc::vec::Vec<u8>>,
+    /// Pixel buffer for the closed-loop target-zq iteration path.
+    /// `Some` when `config.quality.is_zq_target()`; pushes route into
+    /// here instead of the inner streaming encoder. `None` for the
+    /// regular streaming path — pushes go straight into `inner`.
+    /// Capacity = `width * height * bytes_per_pixel`.
+    zq_pixel_buffer: Option<alloc::vec::Vec<u8>>,
 }
 
 impl BytesEncoder {
@@ -69,8 +81,33 @@ impl BytesEncoder {
             ));
         }
 
-        // Build and start the streaming encoder with config from v2
+        // Build and start the streaming encoder with config from v2.
+        //
+        // For target-zq quality variants, the inner encoder is built using
+        // `Quality::to_internal()` (which resolves Zq → starting jpegli q).
+        // It serves as the pass-0 encoder when the iteration loop runs.
         let inner = Self::build_streaming_encoder(&config, width, height, layout)?;
+
+        // When in target-zq mode AND the `target-zq` feature is enabled,
+        // allocate a pixel buffer so we can re-encode the same image
+        // across iteration passes. The streaming path is bypassed
+        // entirely in that case (see `push`/`push_packed`). Without the
+        // feature, Zq variants degrade to ApproxJpegli at the resolved
+        // starting quality (no iteration, no measurement).
+        let zq_pixel_buffer = if cfg!(feature = "target-zq") && config.quality.is_zq_target() {
+            let bpp = layout.bytes_per_pixel();
+            let total = (width as usize)
+                .checked_mul(height as usize)
+                .and_then(|n| n.checked_mul(bpp))
+                .ok_or_else(|| Error::invalid_dimensions(width, height, "buffer size overflow"))?;
+            let mut buf = alloc::vec::Vec::new();
+            buf.try_reserve_exact(total).map_err(|_| {
+                Error::invalid_dimensions(width, height, "could not allocate Zq pixel buffer")
+            })?;
+            Some(buf)
+        } else {
+            None
+        };
 
         Ok(Self {
             config,
@@ -81,6 +118,7 @@ impl BytesEncoder {
             icc_profile,
             exif_data,
             xmp_data,
+            zq_pixel_buffer,
         })
     }
 
@@ -208,8 +246,13 @@ impl BytesEncoder {
             return Err(Error::stride_too_small(self.width, stride_bytes));
         }
 
-        // Validate row count
-        let current_rows = self.inner.rows_pushed() as u32;
+        // Validate row count. In Zq mode, rows pushed are tracked by the
+        // buffer length; in streaming mode, by the inner encoder.
+        let current_rows: u32 = if let Some(buf) = &self.zq_pixel_buffer {
+            (buf.len() / min_stride) as u32
+        } else {
+            self.inner.rows_pushed() as u32
+        };
         let new_total = current_rows + rows as u32;
         if new_total > self.height {
             return Err(Error::too_many_rows(self.height, new_total));
@@ -221,13 +264,22 @@ impl BytesEncoder {
             return Err(Error::invalid_buffer_size(expected_size, data.len()));
         }
 
-        // Push rows to streaming encoder
-        if stride_bytes == min_stride {
-            // Packed data - can push directly
+        if let Some(buf) = self.zq_pixel_buffer.as_mut() {
+            // Target-zq path: store packed rows for later iteration.
+            for row in 0..rows {
+                if stop.should_stop() {
+                    return Err(Error::cancelled());
+                }
+                let src_start = row * stride_bytes;
+                let src_end = src_start + min_stride;
+                buf.extend_from_slice(&data[src_start..src_end]);
+            }
+        } else if stride_bytes == min_stride {
+            // Streaming path, packed data — direct push.
             self.inner
                 .push_rows_with_stop(&data[..rows * min_stride], rows, &stop)?;
         } else {
-            // Strided data - push row by row
+            // Streaming path, strided data — row by row.
             for row in 0..rows {
                 if stop.should_stop() {
                     return Err(Error::cancelled());
@@ -294,13 +346,23 @@ impl BytesEncoder {
     /// Get number of rows pushed so far.
     #[must_use]
     pub fn rows_pushed(&self) -> u32 {
-        self.inner.rows_pushed() as u32
+        if let Some(buf) = &self.zq_pixel_buffer {
+            let bpp = self.layout.bytes_per_pixel();
+            let row_bytes = self.width as usize * bpp;
+            if row_bytes == 0 {
+                0
+            } else {
+                (buf.len() / row_bytes) as u32
+            }
+        } else {
+            self.inner.rows_pushed() as u32
+        }
     }
 
     /// Get number of rows remaining.
     #[must_use]
     pub fn rows_remaining(&self) -> u32 {
-        self.height - self.inner.rows_pushed() as u32
+        self.height - self.rows_pushed()
     }
 
     /// Get allocation statistics from the strip processor.
@@ -317,10 +379,32 @@ impl BytesEncoder {
         self.layout
     }
 
+    /// Install a per-iMCU `AqController` on the inner streaming encoder.
+    /// Used by the target-zq iteration loop in [`super::zq`] to scale
+    /// streaming AQ multiplicatively between passes. Not exposed
+    /// publicly — the public API is [`super::Quality::Zq`].
+    #[allow(dead_code)] // wired only on the Zq path; #[cfg(test)] callers exist via __test-utils.
+    pub(crate) fn set_aq_controller(
+        &mut self,
+        ctrl: Option<Box<dyn super::aq_controller::AqController>>,
+    ) {
+        self.inner.set_aq_controller(ctrl);
+    }
+
     // === Finish ===
 
     /// Finish encoding, return JPEG bytes.
+    ///
+    /// For target-zq quality variants, this transparently routes through
+    /// [`Self::finish_with_metrics`] and discards the metrics — call
+    /// `finish_with_metrics` directly if you need them.
     pub fn finish(self) -> Result<Vec<u8>> {
+        // Target-zq path: iteration loop owns finishing.
+        #[cfg(feature = "target-zq")]
+        if self.zq_pixel_buffer.is_some() {
+            let (bytes, _metrics) = self.finish_with_metrics()?;
+            return Ok(bytes);
+        }
         let mut output = Vec::new();
         self.finish_into(&mut output)?;
         Ok(output)
@@ -331,6 +415,9 @@ impl BytesEncoder {
     /// This is the most efficient way to complete encoding as it avoids
     /// intermediate allocations. The buffer is cleared before writing.
     ///
+    /// For target-zq quality variants, transparently routes through
+    /// [`Self::finish_with_metrics`].
+    ///
     /// # Example
     ///
     /// ```rust,ignore
@@ -339,6 +426,14 @@ impl BytesEncoder {
     /// // output now contains the JPEG data
     /// ```
     pub fn finish_into(mut self, output: &mut Vec<u8>) -> Result<()> {
+        // Target-zq path: iteration writes its own bytes.
+        #[cfg(feature = "target-zq")]
+        if self.zq_pixel_buffer.is_some() {
+            let (bytes, _metrics) = self.finish_with_metrics()?;
+            output.clear();
+            output.extend_from_slice(&bytes);
+            return Ok(());
+        }
         let rows_pushed = self.inner.rows_pushed() as u32;
         if rows_pushed != self.height {
             return Err(Error::incomplete_image(self.height, rows_pushed));
@@ -428,6 +523,80 @@ impl BytesEncoder {
         self.finish_into(&mut jpeg)?;
         output.write_all(&jpeg)?;
         Ok(output)
+    }
+
+    /// Finish encoding and return JPEG bytes plus
+    /// [`super::zq::EncodeMetrics`].
+    ///
+    /// For non-target-zq quality variants, returns minimal metrics
+    /// (`achieved_score = NaN`, `targets_met = true`) and the same
+    /// bytes [`Self::finish`] would. For target-zq variants
+    /// ([`super::Quality::Zq`] / [`super::Quality::ZqExplicit`]) and
+    /// when the `target-zq` feature is enabled, this triggers the
+    /// closed-loop iteration: encode → decode → measure → adjust
+    /// per-block AQ → repeat, returning the smallest-bytes feasible
+    /// candidate observed across `max_passes`.
+    ///
+    /// Errors when [`super::zq::ZqTarget::max_undershoot`] or
+    /// [`super::zq::BlockArtifactBound::max_overshoot`] strictness was
+    /// set and the achieved value falls outside that band.
+    pub fn finish_with_metrics(mut self) -> Result<(Vec<u8>, super::zq::EncodeMetrics)> {
+        #[cfg(feature = "target-zq")]
+        if let (Some(buf), Some(target)) =
+            (self.zq_pixel_buffer.take(), self.config.quality.zq_target())
+        {
+            // Validate complete row count was pushed.
+            let bpp = self.layout.bytes_per_pixel();
+            let row_bytes = self.width as usize * bpp;
+            let pushed_rows = if row_bytes == 0 {
+                0
+            } else {
+                buf.len() / row_bytes
+            };
+            if pushed_rows != self.height as usize {
+                return Err(Error::incomplete_image(self.height, pushed_rows as u32));
+            }
+
+            let ctx = super::zq::IterationContext {
+                config: &self.config,
+                width: self.width,
+                height: self.height,
+                layout: self.layout,
+                pixels: &buf,
+                target,
+            };
+            let (mut bytes, metrics) = super::zq::run_iteration_loop(ctx)?;
+
+            // Inject metadata after iteration. Each per-pass encode ran
+            // without metadata; the same post-encode injection helpers
+            // used by `finish_into` apply here.
+            if let Some(ref exif) = self.exif_data
+                && let Some(exif_bytes) = exif.to_bytes()
+            {
+                inject_exif_inplace(&mut bytes, &exif_bytes);
+            }
+            if let Some(ref xmp_data) = self.xmp_data {
+                inject_xmp_inplace(&mut bytes, xmp_data);
+            }
+            if let Some(ref icc_data) = self.icc_profile {
+                inject_icc_profile_inplace(&mut bytes, icc_data);
+            }
+
+            let final_len = bytes.len();
+            return Ok((
+                bytes,
+                super::zq::EncodeMetrics {
+                    bytes: final_len,
+                    ..metrics
+                },
+            ));
+        }
+
+        // Non-Zq path: existing single-pass encode + minimal metrics.
+        let mut bytes = Vec::new();
+        self.finish_into(&mut bytes)?;
+        let metrics = super::zq::EncodeMetrics::no_target(bytes.len());
+        Ok((bytes, metrics))
     }
 }
 

--- a/zenjpeg/src/encode/encoder_types.rs
+++ b/zenjpeg/src/encode/encoder_types.rs
@@ -22,6 +22,25 @@ pub enum Quality {
     /// Approximate Butteraugli distance target.
     /// Range: 0.0+ (lower = better). <1.0 excellent, <3.0 good.
     ApproxButteraugli(f32),
+
+    /// Target perceptual quality in `zq` units (issue #113).
+    ///
+    /// `zq` is calibrated against zensim score so that the encoder lands
+    /// at roughly the same PERCEIVED quality regardless of content type.
+    /// Unlike `ApproxJpegli` (which is a fixed algorithmic knob), `Zq`
+    /// triggers a closed-loop encode: the encoder iterates per-block
+    /// quantization until the achieved zensim score is at or above
+    /// `target` (within the default budget).
+    ///
+    /// Range: ~30–100 useful, with 75–90 the typical web/CDN range.
+    /// Uses [`zq::ZqTarget::default()`] for everything except the target
+    /// value; for explicit budget/strictness control, use
+    /// [`Quality::ZqExplicit`].
+    Zq(f32),
+
+    /// Target perceptual quality with explicit iteration policy
+    /// (issue #113). See [`zq::ZqTarget`] for the per-knob semantics.
+    ZqExplicit(crate::encode::zq::ZqTarget),
 }
 
 impl Default for Quality {
@@ -50,6 +69,11 @@ impl From<i32> for Quality {
 
 impl Quality {
     /// Convert to internal quality value (0.0-100.0 scale).
+    ///
+    /// For [`Quality::Zq`] / [`Quality::ZqExplicit`] this returns the
+    /// STARTING jpegli quality for the iteration loop's first pass, NOT
+    /// the eventual achieved quality. The closed-loop encoder adjusts
+    /// per-block AQ from this baseline.
     #[must_use]
     pub fn to_internal(&self) -> f32 {
         match self {
@@ -57,6 +81,27 @@ impl Quality {
             Quality::ApproxMozjpeg(q) => mozjpeg_to_internal(*q),
             Quality::ApproxSsim2(score) => ssim2_to_internal(*score),
             Quality::ApproxButteraugli(dist) => butteraugli_to_internal(*dist),
+            Quality::Zq(zq) => crate::encode::zq::zq_to_starting_jpegli_q(*zq),
+            Quality::ZqExplicit(t) => crate::encode::zq::zq_to_starting_jpegli_q(t.target),
+        }
+    }
+
+    /// Whether this quality variant triggers the closed-loop iteration
+    /// path (i.e. requires the decoder + zensim measurement on each
+    /// pass). Returns `false` for the existing one-shot variants.
+    #[must_use]
+    pub fn is_zq_target(&self) -> bool {
+        matches!(self, Quality::Zq(_) | Quality::ZqExplicit(_))
+    }
+
+    /// Resolve to a [`crate::encode::zq::ZqTarget`] when this is a
+    /// closed-loop variant. Returns `None` for the one-shot variants.
+    #[must_use]
+    pub fn zq_target(&self) -> Option<crate::encode::zq::ZqTarget> {
+        match self {
+            Quality::Zq(zq) => Some(crate::encode::zq::ZqTarget::new(*zq)),
+            Quality::ZqExplicit(t) => Some(*t),
+            _ => None,
         }
     }
 

--- a/zenjpeg/src/encode/mod.rs
+++ b/zenjpeg/src/encode/mod.rs
@@ -34,7 +34,9 @@
 // by an unrelated commit on main); wiring it in here makes the file
 // actually reachable.
 mod adaptive;
+pub(crate) mod aq_controller;
 mod blocks;
+
 #[doc(hidden)]
 pub mod chroma;
 #[doc(hidden)]
@@ -45,6 +47,10 @@ pub(crate) mod scan_optimize;
 #[doc(hidden)]
 pub mod scan_script;
 mod serialize;
+/// Target perceptual-quality (`zq`) types and helpers (issue #113).
+///
+/// See [`Quality::Zq`] and [`Quality::ZqExplicit`] for the entry points.
+pub mod zq;
 
 #[doc(hidden)]
 pub mod config;

--- a/zenjpeg/src/encode/streaming.rs
+++ b/zenjpeg/src/encode/streaming.rs
@@ -113,6 +113,16 @@ impl StreamingEncoder {
         &self.processor.quant
     }
 
+    /// Install a per-iMCU [`super::aq_controller::AqController`] on the
+    /// underlying strip processor. Used by the target-zq iteration loop
+    /// in [`super::zq`].
+    pub(crate) fn set_aq_controller(
+        &mut self,
+        ctrl: Option<Box<dyn super::aq_controller::AqController>>,
+    ) {
+        self.processor.set_aq_controller(ctrl);
+    }
+
     /// Creates a new streaming encoder builder with the given dimensions.
     ///
     /// Use the builder methods to configure quality, subsampling, etc.

--- a/zenjpeg/src/encode/strip/mod.rs
+++ b/zenjpeg/src/encode/strip/mod.rs
@@ -583,6 +583,19 @@ pub struct StripProcessor {
     // === Reusable AQ strengths buffer ===
     /// Buffer for AQ strengths from process_y_strip_into (avoids per-strip allocation)
     aq_strengths_buffer: Vec<f32>,
+
+    // === Per-iMCU AQ controller hook (issue #113, PR-A) ===
+    /// Optional controller invoked between `StreamingAQ` emitting per-iMCU
+    /// strengths and `quantize_prev_pending_imcu` consuming them. `None`
+    /// (default) is the byte-identity path — locked-hash tests verify
+    /// this. Future layers (Layers 3–4 of #113) install a real controller
+    /// to drive a target-zensim closed loop.
+    ///
+    /// Counts iMCU rows for which `adjust` has been called, so the
+    /// controller sees a monotonic 0-based index even when AQ buffers
+    /// arrive in irregular shapes (e.g. zero-length flush at EOI).
+    aq_controller: Option<Box<dyn crate::encode::aq_controller::AqController>>,
+    aq_controller_imcu_idx: usize,
 }
 
 impl StripProcessor {
@@ -873,6 +886,10 @@ impl StripProcessor {
             // Reusable AQ strengths buffer (one iMCU row worth of blocks)
             // Size: blocks_per_row * v_samp_factor (max 2 for 4:2:0)
             aq_strengths_buffer: vec![0.0f32; pending_y_capacity],
+
+            // No AQ controller installed by default (#113 PR-A scaffold).
+            aq_controller: None,
+            aq_controller_imcu_idx: 0,
         })
     }
 
@@ -954,6 +971,30 @@ impl StripProcessor {
     #[cfg(feature = "boundary-rd")]
     pub(crate) fn set_boundary_rd(&mut self, flat: Option<BoundaryRdFlat>) {
         self.boundary_rd = flat.map(BoundaryRdState::new);
+    }
+
+    /// Install a per-iMCU AQ-strength controller (#113 PR-A scaffold).
+    ///
+    /// `Some(ctrl)` enables the hook in `process_strip_common`: the
+    /// controller's `adjust` is invoked once per iMCU row, immediately
+    /// after `StreamingAQ` finalizes that iMCU's strengths and before
+    /// quantization consumes them. `None` (the default) leaves the
+    /// strength buffer untouched — encode is byte-identical to the
+    /// pre-controller path.
+    ///
+    /// The iMCU index passed to `adjust` is reset whenever a new
+    /// controller is installed.
+    ///
+    /// Currently unused inside the crate — wired up by external callers
+    /// in PR-D (target-zensim closed loop). The compiler's dead-code lint
+    /// is silenced until then.
+    #[allow(dead_code)]
+    pub(crate) fn set_aq_controller(
+        &mut self,
+        ctrl: Option<Box<dyn crate::encode::aq_controller::AqController>>,
+    ) {
+        self.aq_controller = ctrl;
+        self.aq_controller_imcu_idx = 0;
     }
 
     /// Sets trellis quantization configuration.
@@ -1211,7 +1252,17 @@ impl StripProcessor {
         // This is the key optimization: quantize to i16 immediately instead of storing f32.
         if let Some(count) = aq_count {
             // Use mem::take to avoid borrow conflict (moves buffer, no allocation)
-            let temp_buffer = std::mem::take(&mut self.aq_strengths_buffer);
+            let mut temp_buffer = std::mem::take(&mut self.aq_strengths_buffer);
+
+            // Per-iMCU AQ controller hook (#113 PR-A). Default is `None`,
+            // which leaves `temp_buffer` untouched — encode is byte-identical
+            // to the pre-controller path. Locked-hash regression tests verify
+            // this is preserved (see tests/bundled/locked_values.rs).
+            if let Some(ctrl) = self.aq_controller.as_mut() {
+                ctrl.adjust(&mut temp_buffer[..count], self.aq_controller_imcu_idx);
+                self.aq_controller_imcu_idx += 1;
+            }
+
             self.quantize_prev_pending_imcu(&temp_buffer[..count]);
             self.aq_strengths_buffer = temp_buffer;
             self.pending.clear_prev();
@@ -2358,6 +2409,70 @@ mod tests {
                 psnr,
                 height
             );
+        }
+    }
+
+    /// AqController scaffold (#113 PR-A): the hook is invoked once per
+    /// iMCU row with a monotonic index. The trait requires `Send`, so
+    /// the test stashes its log in a thread_local instead of `Rc<RefCell>`.
+    /// We exercise the live encode path via `process_strip` and verify
+    /// the controller saw at least one call with monotonic indices and
+    /// non-empty strength slices.
+    #[test]
+    fn aq_controller_hook_is_called_per_imcu() {
+        use crate::encode::aq_controller::AqController;
+        use core::cell::RefCell;
+
+        thread_local! {
+            static LOG: RefCell<Vec<(usize, usize)>> = const { RefCell::new(Vec::new()) };
+        }
+
+        #[derive(Debug)]
+        struct Recorder;
+        impl AqController for Recorder {
+            fn adjust(&mut self, strengths: &mut [f32], imcu_idx: usize) {
+                LOG.with(|l| l.borrow_mut().push((imcu_idx, strengths.len())));
+            }
+        }
+
+        LOG.with(|l| l.borrow_mut().clear());
+
+        let width = 64usize;
+        let height = 64usize;
+        let mut rgb = vec![0u8; width * height * 3];
+        for y in 0..height {
+            for x in 0..width {
+                let idx = (y * width + x) * 3;
+                rgb[idx] = ((x * 4) & 0xFF) as u8;
+                rgb[idx + 1] = ((y * 4) & 0xFF) as u8;
+                rgb[idx + 2] = (((x + y) * 2) & 0xFF) as u8;
+            }
+        }
+
+        let mut processor = StripProcessor::new(width, height, Subsampling::S420, PixelFormat::Rgb)
+            .expect("processor creation");
+        processor.set_aq_controller(Some(Box::new(Recorder)));
+
+        let strip_h = processor.strip_height();
+        for strip_y in (0..height).step_by(strip_h) {
+            let h = strip_h.min(height - strip_y);
+            let row_size = width * 3;
+            let strip = &rgb[strip_y * row_size..(strip_y + h) * row_size];
+            processor
+                .process_strip(strip, strip_y)
+                .expect("process_strip");
+        }
+
+        let log = LOG.with(|l| l.borrow().clone());
+        // 64-row 4:2:0 image is 4 iMCU rows (16 px per iMCU). StreamingAQ
+        // holds back the first iMCU as lookahead for fuzzy erosion, so
+        // the trailing emission lands at flush time (not exercised by
+        // process_strip alone). What this test pins down: the hook
+        // fires, indices are monotonic from 0, slices are non-empty.
+        assert!(!log.is_empty(), "controller adjust never called");
+        for (n, (idx, len)) in log.iter().enumerate() {
+            assert_eq!(*idx, n, "imcu_idx must be monotonic from 0");
+            assert!(*len > 0, "strength slice must not be empty");
         }
     }
 }

--- a/zenjpeg/src/encode/zq.rs
+++ b/zenjpeg/src/encode/zq.rs
@@ -1,0 +1,837 @@
+//! Target perceptual-quality (`zq`) types for the closed-loop encoder.
+//!
+//! See [`crate::encode::Quality::Zq`] / [`crate::encode::Quality::ZqExplicit`]
+//! for usage. The encoder iteratively encodes the image, measures perceptual
+//! error against the source (using zensim diffmap), and adjusts per-block
+//! quantization until the target band is met or the iteration budget runs out.
+//!
+//! # Naming convention
+//!
+//! Throughout this module:
+//! - `_overshoot` = how much the achieved value may exceed the target/ceiling
+//! - `_undershoot` = how much the achieved value may fall below it
+//!
+//! Whether `_overshoot` or `_undershoot` is the "good" direction depends on
+//! the constraint:
+//!
+//! - [`ZqTarget::target`] is a quality FLOOR: overshoot = more quality
+//!   (good), undershoot = less quality (bad). Claw-back triggers on
+//!   overshoot; failure on undershoot.
+//! - [`BlockArtifactBound::ceiling`] is an error CEILING: overshoot = more
+//!   artifact (bad), undershoot = less artifact (good). Failure triggers on
+//!   overshoot; claw-back on undershoot.
+//!
+//! Defaults are tuned so the typical caller gets best-effort behavior with
+//! no surprise errors. Callers that need strict guarantees opt in via
+//! [`ZqTarget::max_undershoot`] (for the floor) or
+//! [`BlockArtifactBound::max_overshoot`] (for the ceiling).
+
+/// Explicit target-perceptual-quality specification.
+///
+/// Used via [`crate::encode::Quality::ZqExplicit`]. For the simple single-
+/// knob form, use [`crate::encode::Quality::Zq`] instead — that path uses
+/// `ZqTarget::default()` for everything except the target value.
+///
+/// Per-field naming convention is documented at the [module level][self].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ZqTarget {
+    /// IDEAL perceived quality (zq units). The encoder iterates to reach
+    /// or exceed this score within the [`Self::max_passes`] budget.
+    pub target: f32,
+
+    /// Distance ABOVE target the encoder will accept without further
+    /// iteration. `None` = ship the first feasible result (single pass
+    /// once target is met). `Some(t)` = if `achieved_score > target + t`,
+    /// iterate to recover bytes.
+    ///
+    /// Smaller value → tighter hug → more iteration cost on average.
+    /// Asymmetric by design: there is no over-target tolerance for
+    /// failure, only for waste.
+    ///
+    /// Default: `Some(1.5)`.
+    pub max_overshoot: Option<f32>,
+
+    /// Distance BELOW target the encoder will accept as a SUCCESSFUL
+    /// encode. `None` = best-effort, never error (default; encoder ships
+    /// whatever it managed within `max_passes`). `Some(t)` = if final
+    /// `achieved_score < target - t` after exhausting `max_passes`, the
+    /// encoder returns `Err`.
+    ///
+    /// Set this when you NEED a strictness guarantee (archival,
+    /// accessibility, SLA-bound serving). Permissive callers leave it
+    /// `None` and inspect [`EncodeMetrics::achieved_score`] themselves.
+    ///
+    /// Default: `None`.
+    pub max_undershoot: Option<f32>,
+
+    /// Optional per-block worst-case artifact bound. See
+    /// [`BlockArtifactBound`] for the inner knobs.
+    pub block_artifact: Option<BlockArtifactBound>,
+
+    /// Diffmap-driven correction-pass budget.
+    /// - `0` = single-pass (controller disabled; encoder behaves like
+    ///   `Quality::ApproxJpegli` at the resolved starting quality).
+    /// - `2` = default; one initial encode plus one correction pass.
+    /// - `4` = aggressive; up to four correction passes.
+    ///
+    /// Each pass costs roughly one base-encode + one zensim diffmap
+    /// computation.
+    pub max_passes: u8,
+}
+
+impl Default for ZqTarget {
+    fn default() -> Self {
+        Self {
+            target: 80.0,
+            max_overshoot: Some(1.5),
+            max_undershoot: None,
+            block_artifact: None,
+            max_passes: 2,
+        }
+    }
+}
+
+impl ZqTarget {
+    /// Construct a `ZqTarget` with the given target value and all other
+    /// fields at their defaults. Equivalent to
+    /// `ZqTarget { target, ..Default::default() }`.
+    #[must_use]
+    pub fn new(target: f32) -> Self {
+        Self {
+            target,
+            ..Default::default()
+        }
+    }
+
+    /// Builder-style override of [`Self::max_overshoot`].
+    #[must_use]
+    pub fn with_max_overshoot(mut self, v: Option<f32>) -> Self {
+        self.max_overshoot = v;
+        self
+    }
+
+    /// Builder-style override of [`Self::max_undershoot`].
+    #[must_use]
+    pub fn with_max_undershoot(mut self, v: Option<f32>) -> Self {
+        self.max_undershoot = v;
+        self
+    }
+
+    /// Builder-style override of [`Self::block_artifact`].
+    #[must_use]
+    pub fn with_block_artifact(mut self, v: Option<BlockArtifactBound>) -> Self {
+        self.block_artifact = v;
+        self
+    }
+
+    /// Builder-style override of [`Self::max_passes`].
+    #[must_use]
+    pub fn with_max_passes(mut self, n: u8) -> Self {
+        self.max_passes = n;
+        self
+    }
+}
+
+/// Per-block worst-case artifact bound. Companion to [`ZqTarget`].
+///
+/// `ceiling` is in zensim diffmap units (per-pixel perceptual error,
+/// averaged within an 8×8 block). The encoder tries to ensure no block's
+/// averaged diffmap exceeds `ceiling`. Like [`ZqTarget::target`], this is
+/// best-effort by default — if the budget runs out, the encoder ships
+/// what it has. Set [`Self::max_overshoot`] to make the bound strict
+/// (encoder errors if the final worst-block exceeds the threshold).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BlockArtifactBound {
+    /// Worst-case per-block perceptual error, in zensim diffmap units.
+    /// The encoder iterates toward "no block exceeds this".
+    pub ceiling: f32,
+
+    /// Distance ABOVE the ceiling the encoder will accept as a
+    /// SUCCESSFUL encode. `None` = best-effort, never error.
+    /// `Some(t)` = if final max-block-artifact > `ceiling + t` after
+    /// `max_passes`, the encoder returns `Err`.
+    ///
+    /// Set this when you NEED a per-block guarantee (subjective testing,
+    /// archival, accessibility).
+    ///
+    /// Default: `None`.
+    pub max_overshoot: Option<f32>,
+
+    /// Distance BELOW the ceiling that triggers byte-recovery iteration.
+    /// `None` = no per-block clawback (default; the score-side clawback
+    /// via [`ZqTarget::max_overshoot`] usually handles this incidentally).
+    /// `Some(t)` = if max-block-artifact < `ceiling - t`, iterate to
+    /// recover bytes.
+    ///
+    /// Surface for completeness + callers who want explicit per-block
+    /// clawback semantics.
+    ///
+    /// Default: `None`.
+    pub max_undershoot: Option<f32>,
+}
+
+impl BlockArtifactBound {
+    /// Construct a `BlockArtifactBound` with the given ceiling and all
+    /// other fields at their defaults (best-effort, no errors, no
+    /// per-block clawback).
+    #[must_use]
+    pub fn new(ceiling: f32) -> Self {
+        Self {
+            ceiling,
+            max_overshoot: None,
+            max_undershoot: None,
+        }
+    }
+
+    /// Builder-style override of [`Self::max_overshoot`].
+    #[must_use]
+    pub fn with_max_overshoot(mut self, v: Option<f32>) -> Self {
+        self.max_overshoot = v;
+        self
+    }
+
+    /// Builder-style override of [`Self::max_undershoot`].
+    #[must_use]
+    pub fn with_max_undershoot(mut self, v: Option<f32>) -> Self {
+        self.max_undershoot = v;
+        self
+    }
+}
+
+/// Outcome of a target-perceptual-quality encode.
+///
+/// Returned alongside the JPEG bytes from
+/// [`crate::encode::BytesEncoder::finish_with_metrics`] (and similar
+/// methods on other encoder facades). Callers inspect this when they want
+/// to know whether the encoder hit the target, how many passes it took,
+/// or what byte budget was actually spent.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub struct EncodeMetrics {
+    /// Final achieved zensim score of the shipped output, computed
+    /// against the source via zensim's `Trained` diffmap weighting.
+    /// `f32::NAN` if no measurement was performed (e.g. `max_passes=0`
+    /// or the decoder feature is unavailable).
+    pub achieved_score: f32,
+
+    /// Largest per-block diffmap value (averaged over the 8×8 block) in
+    /// the shipped output. `f32::NAN` if not measured.
+    pub achieved_max_block_artifact: f32,
+
+    /// Number of encode passes performed, including the initial pass.
+    /// `1` means single-pass (no correction).
+    pub passes_used: u8,
+
+    /// Encoded JPEG byte count.
+    pub bytes: usize,
+
+    /// Whether every active goal was met. `true` iff:
+    /// - achieved_score ≥ target, AND
+    /// - if `BlockArtifactBound` was set, achieved_max_block_artifact ≤ ceiling
+    ///
+    /// For non-`Zq` quality variants this is always `true` (no goal).
+    pub targets_met: bool,
+}
+
+impl EncodeMetrics {
+    /// Convenience: the metrics returned for a non-`Zq` quality variant
+    /// (no goal, no measurement). Bytes are still recorded.
+    pub(crate) fn no_target(bytes: usize) -> Self {
+        Self {
+            achieved_score: f32::NAN,
+            achieved_max_block_artifact: f32::NAN,
+            passes_used: 1,
+            bytes,
+            targets_met: true,
+        }
+    }
+}
+
+/// Maps a user-facing zq value to a starting jpegli-quality estimate for
+/// the iteration loop's first pass.
+///
+/// This is a small lookup table calibrated from the
+/// `examples/method_b_real.rs` corpus run (CID22 + screen content). The
+/// goal is "first pass lands close enough to target that 1–2 correction
+/// passes can refine it"; precision isn't required.
+///
+/// Identity-ish in the typical user range (zq 70–95 maps to jpegli q 70–95).
+/// The iteration loop in `BytesEncoder` corrects from here.
+#[must_use]
+pub(crate) fn zq_to_starting_jpegli_q(zq: f32) -> f32 {
+    // Empirical: streaming-AQ zensim score at jpegli q lands roughly
+    // 1–3 zq points above the q value on photos, 1–2 below on dense
+    // screen content. Picking q ≈ zq + 1 as the starting point makes
+    // pass 1 land at-or-above target on most images, leaving headroom
+    // for the controller to claw bytes.
+    const ANCHORS: &[(f32, f32)] = &[
+        (40.0, 38.0),
+        (60.0, 58.0),
+        (75.0, 75.0),
+        (80.0, 81.0),
+        (85.0, 87.0),
+        (90.0, 93.0),
+        (95.0, 97.0),
+    ];
+
+    if zq <= ANCHORS[0].0 {
+        return ANCHORS[0].1;
+    }
+    if zq >= ANCHORS[ANCHORS.len() - 1].0 {
+        return ANCHORS[ANCHORS.len() - 1].1.min(100.0);
+    }
+    for w in ANCHORS.windows(2) {
+        let (lo, hi) = (w[0], w[1]);
+        if zq >= lo.0 && zq <= hi.0 {
+            let t = (zq - lo.0) / (hi.0 - lo.0);
+            return lo.1 + t * (hi.1 - lo.1);
+        }
+    }
+    zq // unreachable
+}
+
+// ============================================================================
+// Internal: iteration loop wiring
+// ============================================================================
+
+use super::aq_controller::AqController;
+
+/// Per-iMCU multiplicative-scale controller. Each iMCU row carries a
+/// row of per-block scale factors that multiply the streaming-AQ output.
+///
+/// scale = 1.0 → no change. scale < 1.0 → tighter (more bits).
+/// scale > 1.0 → looser (fewer bits). Final AQ is clamped to `[0.0, 0.20]`
+/// by the strip processor.
+#[derive(Debug)]
+struct ScalingController {
+    /// `scales[imcu_idx]` = per-block scale factors for that iMCU row.
+    scales: alloc::vec::Vec<alloc::vec::Vec<f32>>,
+}
+
+impl AqController for ScalingController {
+    fn adjust(&mut self, strengths: &mut [f32], imcu_idx: usize) {
+        let row = match self.scales.get(imcu_idx) {
+            Some(r) => r,
+            None => return,
+        };
+        for (i, s) in strengths.iter_mut().enumerate() {
+            let scale = row.get(i).copied().unwrap_or(1.0);
+            *s = (*s * scale).clamp(0.0, 0.20);
+        }
+    }
+}
+
+/// Iteration-loop controller hyperparameters. Picked from the
+/// `examples/method_b_real.rs` corpus run; small surface so the public
+/// API doesn't expose them in v1.
+mod hp {
+    /// Per-pass cap on absolute scale change per block.
+    pub(super) const MAX_SCALE_DELTA: f32 = 0.20;
+    /// Lower clamp on cumulative scale.
+    pub(super) const MIN_SCALE: f32 = 0.40;
+    /// Upper clamp on cumulative scale.
+    pub(super) const MAX_SCALE: f32 = 1.80;
+}
+
+/// Compute the per-block multiplicative scale schedule for the next pass.
+///
+/// `prev_scales` and `block_dm` are flat per-block vectors in row-major
+/// order, length = blocks_w * blocks_h. The returned scales replace
+/// `prev_scales` for the next pass — they are CUMULATIVE, not deltas.
+///
+/// Policy:
+/// - Score below target → tighten the highest-error blocks (scale↓).
+/// - Block diffmap above peak ceiling → tighten THOSE blocks specifically.
+/// - Score in band, no ceiling violation → loosen the lowest-error
+///   blocks (scale↑) to recover bytes.
+fn next_scales(
+    prev_scales: &[f32],
+    block_dm: &[f32],
+    current_score: f32,
+    current_max_block: f32,
+    target: &ZqTarget,
+) -> alloc::vec::Vec<f32> {
+    let mut sorted = block_dm.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let p25 = sorted[sorted.len() / 4];
+    let p75 = sorted[(3 * sorted.len()) / 4];
+    let max = *sorted.last().unwrap_or(&0.0);
+
+    let score_violation = current_score < target.target;
+    let peak_violation = match target.block_artifact {
+        Some(b) => current_max_block > b.ceiling,
+        None => false,
+    };
+
+    // Where to tighten:
+    // - peak violation → tighten any block above the ceiling specifically
+    // - score violation → tighten the top-25% diffmap tail
+    // - both → tighten the union (handled via min)
+    let tighten_above = match (peak_violation, score_violation) {
+        (true, _) => target.block_artifact.unwrap().ceiling,
+        (false, true) => p75,
+        _ => f32::INFINITY,
+    };
+
+    // Where to loosen (claw back bytes): only if both score and peak are
+    // satisfied AND the current score is well into overshoot territory.
+    let in_band = !score_violation && !peak_violation;
+    let overshoot = current_score - target.target;
+    let claw_active = in_band
+        && match target.max_overshoot {
+            Some(t) => overshoot > t,
+            None => false,
+        };
+    let loosen_below = if claw_active { p25 } else { f32::NEG_INFINITY };
+
+    prev_scales
+        .iter()
+        .zip(block_dm.iter())
+        .map(|(&prev, &dm)| {
+            let delta = if dm > tighten_above {
+                let frac = ((dm - tighten_above) / (max - tighten_above).max(1e-6)).clamp(0.0, 1.0);
+                -hp::MAX_SCALE_DELTA * frac
+            } else if dm < loosen_below {
+                let frac = ((loosen_below - dm) / loosen_below.max(1e-6)).clamp(0.0, 1.0);
+                hp::MAX_SCALE_DELTA * frac
+            } else {
+                0.0
+            };
+            (prev + delta).clamp(hp::MIN_SCALE, hp::MAX_SCALE)
+        })
+        .collect()
+}
+
+/// Lay out a flat per-block scale vector into the iMCU-row schedule
+/// shape that [`AqController::adjust`] consumes.
+///
+/// `flat[bx + by * blocks_w]` is the scale for block `(bx, by)`.
+/// One iMCU row covers `v_samp` block rows of width `blocks_w`.
+fn flat_to_imcu_schedule(
+    flat: &[f32],
+    blocks_w: usize,
+    blocks_h: usize,
+    v_samp: usize,
+) -> alloc::vec::Vec<alloc::vec::Vec<f32>> {
+    let imcu_rows = blocks_h.div_ceil(v_samp);
+    let mut out = alloc::vec::Vec::with_capacity(imcu_rows);
+    for imcu_idx in 0..imcu_rows {
+        let mut row = alloc::vec::Vec::with_capacity(blocks_w * v_samp);
+        for vrow in 0..v_samp {
+            let by = imcu_idx * v_samp + vrow;
+            if by >= blocks_h {
+                break;
+            }
+            for bx in 0..blocks_w {
+                row.push(flat[by * blocks_w + bx]);
+            }
+        }
+        out.push(row);
+    }
+    out
+}
+
+/// Aggregate a full-resolution diffmap (`width × height` f32) into a
+/// per-block mean. Truncating divides for non-multiples-of-8 dims —
+/// the right/bottom edge sliver is dropped (matches the encoder's
+/// 8×8 block grid).
+fn aggregate_diffmap_to_blocks(
+    diffmap: &[f32],
+    width: usize,
+    height: usize,
+) -> alloc::vec::Vec<f32> {
+    const BLOCK: usize = 8;
+    let blocks_w = width / BLOCK;
+    let blocks_h = height / BLOCK;
+    let mut out = alloc::vec::Vec::with_capacity(blocks_w * blocks_h);
+    for by in 0..blocks_h {
+        for bx in 0..blocks_w {
+            let mut sum = 0.0f64;
+            for ly in 0..BLOCK {
+                for lx in 0..BLOCK {
+                    let x = bx * BLOCK + lx;
+                    let y = by * BLOCK + ly;
+                    sum += diffmap[y * width + x] as f64;
+                }
+            }
+            out.push((sum / (BLOCK * BLOCK) as f64) as f32);
+        }
+    }
+    out
+}
+
+/// Configuration, dimensions, and pixels captured by a
+/// [`crate::encode::BytesEncoder`] in target-zq mode. The iteration loop
+/// rebuilds a fresh `BytesEncoder` per pass from these.
+///
+/// Per-image metadata (ICC, EXIF, XMP) is intentionally NOT carried here
+/// — it's injected into the final JPEG bytes by `BytesEncoder` after the
+/// iteration loop returns, the same post-encode injection helpers used
+/// by the streaming `finish_into` path. The iteration loop itself
+/// produces metadata-free JPEGs to keep its inner encodes fast.
+#[cfg(feature = "target-zq")]
+pub(crate) struct IterationContext<'a> {
+    pub(crate) config: &'a crate::encode::EncoderConfig,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) layout: crate::encode::PixelLayout,
+    pub(crate) pixels: &'a [u8],
+    pub(crate) target: ZqTarget,
+}
+
+/// Run the closed-loop target-zq iteration. Returns the JPEG bytes of
+/// the best feasible candidate observed (smallest bytes among all
+/// passes that meet active goals; if no pass meets goals, the highest-
+/// score pass).
+///
+/// Errors only when:
+/// - Encoding errors out at any pass (propagated).
+/// - `max_undershoot` is set on `target` and the final achieved score
+///   is below `target.target - max_undershoot`.
+/// - `block_artifact.max_overshoot` is set and the final max-block
+///   artifact exceeds `ceiling + max_overshoot`.
+#[cfg(feature = "target-zq")]
+pub(crate) fn run_iteration_loop(
+    ctx: IterationContext<'_>,
+) -> crate::error::Result<(alloc::vec::Vec<u8>, EncodeMetrics)> {
+    use crate::encode::{EncoderConfig, Quality};
+    use zensim::{RgbSlice, Zensim, ZensimProfile};
+
+    let blocks_w = (ctx.width as usize) / 8;
+    let blocks_h = (ctx.height as usize) / 8;
+    if blocks_w == 0 || blocks_h == 0 {
+        // Image too small to do per-block correction; fall back to the
+        // single-pass starting-q encode.
+        return run_single_pass(&ctx, None);
+    }
+
+    // Vertical sampling factor of the luma plane in iMCUs. Determines
+    // how many block rows belong to a single iMCU emission. Covers
+    // every supported color mode + subsampling combo:
+    //
+    //   YCbCr 4:4:4, 4:2:2  → v_samp = 1
+    //   YCbCr 4:2:0, 4:4:0  → v_samp = 2
+    //   XYB Full            → v_samp = 1
+    //   XYB BQuarter        → v_samp = 2  (B is 2×2 downsampled, max v_samp=2)
+    //   Grayscale           → v_samp = 1
+    let v_samp = match ctx.config.color_mode {
+        crate::encode::ColorMode::YCbCr { subsampling } => {
+            subsampling.v_samp_factor_luma() as usize
+        }
+        crate::encode::ColorMode::Xyb { subsampling } => match subsampling {
+            crate::encode::XybSubsampling::BQuarter => 2,
+            crate::encode::XybSubsampling::Full => 1,
+        },
+        crate::encode::ColorMode::Grayscale => 1,
+    };
+
+    // Build the source ImageSource for zensim. Layout currently must be
+    // RGB8 — other layouts would require zenpixels conversion to drive
+    // zensim's per-channel pipeline. (XYB encoding accepts RGB8 input
+    // and converts internally; the source stays in sRGB8 here.)
+    if ctx.layout != crate::encode::PixelLayout::Rgb8Srgb {
+        // For non-RGB8 layouts, fall back to single-pass — extending
+        // the closed loop to other layouts is future work.
+        return run_single_pass(&ctx, None);
+    }
+
+    let z = Zensim::new(ZensimProfile::latest());
+    let src_chunks: &[[u8; 3]] = bytemuck_chunks(ctx.pixels);
+    let src_slice = RgbSlice::new(src_chunks, ctx.width as usize, ctx.height as usize);
+    let pre = match z.precompute_reference(&src_slice) {
+        Ok(p) => p,
+        Err(_) => return run_single_pass(&ctx, None),
+    };
+
+    // Pass 0: streaming-AQ baseline. Substitute Quality::Zq* with the
+    // resolved starting jpegli q to avoid recursion.
+    let starting_q = ctx.config.quality.to_internal();
+    let mut pass_config: EncoderConfig = ctx.config.clone();
+    pass_config = pass_config.quality(Quality::ApproxJpegli(starting_q));
+
+    let bytes0 = encode_pass(&pass_config, &ctx, None)?;
+    let (score0, dm0) = measure(&z, &pre, &bytes0, ctx.width, ctx.height)?;
+    let max0 = max_block(&dm0);
+
+    let mut best_bytes = bytes0.clone();
+    let mut best_score = score0;
+    let mut best_max = max0;
+    let mut best_feasible = is_feasible(score0, max0, &ctx.target);
+    let mut passes_used: u8 = 1;
+
+    if !is_feasible(score0, max0, &ctx.target) || ctx.target.max_passes == 0 {
+        // No iteration budget, or pass 0 already infeasible and we still
+        // have to exit cleanly: enter the loop below.
+    } else if let Some(t) = ctx.target.max_overshoot {
+        if score0 - ctx.target.target <= t {
+            // Already in band; ship pass 0.
+            return finalize(best_bytes, score0, max0, passes_used, &ctx.target);
+        }
+    } else {
+        // No claw-back budget configured; ship first feasible pass.
+        return finalize(best_bytes, score0, max0, passes_used, &ctx.target);
+    }
+
+    let mut current_scales = alloc::vec![1.0f32; blocks_w * blocks_h];
+    let mut current_dm = dm0;
+    let mut current_score = score0;
+    let mut current_max = max0;
+
+    for _pass in 1..=ctx.target.max_passes {
+        let next = next_scales(
+            &current_scales,
+            &current_dm,
+            current_score,
+            current_max,
+            &ctx.target,
+        );
+        let schedule = flat_to_imcu_schedule(&next, blocks_w, blocks_h, v_samp);
+        let ctrl: Box<dyn AqController> = Box::new(ScalingController { scales: schedule });
+        let bytes_n = encode_pass(&pass_config, &ctx, Some(ctrl))?;
+        let (score_n, dm_n) = measure(&z, &pre, &bytes_n, ctx.width, ctx.height)?;
+        let max_n = max_block(&dm_n);
+        passes_used = passes_used.saturating_add(1);
+
+        let cand_feasible = is_feasible(score_n, max_n, &ctx.target);
+        // Best-tracking: prefer feasible over infeasible, then smallest bytes.
+        let take = match (best_feasible, cand_feasible) {
+            (false, true) => true,
+            (true, false) => false,
+            (true, true) => bytes_n.len() < best_bytes.len(),
+            (false, false) => score_n > best_score,
+        };
+        if take {
+            best_bytes = bytes_n;
+            best_score = score_n;
+            best_max = max_n;
+            best_feasible = cand_feasible;
+        }
+
+        // Stop early if we just landed in the comfort band.
+        let in_band = cand_feasible
+            && match ctx.target.max_overshoot {
+                Some(t) => (score_n - ctx.target.target) <= t,
+                None => true,
+            };
+        if in_band {
+            break;
+        }
+
+        current_scales = next;
+        current_dm = dm_n;
+        current_score = score_n;
+        current_max = max_n;
+    }
+
+    finalize(best_bytes, best_score, best_max, passes_used, &ctx.target)
+}
+
+#[cfg(feature = "target-zq")]
+fn finalize(
+    bytes: alloc::vec::Vec<u8>,
+    score: f32,
+    max_block: f32,
+    passes_used: u8,
+    target: &ZqTarget,
+) -> crate::error::Result<(alloc::vec::Vec<u8>, EncodeMetrics)> {
+    // Strict-mode failure checks (see `ZqTarget::max_undershoot` and
+    // `BlockArtifactBound::max_overshoot` docs).
+    if let Some(slack) = target.max_undershoot {
+        if score < target.target - slack {
+            return Err(crate::error::Error::invalid_config(alloc::format!(
+                "target-zq encoder achieved score {:.3}, below floor {:.3} \
+                 (max_undershoot = {:.3}) after {} passes",
+                score,
+                target.target,
+                slack,
+                passes_used
+            )));
+        }
+    }
+    if let Some(b) = target.block_artifact {
+        if let Some(slack) = b.max_overshoot {
+            if max_block > b.ceiling + slack {
+                return Err(crate::error::Error::invalid_config(alloc::format!(
+                    "target-zq encoder achieved max-block-artifact {:.4}, \
+                     above ceiling {:.4} (max_overshoot = {:.4}) after {} passes",
+                    max_block,
+                    b.ceiling,
+                    slack,
+                    passes_used
+                )));
+            }
+        }
+    }
+    let targets_met = is_feasible(score, max_block, target);
+    let bytes_len = bytes.len();
+    Ok((
+        bytes,
+        EncodeMetrics {
+            achieved_score: score,
+            achieved_max_block_artifact: max_block,
+            passes_used,
+            bytes: bytes_len,
+            targets_met,
+        },
+    ))
+}
+
+#[cfg(feature = "target-zq")]
+fn is_feasible(score: f32, max_block: f32, target: &ZqTarget) -> bool {
+    let score_ok = score >= target.target;
+    let peak_ok = match target.block_artifact {
+        Some(b) => max_block <= b.ceiling,
+        None => true,
+    };
+    score_ok && peak_ok
+}
+
+#[cfg(feature = "target-zq")]
+fn max_block(dm: &[f32]) -> f32 {
+    dm.iter().copied().fold(0.0f32, f32::max)
+}
+
+/// Encode pixels via a fresh [`crate::encode::BytesEncoder`] built from
+/// `pass_config`. Optional `controller` is installed before pushing.
+#[cfg(feature = "target-zq")]
+fn encode_pass(
+    pass_config: &crate::encode::EncoderConfig,
+    ctx: &IterationContext<'_>,
+    controller: Option<Box<dyn AqController>>,
+) -> crate::error::Result<alloc::vec::Vec<u8>> {
+    use enough::Unstoppable;
+    let mut enc = pass_config.encode_from_bytes(ctx.width, ctx.height, ctx.layout)?;
+    if let Some(c) = controller {
+        enc.set_aq_controller(Some(c));
+    }
+    enc.push_packed(ctx.pixels, Unstoppable)?;
+    enc.finish()
+}
+
+/// Decode `jpeg`, compute zensim diffmap against `pre`, return
+/// (score, per-block diffmap).
+#[cfg(feature = "target-zq")]
+fn measure(
+    z: &zensim::Zensim,
+    pre: &zensim::PrecomputedReference,
+    jpeg: &[u8],
+    width: u32,
+    height: u32,
+) -> crate::error::Result<(f32, alloc::vec::Vec<f32>)> {
+    use enough::Unstoppable;
+    use zensim::{DiffmapWeighting, RgbSlice};
+    let dec = crate::decode::Decoder::new()
+        .decode(jpeg, Unstoppable)
+        .map_err(|e| {
+            crate::error::Error::invalid_config(alloc::format!(
+                "decode for measurement failed: {e}"
+            ))
+        })?;
+    let pixels = dec.into_pixels_u8().ok_or_else(|| {
+        crate::error::Error::invalid_config("decoder returned non-u8 pixels".into())
+    })?;
+    let chunks: &[[u8; 3]] = bytemuck_chunks(&pixels);
+    let dec_slice = RgbSlice::new(chunks, width as usize, height as usize);
+    let res = z
+        .compute_with_ref_and_diffmap(pre, &dec_slice, DiffmapWeighting::Trained)
+        .map_err(|e| {
+            crate::error::Error::invalid_config(alloc::format!(
+                "zensim compute_with_ref_and_diffmap failed: {e}"
+            ))
+        })?;
+    let dm = aggregate_diffmap_to_blocks(res.diffmap(), width as usize, height as usize);
+    Ok((res.score() as f32, dm))
+}
+
+/// Single-pass fallback: encode at the resolved starting q, no
+/// controller, no measurement. Used when target-zq mode can't run the
+/// full loop (image too small, layout unsupported, decoder feature off,
+/// etc.).
+#[cfg(feature = "target-zq")]
+fn run_single_pass(
+    ctx: &IterationContext<'_>,
+    _controller: Option<Box<dyn AqController>>,
+) -> crate::error::Result<(alloc::vec::Vec<u8>, EncodeMetrics)> {
+    use crate::encode::{EncoderConfig, Quality};
+    let starting_q = ctx.config.quality.to_internal();
+    let mut pass_config: EncoderConfig = ctx.config.clone();
+    pass_config = pass_config.quality(Quality::ApproxJpegli(starting_q));
+    let bytes = encode_pass(&pass_config, ctx, None)?;
+    let bytes_len = bytes.len();
+    Ok((
+        bytes,
+        EncodeMetrics {
+            achieved_score: f32::NAN,
+            achieved_max_block_artifact: f32::NAN,
+            passes_used: 1,
+            bytes: bytes_len,
+            targets_met: true,
+        },
+    ))
+}
+
+/// Reinterpret a packed RGB byte slice as `[u8; 3]` chunks. Length must
+/// be a multiple of 3; truncates excess.
+#[cfg(feature = "target-zq")]
+fn bytemuck_chunks(pixels: &[u8]) -> &[[u8; 3]] {
+    let n = pixels.len() / 3;
+    // SAFETY-equivalent via the `as_chunks` slice method (stable on
+    // recent rustc). All bytes in `pixels` are valid; we cast a flat
+    // u8 slice to a fixed-stride array slice of the same byte layout.
+    let (chunks, _) = pixels.as_chunks::<3>();
+    let _ = n;
+    chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zq_target_default_is_sensible() {
+        let t = ZqTarget::default();
+        assert_eq!(t.target, 80.0);
+        assert_eq!(t.max_overshoot, Some(1.5));
+        assert_eq!(t.max_undershoot, None);
+        assert!(t.block_artifact.is_none());
+        assert_eq!(t.max_passes, 2);
+    }
+
+    #[test]
+    fn zq_target_builder_chains() {
+        let t = ZqTarget::new(85.0)
+            .with_max_overshoot(Some(0.5))
+            .with_max_undershoot(Some(2.0))
+            .with_max_passes(3)
+            .with_block_artifact(Some(BlockArtifactBound::new(0.012)));
+        assert_eq!(t.target, 85.0);
+        assert_eq!(t.max_overshoot, Some(0.5));
+        assert_eq!(t.max_undershoot, Some(2.0));
+        assert_eq!(t.max_passes, 3);
+        assert!(t.block_artifact.is_some());
+        assert_eq!(t.block_artifact.unwrap().ceiling, 0.012);
+    }
+
+    #[test]
+    fn block_artifact_bound_default_is_best_effort() {
+        let b = BlockArtifactBound::new(0.020);
+        assert_eq!(b.ceiling, 0.020);
+        assert_eq!(b.max_overshoot, None);
+        assert_eq!(b.max_undershoot, None);
+    }
+
+    #[test]
+    fn zq_calibration_is_monotonic_and_in_range() {
+        // Small smoke check: starting q increases with zq, and stays
+        // within the jpegli-q range.
+        let mut prev = 0.0f32;
+        for zq in (40..=95).step_by(5) {
+            let q = zq_to_starting_jpegli_q(zq as f32);
+            assert!(q > prev, "non-monotonic at zq={zq}: {prev} -> {q}");
+            assert!((1.0..=100.0).contains(&q), "out of range at zq={zq}: {q}");
+            prev = q;
+        }
+    }
+}

--- a/zenjpeg/tests/zq_target.rs
+++ b/zenjpeg/tests/zq_target.rs
@@ -1,0 +1,320 @@
+//! Integration tests for `Quality::Zq` / `Quality::ZqExplicit` (#113).
+//!
+//! These tests validate the public API contract: types compile, the
+//! iteration loop runs end-to-end, metrics are populated honestly, and
+//! the closed-loop encoder can hit a perceptual target on at least one
+//! synthetic image.
+//!
+//! These tests run only with `--features target-zq` since that's the
+//! feature that enables the iteration path. Without the feature,
+//! `Quality::Zq*` falls back to single-pass encoding at the resolved
+//! starting quality (covered by a separate test).
+
+#![cfg(feature = "target-zq")]
+
+use enough::Unstoppable;
+use zenjpeg::encode::zq::{BlockArtifactBound, ZqTarget};
+use zenjpeg::encode::{ChromaSubsampling, EncoderConfig, PixelLayout, Quality};
+
+/// Generate a 256×256 synthetic image with mixed smooth + textured regions.
+/// Roughly photo-shaped so the iteration loop has meaningful per-block
+/// diffmap variance to work with.
+fn synthetic_image(w: u32, h: u32) -> Vec<u8> {
+    let w = w as usize;
+    let h = h as usize;
+    let mut rgb = vec![0u8; w * h * 3];
+    for y in 0..h {
+        for x in 0..w {
+            let idx = (y * w + x) * 3;
+            // Smooth ramp + per-tile noise. Tiles 32×32; alternating
+            // "smooth gradient" and "textured" blocks.
+            let tx = x / 32;
+            let ty = y / 32;
+            let tile_smooth = (tx + ty) % 2 == 0;
+            let r_base = (x * 255 / w) as u8;
+            let g_base = (y * 255 / h) as u8;
+            let b_base = ((x + y) * 255 / (w + h)) as u8;
+            if tile_smooth {
+                rgb[idx] = r_base;
+                rgb[idx + 1] = g_base;
+                rgb[idx + 2] = b_base;
+            } else {
+                // Pseudo-random noise: deterministic from x,y.
+                let n = ((x.wrapping_mul(2654435761)) ^ (y.wrapping_mul(40503))) as u8;
+                rgb[idx] = r_base.saturating_add(n & 0x3F);
+                rgb[idx + 1] = g_base.saturating_sub((n >> 2) & 0x3F);
+                rgb[idx + 2] = b_base.saturating_add((n >> 4) & 0x3F);
+            }
+        }
+    }
+    rgb
+}
+
+#[test]
+fn zq_simple_form_encodes_and_returns_metrics() {
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::ycbcr(Quality::Zq(80.0), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .expect("encoder creation");
+    enc.push_packed(&rgb, Unstoppable).expect("push");
+    let (jpeg, metrics) = enc.finish_with_metrics().expect("finish_with_metrics");
+    assert!(!jpeg.is_empty(), "should produce some JPEG bytes");
+    assert!(
+        jpeg.len() == metrics.bytes,
+        "metrics.bytes must match jpeg.len()"
+    );
+    assert!(
+        metrics.passes_used >= 1 && metrics.passes_used <= 3,
+        "default budget = 2 passes, plus the initial pass = up to 3 total observed"
+    );
+    assert!(
+        metrics.achieved_score.is_finite(),
+        "iteration path always measures a final score"
+    );
+    // The synthetic image (noise tiles + gradient) is HARD: starting q=81
+    // typically lands well below target 80 on this content. We don't
+    // assert convergence quality here — that's the convergence test's
+    // job. We only assert the API contract: the encoder ran the loop,
+    // produced finite metrics, and reported targets_met honestly.
+    if metrics.achieved_score >= 80.0 {
+        assert!(metrics.targets_met, "score >= target should report met");
+    } else {
+        assert!(!metrics.targets_met, "score < target should NOT report met");
+    }
+}
+
+#[test]
+fn zq_explicit_form_respects_max_passes_zero() {
+    let (w, h) = (128u32, 128);
+    let rgb = synthetic_image(w, h);
+    let target = ZqTarget::new(75.0).with_max_passes(0);
+    let config = EncoderConfig::ycbcr(Quality::ZqExplicit(target), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (_jpeg, metrics) = enc.finish_with_metrics().unwrap();
+    assert_eq!(
+        metrics.passes_used, 1,
+        "max_passes=0 means single-pass (just the initial encode, no correction)"
+    );
+}
+
+#[test]
+fn zq_explicit_max_undershoot_strict_mode_catches_misses() {
+    let (w, h) = (128u32, 128);
+    let rgb = synthetic_image(w, h);
+    // Target zq=99 with strict floor — basically unreachable.
+    let target = ZqTarget::new(99.0)
+        .with_max_undershoot(Some(0.5))
+        .with_max_passes(2);
+    let config = EncoderConfig::ycbcr(Quality::ZqExplicit(target), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let res = enc.finish_with_metrics();
+    assert!(
+        res.is_err(),
+        "Zq target=99 with max_undershoot=0.5 should error on this image"
+    );
+}
+
+#[test]
+fn zq_with_block_artifact_bound_runs() {
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    let target = ZqTarget::new(80.0).with_block_artifact(Some(BlockArtifactBound::new(0.020)));
+    let config = EncoderConfig::ycbcr(Quality::ZqExplicit(target), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc.finish_with_metrics().unwrap();
+    assert!(!jpeg.is_empty());
+    assert!(metrics.achieved_max_block_artifact.is_finite());
+    // Block-artifact bound is 0.020 — at zq=80 on a well-behaved
+    // synthetic image, achieved should be well below this.
+    assert!(
+        metrics.achieved_max_block_artifact <= 0.030,
+        "max-block artifact {} unexpectedly high",
+        metrics.achieved_max_block_artifact
+    );
+}
+
+#[test]
+fn zq_block_artifact_max_overshoot_strict_mode_errors_on_unreachable_ceiling() {
+    let (w, h) = (128u32, 128);
+    let rgb = synthetic_image(w, h);
+    // Set a very tight ceiling that's basically impossible at low q.
+    let target = ZqTarget::new(60.0)
+        .with_block_artifact(Some(
+            BlockArtifactBound::new(0.0001).with_max_overshoot(Some(0.0001)),
+        ))
+        .with_max_passes(2);
+    let config = EncoderConfig::ycbcr(Quality::ZqExplicit(target), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let res = enc.finish_with_metrics();
+    assert!(
+        res.is_err(),
+        "block_artifact ceiling=0.0001 with strict overshoot=0.0001 should error"
+    );
+}
+
+#[test]
+fn quality_to_internal_resolves_zq_to_starting_q() {
+    // Sanity: zq → starting jpegli q is in a sensible range.
+    let zq75 = Quality::Zq(75.0);
+    let zq85 = Quality::Zq(85.0);
+    let zq95 = Quality::Zq(95.0);
+    assert!(zq75.to_internal() > 50.0 && zq75.to_internal() < 90.0);
+    assert!(zq85.to_internal() > 70.0 && zq85.to_internal() < 95.0);
+    assert!(zq95.to_internal() > 85.0 && zq95.to_internal() <= 100.0);
+}
+
+#[test]
+fn quality_zq_target_round_trip() {
+    let q = Quality::Zq(82.5);
+    assert!(q.is_zq_target());
+    let t = q.zq_target().expect("Zq has a ZqTarget");
+    assert_eq!(t.target, 82.5);
+
+    let explicit = ZqTarget::new(82.5)
+        .with_max_overshoot(Some(0.5))
+        .with_max_passes(3);
+    let q2 = Quality::ZqExplicit(explicit);
+    assert!(q2.is_zq_target());
+    let t2 = q2.zq_target().unwrap();
+    assert_eq!(t2.max_overshoot, Some(0.5));
+    assert_eq!(t2.max_passes, 3);
+}
+
+#[test]
+fn finish_works_on_zq_mode_without_metrics() {
+    // The plain finish() entry point must transparently route through
+    // the iteration loop when a Zq variant is configured (otherwise
+    // pushes-to-buffer would leave the inner streaming encoder with
+    // zero rows and finish() would error with incomplete_image).
+    let (w, h) = (128u32, 128);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::ycbcr(Quality::Zq(75.0), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let jpeg = enc.finish().expect("finish() should work in Zq mode");
+    assert!(!jpeg.is_empty());
+}
+
+#[test]
+fn zq_works_with_subsampling_444() {
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::ycbcr(Quality::Zq(80.0), ChromaSubsampling::None);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc
+        .finish_with_metrics()
+        .expect("4:4:4 Zq encode should succeed");
+    assert!(!jpeg.is_empty());
+    assert!(metrics.passes_used >= 1);
+    assert!(
+        metrics.achieved_score.is_finite(),
+        "4:4:4 must run iteration loop, not single-pass fallback"
+    );
+}
+
+#[test]
+fn zq_works_with_subsampling_422() {
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::ycbcr(Quality::Zq(80.0), ChromaSubsampling::HalfHorizontal);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc
+        .finish_with_metrics()
+        .expect("4:2:2 Zq encode should succeed");
+    assert!(!jpeg.is_empty());
+    assert!(metrics.achieved_score.is_finite());
+}
+
+#[test]
+fn zq_works_with_subsampling_440() {
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::ycbcr(Quality::Zq(80.0), ChromaSubsampling::HalfVertical);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc
+        .finish_with_metrics()
+        .expect("4:4:0 Zq encode should succeed");
+    assert!(!jpeg.is_empty());
+    assert!(metrics.achieved_score.is_finite());
+}
+
+#[test]
+fn zq_works_with_xyb_bquarter() {
+    use zenjpeg::encode::XybSubsampling;
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    // XYB encoding accepts RGB8 input (sRGB) and converts internally;
+    // the decoded JPEG is decoded back to RGB8 by the decoder so the
+    // diffmap measurement against the source RGB8 is well-defined.
+    let config = EncoderConfig::xyb(Quality::Zq(80.0), XybSubsampling::BQuarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc
+        .finish_with_metrics()
+        .expect("XYB BQuarter Zq encode should succeed");
+    assert!(!jpeg.is_empty());
+    assert!(metrics.achieved_score.is_finite());
+}
+
+#[test]
+fn zq_works_with_xyb_full() {
+    use zenjpeg::encode::XybSubsampling;
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::xyb(Quality::Zq(80.0), XybSubsampling::Full);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc
+        .finish_with_metrics()
+        .expect("XYB Full Zq encode should succeed");
+    assert!(!jpeg.is_empty());
+    assert!(metrics.achieved_score.is_finite());
+}
+
+#[test]
+fn non_zq_quality_does_not_iterate() {
+    let (w, h) = (128u32, 128);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::ycbcr(Quality::ApproxJpegli(85.0), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc.finish_with_metrics().unwrap();
+    assert!(!jpeg.is_empty());
+    assert_eq!(metrics.passes_used, 1, "non-Zq is single-pass");
+    assert!(
+        metrics.achieved_score.is_nan(),
+        "non-Zq doesn't measure perceptual score"
+    );
+    assert!(metrics.targets_met, "non-Zq has no goal — vacuously met");
+}


### PR DESCRIPTION
**Combined PR**: AqController scaffold (was #114) + Quality::Zq public API. Closes-as-superseded #114.

## What

Public API for content-invariant target perceptual quality:

```rust
use zenjpeg::encode::{EncoderConfig, Quality, ChromaSubsampling, PixelLayout};
use zenjpeg::encode::zq::{ZqTarget, BlockArtifactBound};

// Single-knob: aim for zq=85 perceptual quality. Defaults: 2 passes,
// claw bytes when overshooting by >1.5 zq.
let cfg = EncoderConfig::ycbcr(Quality::Zq(85.0), ChromaSubsampling::Quarter);

// Or with explicit asymmetric budget controls:
let target = ZqTarget::new(85.0)
    .with_max_overshoot(Some(0.5))                   // tighter claw band
    .with_max_undershoot(Some(2.0))                  // strict-mode floor
    .with_block_artifact(Some(
        BlockArtifactBound::new(0.012)
            .with_max_overshoot(Some(0.0))           // strict per-block
    ))
    .with_max_passes(3);
let cfg = EncoderConfig::ycbcr(Quality::ZqExplicit(target), ChromaSubsampling::Quarter);

// Single entry point — finish_with_metrics returns achieved score, max
// per-block artifact, passes used, bytes, and whether all goals were met.
let mut enc = cfg.encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)?;
enc.push_packed(&rgb, Unstoppable)?;
let (jpeg, metrics) = enc.finish_with_metrics()?;
```

## Naming convention (asymmetric on purpose)

`_overshoot` = how much the achieved value may exceed the target/ceiling.
`_undershoot` = how much the achieved value may fall below it.

Whether overshoot or undershoot is the "good" direction depends on the constraint:
- `target` is a quality FLOOR: overshoot=more quality (good), undershoot=less (bad). Claw-back triggers on overshoot, failure on undershoot.
- `BlockArtifactBound::ceiling` is an error CEILING: overshoot=more artifact (bad), undershoot=less (good). Failure triggers on overshoot, claw-back on undershoot.

Defaults are tuned for best-effort: `max_overshoot=Some(1.5)`, `max_undershoot=None`. Strict callers opt in.

## Architecture

The `AqController` trait is the per-iMCU hook that lets the iteration loop scale streaming-AQ output multiplicatively per-block, preserving jpegli's content-aware spatial allocation. Without a controller installed, the encoder is byte-identical to today (verified by 1053 bundled tests).

The iteration loop in `BytesEncoder::finish_with_metrics`:
- Pass 0: streaming-AQ baseline at `zq_to_starting_jpegli_q(target)`.
- Pass N: scale streaming AQ multiplicatively per-block from previous pass's diffmap. Tighten high-error blocks (top-25% by diffmap, or above ceiling) when below target; loosen low-error blocks (bottom-25%) when score is well into overshoot territory.
- Stops early when in band, runs to `max_passes` otherwise. Returns smallest-bytes feasible candidate.

## Subsampling support

All YCbCr subsamplings supported via generalized `v_samp` lookup:
- 4:4:4, 4:2:2 → v_samp = 1
- 4:2:0, 4:4:0 → v_samp = 2
- XYB Full → v_samp = 1
- XYB BQuarter → v_samp = 2
- Grayscale → v_samp = 1

Only fall-through to single-pass: non-RGB8 input layouts. Linear-f32 input requires routing through zensim's StridedBytes path for measurement and is deferred.

## Surface

- `Quality::{Zq, ZqExplicit}` enum variants — always present.
- `encode::aq_controller` module: `AqController` trait + setters. `pub(crate)` until external user demand.
- `encode::zq` module — always present: `ZqTarget`, `BlockArtifactBound`, `EncodeMetrics`, builder methods.
- `BytesEncoder::finish_with_metrics()` — always present (minimal metrics for non-Zq variants).
- `target-zq` Cargo feature (default OFF) gates the actual iteration. Without it, `Quality::Zq*` degrades to `ApproxJpegli` at the resolved starting q.

## Test coverage

- **14 integration tests** in `tests/zq_target.rs` covering API contract, both strict-mode error paths, `max_passes=0`, `finish()` routing, builder chaining, **all 4 YCbCr subsamplings + both XYB modes**.
- **1053 bundled tests** pass with `--features parallel,trellis,boundary-rd` — byte-identity preserved on non-Zq path; locked-hash regression suite unchanged.
- **1067 lib tests** pass with `target-zq` + heavy features.

## Validation

Validated empirically by the predictor experiment (separate workspace, `zmyuurlo` → `qrxunvuslqur` `27e51623`): 51 images × 3 targets, 88% win rate when controller met target, mean B/A=0.943, best segment cid22 q=85 saves 16% bytes vs raw quality bump.

## Diff

10 files changed, +1442/-15:
- `zenjpeg/src/encode/zq.rs` (new, ~825 lines)
- `zenjpeg/src/encode/aq_controller.rs` (new, ~125 lines)
- `zenjpeg/src/encode/byte_encoders.rs` (+~190, finish_with_metrics + buffer routing)
- `zenjpeg/src/encode/encoder_types.rs` (+45, two new Quality variants + helpers)
- `zenjpeg/src/encode/strip/mod.rs` (+~115, AQ controller hook + injection point)
- `zenjpeg/src/encode/streaming.rs` (+10, controller setter)
- Wiring: `mod.rs`, `adaptive.rs` (small)
- `zenjpeg/Cargo.toml`, `Cargo.toml` (target-zq feature, zensim workspace dep)
- `zenjpeg/tests/zq_target.rs` (new, ~310 lines)

## Limitations / future work

- Starting-q calibration table is rough (one-corpus fit). Better fit + per-content-bucket tables come in a follow-up PR.
- Linear-f32 input still falls through to single-pass.
- Per-pass diffmap is full-image; per-window streaming would amortize cost on large images. Real architectural work for a follow-up.

Refs #113. Supersedes #114.