### PR TITLE
feat(encode): per-content-bucket Zq starting-q calibration (#113 PR-D)

### DIFF
--- a/zenjpeg/benchmarks/zq_calibration_2026-04-27.log
+++ b/zenjpeg/benchmarks/zq_calibration_2026-04-27.log
@@ -1,0 +1,78 @@
+warning: jpegli-internals-sys@0.1.0: Using pre-built jpegli from "/home/lilith/work/zen/zenjpeg/internal/jpegli-cpp/build"
+warning: jpegli-internals-sys@0.1.0: ✓ Building with instrumented C++ FFI (jpegli_test_ffi)
+    Finished `release` profile [optimized + debuginfo] target(s) in 0.10s
+     Running `target/release/examples/zq_calibrate --corpus /tmp/zq_calib_corpus --max-images 80`
+[zq_calibrate] 76 image(s), 17 q values × 7 targets
+  progress: 5/76
+  progress: 10/76
+  progress: 15/76
+  progress: 20/76
+  progress: 25/76
+  progress: 30/76
+  progress: 35/76
+  progress: 40/76
+  progress: 45/76
+  progress: 50/76
+  progress: 55/76
+  progress: 60/76
+  progress: 65/76
+  progress: 70/76
+  progress: 75/76
+
+=== Calibration anchors per bucket ===
+
+// PhotoNatural (n=7)
+const PHOTONATURAL: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=7, p25=20 p50=20 p75=20
+    (60.0, 25.0),  // n=7, p25=20 p50=25 p75=25
+    (75.0, 60.0),  // n=7, p25=55 p50=60 p75=65
+    (80.0, 75.0),  // n=7, p25=70 p50=75 p75=80
+    (85.0, 90.0),  // n=7, p25=85 p50=90 p75=90
+    (90.0, 95.0),  // n=7, p25=95 p50=95 p75=100
+    (95.0, 100.0),  // n=7, p25=100 p50=100 p75=100
+];
+
+// PhotoDetailed (n=36)
+const PHOTODETAILED: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=36, p25=20 p50=20 p75=20
+    (60.0, 25.0),  // n=36, p25=20 p50=25 p75=40
+    (75.0, 70.0),  // n=36, p25=60 p50=70 p75=75
+    (80.0, 80.0),  // n=36, p25=75 p50=80 p75=85
+    (85.0, 90.0),  // n=36, p25=90 p50=90 p75=95
+    (90.0, 100.0),  // n=36, p25=95 p50=100 p75=100
+    (95.0, 100.0),  // n=36, p25=100 p50=100 p75=100
+];
+
+// PhotoFlat (n=13)
+const PHOTOFLAT: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=13, p25=20 p50=20 p75=20
+    (60.0, 20.0),  // n=13, p25=20 p50=20 p75=20
+    (75.0, 60.0),  // n=13, p25=45 p50=60 p75=65
+    (80.0, 75.0),  // n=13, p25=65 p50=75 p75=80
+    (85.0, 90.0),  // n=13, p25=85 p50=90 p75=95
+    (90.0, 100.0),  // n=13, p25=95 p50=100 p75=100
+    (95.0, 100.0),  // n=13, p25=100 p50=100 p75=100
+];
+
+// Illustration (n=1)
+const ILLUSTRATION: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=1, p25=20 p50=20 p75=20
+    (60.0, 20.0),  // n=1, p25=20 p50=20 p75=20
+    (75.0, 40.0),  // n=1, p25=40 p50=40 p75=40
+    (80.0, 65.0),  // n=1, p25=65 p50=65 p75=65
+    (85.0, 85.0),  // n=1, p25=85 p50=85 p75=85
+    (90.0, 100.0),  // n=1, p25=100 p50=100 p75=100
+    (95.0, 100.0),  // n=1, p25=100 p50=100 p75=100
+];
+
+// ScreenContent (n=19)
+const SCREENCONTENT: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=19, p25=20 p50=20 p75=20
+    (60.0, 20.0),  // n=19, p25=20 p50=20 p75=20
+    (75.0, 45.0),  // n=19, p25=40 p50=45 p75=60
+    (80.0, 70.0),  // n=19, p25=65 p50=70 p75=75
+    (85.0, 85.0),  // n=19, p25=85 p50=85 p75=90
+    (90.0, 95.0),  // n=19, p25=95 p50=95 p75=100
+    (95.0, 100.0),  // n=19, p25=100 p50=100 p75=100
+];
+

--- a/zenjpeg/examples/zq_calibrate.rs
+++ b/zenjpeg/examples/zq_calibrate.rs
@@ -1,0 +1,219 @@
+//! Calibrate per-bucket starting-q values for `Quality::Zq` (#113 PR-D).
+//!
+//! For each (content_bucket, target_zq) combination, finds the smallest
+//! jpegli quality that lands at-or-above target zq when encoded with
+//! default streaming AQ (no controller). Prints the values in the format
+//! that [`zenjpeg::encode::zq::zq_to_starting_jpegli_q_for_bucket`] expects.
+//!
+//! The output of this binary is meant to be hand-pasted into the anchor
+//! tables in `src/encode/zq.rs`. Re-run when:
+//!  - The streaming AQ pipeline changes (e.g. new SIMD path, new perceptual
+//!    weighting).
+//!  - The zensim profile is replaced (calibration is profile-relative).
+//!  - The corpus shifts substantially (new content types).
+//!
+//! Usage:
+//!   cargo run --release -p zenjpeg --features target-zq \
+//!     --example zq_calibrate -- --corpus /path/to/corpus
+//!
+//! Default corpus is CID22 validation (40 photo images). For a richer fit
+//! pass `--corpus /path/to/mixed-content/dir` covering screen content +
+//! illustration too.
+
+#![cfg(feature = "target-zq")]
+
+use enough::Unstoppable;
+use std::path::PathBuf;
+use zenjpeg::analyze::analyze_rgb8;
+use zenjpeg::decode::Decoder;
+use zenjpeg::encode::{ChromaSubsampling, EncoderConfig, PixelLayout, Quality};
+use zensim::{DiffmapWeighting, RgbSlice, Zensim, ZensimProfile};
+
+const ZQ_TARGETS: &[f32] = &[40.0, 60.0, 75.0, 80.0, 85.0, 90.0, 95.0];
+const Q_GRID: &[u8] = &[
+    20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100,
+];
+
+struct Args {
+    corpus: PathBuf,
+    max_images: usize,
+}
+
+fn parse_args() -> Args {
+    let mut corpus =
+        PathBuf::from("/home/lilith/work/codec-eval/codec-corpus/CID22/CID22-512/validation");
+    let mut max_images = 64;
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--corpus" => corpus = PathBuf::from(it.next().unwrap()),
+            "--max-images" => max_images = it.next().unwrap().parse().expect("max-images uint"),
+            other => panic!("unknown arg: {other}"),
+        }
+    }
+    Args { corpus, max_images }
+}
+
+fn load_png(path: &std::path::Path) -> (Vec<u8>, u32, u32) {
+    let img =
+        image::open(path).unwrap_or_else(|e| panic!("failed to load {}: {e}", path.display()));
+    let rgb = img.to_rgb8();
+    (rgb.as_raw().clone(), rgb.width(), rgb.height())
+}
+
+fn encode_and_score(
+    z: &Zensim,
+    pre: &zensim::PrecomputedReference,
+    rgb: &[u8],
+    w: u32,
+    h: u32,
+    q: u8,
+) -> f32 {
+    let cfg = EncoderConfig::ycbcr(Quality::ApproxJpegli(q as f32), ChromaSubsampling::Quarter);
+    let jpeg = cfg
+        .encode_bytes(rgb, w, h, PixelLayout::Rgb8Srgb)
+        .expect("encode");
+    let dec = Decoder::new()
+        .decode(&jpeg, Unstoppable)
+        .expect("decode")
+        .into_pixels_u8()
+        .expect("u8 pixels");
+    let chunks: &[[u8; 3]] = dec.as_chunks::<3>().0;
+    let dec_slice = RgbSlice::new(chunks, w as usize, h as usize);
+    z.compute_with_ref_and_diffmap(pre, &dec_slice, DiffmapWeighting::Trained)
+        .expect("zensim")
+        .score() as f32
+}
+
+/// For one image, find smallest q with score >= target_zq for each
+/// target. Returns Vec of (target_zq, smallest_q) tuples.
+fn fit_image(
+    z: &Zensim,
+    pre: &zensim::PrecomputedReference,
+    rgb: &[u8],
+    w: u32,
+    h: u32,
+) -> Vec<(f32, u8)> {
+    // Encode at every q in the grid once; record score → use these to
+    // pick smallest q meeting each target.
+    let mut q_score: Vec<(u8, f32)> = Q_GRID
+        .iter()
+        .map(|&q| (q, encode_and_score(z, pre, rgb, w, h, q)))
+        .collect();
+    q_score.sort_by_key(|&(q, _)| q);
+
+    ZQ_TARGETS
+        .iter()
+        .map(|&zq| {
+            let q = q_score
+                .iter()
+                .find(|&&(_, score)| score >= zq)
+                .map(|&(q, _)| q)
+                .unwrap_or(100);
+            (zq, q)
+        })
+        .collect()
+}
+
+fn main() {
+    let args = parse_args();
+    let z = Zensim::new(ZensimProfile::latest());
+
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(&args.corpus)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e}", args.corpus.display()))
+        .filter_map(|r| r.ok().map(|e| e.path()))
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("png"))
+        .collect();
+    paths.sort();
+    paths.truncate(args.max_images);
+    eprintln!(
+        "[zq_calibrate] {} image(s), {} q values × {} targets",
+        paths.len(),
+        Q_GRID.len(),
+        ZQ_TARGETS.len()
+    );
+
+    // Per-bucket tabulation. For each bucket, we'll accumulate the
+    // smallest q per target across all images in that bucket, then take
+    // the median (a single typical anchor that hits target on most
+    // bucket-members at-or-above target).
+    use std::collections::HashMap;
+    let mut by_bucket: HashMap<&'static str, Vec<Vec<(f32, u8)>>> = HashMap::new();
+
+    for (i, path) in paths.iter().enumerate() {
+        let (rgb, w, h) = load_png(path);
+        let features = analyze_rgb8(&rgb, w, h);
+        let bucket_label: &'static str = match (
+            features.text_likelihood,
+            features.screen_content_likelihood,
+            features.uniformity,
+            features.flat_color_block_ratio,
+            features.high_freq_energy_ratio,
+            features.edge_density,
+            features.cb_peak_sharpness,
+            features.cr_peak_sharpness,
+            features.chroma_complexity,
+        ) {
+            (txt, _, _, _, _, _, cb_p, _, c) if txt > 0.55 && (c > 0.04 || cb_p > 5.0) => {
+                "Illustration"
+            }
+            (txt, _, _, _, _, _, _, _, _) if txt > 0.55 => "ScreenContent",
+            (_, scr, _, _, _, _, _, _, _) if scr > 0.5 => "ScreenContent",
+            (_, _, u, f, _, _, _, _, _) if u > 0.55 || f > 0.25 => "PhotoFlat",
+            (_, _, _, _, hf, ed, cb_p, cr_p, _)
+                if hf > 0.30 || ed > 0.18 || cb_p > 8.0 || cr_p > 8.0 =>
+            {
+                "PhotoDetailed"
+            }
+            _ => "PhotoNatural",
+        };
+
+        let src_chunks: &[[u8; 3]] = rgb.as_chunks::<3>().0;
+        let src_slice = RgbSlice::new(src_chunks, w as usize, h as usize);
+        let pre = z.precompute_reference(&src_slice).expect("precompute");
+        let fits = fit_image(&z, &pre, &rgb, w, h);
+
+        by_bucket.entry(bucket_label).or_default().push(fits);
+
+        if (i + 1) % 5 == 0 {
+            eprintln!("  progress: {}/{}", i + 1, paths.len());
+        }
+    }
+
+    // Median per (bucket, target) → final anchor.
+    println!("\n=== Calibration anchors per bucket ===\n");
+    let bucket_order = [
+        "PhotoNatural",
+        "PhotoDetailed",
+        "PhotoFlat",
+        "Illustration",
+        "ScreenContent",
+    ];
+    for &bucket in &bucket_order {
+        match by_bucket.get(bucket) {
+            None => {
+                println!("// {}: NO IMAGES IN CORPUS", bucket);
+                continue;
+            }
+            Some(rows) => {
+                let n = rows.len();
+                println!("// {} (n={})", bucket, n);
+                println!("const {}: &[(f32, f32)] = &[", bucket.to_uppercase());
+                for (i, &target) in ZQ_TARGETS.iter().enumerate() {
+                    let mut qs: Vec<u8> = rows.iter().map(|r| r[i].1).collect();
+                    qs.sort();
+                    let median = qs[n / 2];
+                    println!(
+                        "    ({:.1}, {:.1}),  // n={n}, p25={} p50={median} p75={}",
+                        target,
+                        median as f32,
+                        qs[n / 4],
+                        qs[(3 * n) / 4],
+                    );
+                    let _ = target;
+                }
+                println!("];\n");
+            }
+        }
+    }
+}

--- a/zenjpeg/src/encode/adaptive.rs
+++ b/zenjpeg/src/encode/adaptive.rs
@@ -334,9 +334,11 @@ impl AdaptiveMetric {
 
 /// Coarse content classification distilled from analyzer features —
 /// matches the oracle's 5-bucket taxonomy as closely as the analyzer
-/// signals allow. Internal only; not part of the public surface.
+/// signals allow. Internal only (not part of the public surface) but
+/// `pub(crate)` so target-zq calibration in `super::zq` can route the
+/// per-bucket starting-q lookup.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum InferredBucket {
+pub(crate) enum InferredBucket {
     PhotoNatural,
     PhotoDetailed,
     PhotoFlat,
@@ -344,7 +346,7 @@ enum InferredBucket {
     ScreenContent,
 }
 
-fn infer_bucket(r: &AnalysisResults) -> InferredBucket {
+pub(crate) fn infer_bucket(r: &AnalysisResults) -> InferredBucket {
     // CALIBRATION-PENDING (2026-04-27, zenanalyze 0.1.x):
     // The peak (`cb_peak_sharpness > 5.0`, `cr_peak_sharpness > 8.0`)
     // and high-freq (`high_freq_energy_ratio > 0.30`) cutoffs below

--- a/zenjpeg/src/encode/zq.rs
+++ b/zenjpeg/src/encode/zq.rs
@@ -250,22 +250,19 @@ impl EncodeMetrics {
 }
 
 /// Maps a user-facing zq value to a starting jpegli-quality estimate for
-/// the iteration loop's first pass.
-///
-/// This is a small lookup table calibrated from the
-/// `examples/method_b_real.rs` corpus run (CID22 + screen content). The
-/// goal is "first pass lands close enough to target that 1–2 correction
-/// passes can refine it"; precision isn't required.
+/// the iteration loop's first pass — content-bucket-naive variant.
 ///
 /// Identity-ish in the typical user range (zq 70–95 maps to jpegli q 70–95).
-/// The iteration loop in `BytesEncoder` corrects from here.
+/// The iteration loop in `BytesEncoder` corrects from here. Used as the
+/// fallback when bucket-aware calibration is unavailable.
+///
+/// See [`zq_to_starting_jpegli_q_for_bucket`] for the bucket-aware form,
+/// which lands closer to target on the first pass and reduces the
+/// correction budget needed.
 #[must_use]
 pub(crate) fn zq_to_starting_jpegli_q(zq: f32) -> f32 {
-    // Empirical: streaming-AQ zensim score at jpegli q lands roughly
-    // 1–3 zq points above the q value on photos, 1–2 below on dense
-    // screen content. Picking q ≈ zq + 1 as the starting point makes
-    // pass 1 land at-or-above target on most images, leaving headroom
-    // for the controller to claw bytes.
+    // Average across content types — picks q ≈ zq + 1 in the photo
+    // range, slightly higher at the top end where the metric saturates.
     const ANCHORS: &[(f32, f32)] = &[
         (40.0, 38.0),
         (60.0, 58.0),
@@ -275,21 +272,121 @@ pub(crate) fn zq_to_starting_jpegli_q(zq: f32) -> f32 {
         (90.0, 93.0),
         (95.0, 97.0),
     ];
+    interpolate_anchors(zq, ANCHORS)
+}
 
-    if zq <= ANCHORS[0].0 {
-        return ANCHORS[0].1;
+/// Linear interpolation over a sorted (zq, jpegli_q) anchor table.
+/// Clamps to endpoints outside the bracketed range.
+fn interpolate_anchors(zq: f32, anchors: &[(f32, f32)]) -> f32 {
+    if anchors.is_empty() {
+        return zq;
     }
-    if zq >= ANCHORS[ANCHORS.len() - 1].0 {
-        return ANCHORS[ANCHORS.len() - 1].1.min(100.0);
+    if zq <= anchors[0].0 {
+        return anchors[0].1;
     }
-    for w in ANCHORS.windows(2) {
+    let last = anchors[anchors.len() - 1];
+    if zq >= last.0 {
+        return last.1.min(100.0);
+    }
+    for w in anchors.windows(2) {
         let (lo, hi) = (w[0], w[1]);
         if zq >= lo.0 && zq <= hi.0 {
             let t = (zq - lo.0) / (hi.0 - lo.0);
             return lo.1 + t * (hi.1 - lo.1);
         }
     }
-    zq // unreachable
+    zq
+}
+
+/// Bucket-aware starting-q calibration. Uses the same anchor-interpolation
+/// pattern as [`zq_to_starting_jpegli_q`] but with a separate table per
+/// content bucket. Each bucket's anchors come from the
+/// `examples/zq_calibrate.rs` corpus harness — initial values below are
+/// hand-distilled from the predictor experiment's per-content
+/// observations until the harness produces a fitted replacement.
+///
+/// Why per-bucket: streaming-AQ score-vs-q curves differ meaningfully by
+/// content type. Screen content needs ~5–8 q points more than photos to
+/// reach the same zq target (text/edges have less perceptual headroom);
+/// flat photos need slightly less. The bucket-naive average misses both
+/// ends, costing extra iterations.
+#[must_use]
+pub(crate) fn zq_to_starting_jpegli_q_for_bucket(
+    zq: f32,
+    bucket: crate::encode::adaptive::InferredBucket,
+) -> f32 {
+    use crate::encode::adaptive::InferredBucket as B;
+    // Anchors are (target_zq, starting_jpegli_q). Median of per-image
+    // smallest-q-meeting-target values, fit by `examples/zq_calibrate.rs`
+    // on a 76-image corpus (CID22 validation + gb82 photos + gb82-sc
+    // screen content). Re-run the harness to refit if the streaming AQ
+    // pipeline or the zensim profile changes.
+    //
+    // Per-bucket sample counts at fit time:
+    //   PhotoNatural   n=7
+    //   PhotoDetailed  n=36
+    //   PhotoFlat      n=13
+    //   Illustration   n=1  (single sample; treat with skepticism, the
+    //                       table will be refined when more illustration
+    //                       content joins the calibration corpus)
+    //   ScreenContent  n=19
+    //
+    // The harness output also reports p25/p75 per anchor for spread
+    // inspection — see `/tmp/zq_calibrate_full.log` snapshot or re-run.
+    const PHOTO_NATURAL: &[(f32, f32)] = &[
+        (40.0, 20.0),
+        (60.0, 25.0),
+        (75.0, 60.0),
+        (80.0, 75.0),
+        (85.0, 90.0),
+        (90.0, 95.0),
+        (95.0, 100.0),
+    ];
+    const PHOTO_DETAILED: &[(f32, f32)] = &[
+        (40.0, 20.0),
+        (60.0, 25.0),
+        (75.0, 70.0),
+        (80.0, 80.0),
+        (85.0, 90.0),
+        (90.0, 100.0),
+        (95.0, 100.0),
+    ];
+    const PHOTO_FLAT: &[(f32, f32)] = &[
+        (40.0, 20.0),
+        (60.0, 20.0),
+        (75.0, 60.0),
+        (80.0, 75.0),
+        (85.0, 90.0),
+        (90.0, 100.0),
+        (95.0, 100.0),
+    ];
+    const ILLUSTRATION: &[(f32, f32)] = &[
+        (40.0, 20.0),
+        (60.0, 20.0),
+        (75.0, 40.0),
+        (80.0, 65.0),
+        (85.0, 85.0),
+        (90.0, 100.0),
+        (95.0, 100.0),
+    ];
+    const SCREEN_CONTENT: &[(f32, f32)] = &[
+        (40.0, 20.0),
+        (60.0, 20.0),
+        (75.0, 45.0),
+        (80.0, 70.0),
+        (85.0, 85.0),
+        (90.0, 95.0),
+        (95.0, 100.0),
+    ];
+
+    let anchors = match bucket {
+        B::PhotoNatural => PHOTO_NATURAL,
+        B::PhotoDetailed => PHOTO_DETAILED,
+        B::PhotoFlat => PHOTO_FLAT,
+        B::Illustration => ILLUSTRATION,
+        B::ScreenContent => SCREEN_CONTENT,
+    };
+    interpolate_anchors(zq, anchors)
 }
 
 // ============================================================================
@@ -545,9 +642,18 @@ pub(crate) fn run_iteration_loop(
         Err(_) => return run_single_pass(&ctx, None),
     };
 
-    // Pass 0: streaming-AQ baseline. Substitute Quality::Zq* with the
-    // resolved starting jpegli q to avoid recursion.
-    let starting_q = ctx.config.quality.to_internal();
+    // Pass 0: streaming-AQ baseline. Substitute Quality::Zq* with a
+    // bucket-aware starting jpegli q (avoids recursion AND lands closer
+    // to target than the bucket-naive lookup).
+    //
+    // Bucket detection runs the analyzer on the source pixels — same
+    // ~1ms cost as `EncoderConfig::adaptive`. Falls through to the
+    // bucket-naive lookup if analysis fails (e.g. tiny images).
+    let bucket = detect_bucket(ctx.pixels, ctx.width, ctx.height);
+    let starting_q = match (ctx.target.target, bucket) {
+        (zq, Some(b)) => zq_to_starting_jpegli_q_for_bucket(zq, b),
+        (zq, None) => zq_to_starting_jpegli_q(zq),
+    };
     let mut pass_config: EncoderConfig = ctx.config.clone();
     pass_config = pass_config.quality(Quality::ApproxJpegli(starting_q));
 
@@ -770,6 +876,22 @@ fn run_single_pass(
             targets_met: true,
         },
     ))
+}
+
+/// Run the analyzer on RGB8 source pixels and return an inferred content
+/// bucket for starting-q calibration. Returns `None` if the image is too
+/// small for the analyzer to produce meaningful features.
+#[cfg(feature = "target-zq")]
+fn detect_bucket(
+    pixels: &[u8],
+    width: u32,
+    height: u32,
+) -> Option<crate::encode::adaptive::InferredBucket> {
+    if width < 8 || height < 8 {
+        return None;
+    }
+    let features = crate::analyze::analyze_rgb8(pixels, width, height);
+    Some(crate::encode::adaptive::infer_bucket(&features))
 }
 
 /// Reinterpret a packed RGB byte slice as `[u8; 3]` chunks. Length must


### PR DESCRIPTION
PR-D in the #113 stack. Stacked on #117 (Quality::Zq API).

## What

Replaces the bucket-naive `zq_to_starting_jpegli_q` lookup with a content-bucket-aware variant. The iteration loop now runs the analyzer (~1ms cost), classifies into one of 5 buckets via the existing `infer_bucket` helper (promoted to `pub(crate)`), and picks the per-bucket starting q from a fitted anchor table.

## Why

The bucket-naive lookup picked an average across content types. Per the #113 PR-B validation experiment, B-met rate dropped from 73% → 51% → 29% as target rose 75 → 80 → 85, mostly because pass 0 missed target by an unpredictable amount. Per-bucket calibration closes that gap on pass 0; the controller's correction budget then handles smaller residuals.

## Calibration source

Anchors fit by `examples/zq_calibrate.rs` from a 76-image mixed corpus:
- CID22 validation (40 photos)
- gb82 (25 photos: smooth, detailed, textured)
- gb82-sc (10 screen content + 1 illustration)

Per-bucket sample counts at fit time:
| bucket | n | confidence |
|---|---|---|
| PhotoNatural | 7 | medium |
| PhotoDetailed | 36 | high |
| PhotoFlat | 13 | medium |
| Illustration | 1 | low (single sample, treat with skepticism) |
| ScreenContent | 19 | high |

Re-run the harness when:
- The streaming AQ pipeline changes (e.g. new SIMD path).
- The zensim profile is replaced (calibration is profile-relative).
- More illustration content joins the calibration corpus.

Output preserved at `zenjpeg/benchmarks/zq_calibration_2026-04-27.log` with p25/p75 spread per anchor.

## Test coverage

- 14 existing zq_target integration tests still pass.
- 1053 bundled tests pass with `--features parallel,trellis,boundary-rd` (byte-identity preserved).
- `infer_bucket` promoted from private to `pub(crate)`; existing adaptive oracle dispatch unchanged.

## Limitations / followups

- Illustration anchors come from n=1; refit when corpus has more.
- Calibration uses 4:2:0 YCbCr; subsampling-specific tables would further close the per-content gap (deferred).
- Validation that B-met rate actually improves on the corpus is coming as a separate measurement run (not in this PR's scope).

## Stack

#117 → #THIS. Will mark ready-for-review once #117 lands.