### PR TITLE
feat(encode): Quality::Zq target-perceptual-quality + AqController + per-bucket calibration (#113 combined)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,9 @@ Cargo.toml.original.txt
 *.profdata
 fuzz-*.log
 .workongoing
+
+# Comprehensive Zq Pareto sweep — multi-megabyte raw TSV outputs.
+# Source-informing data, kept locally (do not delete) but too big for git.
+# Reproduce via examples/zq_pareto_calibrate.rs; summary committed at
+# benchmarks/zq_pareto_<DATE>.summary.md.
+benchmarks/zq_pareto_*.tsv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ zune-jpeg = "0.5"      # Reference decoder for comparison (fastest pure Rust)
 # Quality metrics
 dssim-core = "3.4"
 fast-ssim2 = { version = "0.8.0", features = ["imgref"] }
+# Used by zenjpeg's Quality::Zq target-perceptual-quality closed loop and
+# by various dev-only test/measurement examples.
+zensim = { version = "0.2.6" }
 rayon = "1.10"
 
 # Color conversion (for benchmarking/comparison - faster than libyuv)

--- a/benchmarks/zq_calibration_2026-04-28.log
+++ b/benchmarks/zq_calibration_2026-04-28.log
@@ -1,0 +1,141 @@
+warning: jpegli-internals-sys@0.1.0: Using pre-built jpegli from "/home/lilith/work/zen/zenjpeg/internal/jpegli-cpp/build"
+warning: jpegli-internals-sys@0.1.0: ✓ Building with instrumented C++ FFI (jpegli_test_ffi)
+warning: unused import: `RgbSlice`
+   --> zenjpeg/src/encode/zq.rs:597:18
+    |
+597 |     use zensim::{RgbSlice, Zensim, ZensimProfile};
+    |                  ^^^^^^^^
+    |
+    = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+warning: `zenjpeg` (lib) generated 1 warning (run `cargo fix --lib -p zenjpeg` to apply 1 suggestion)
+    Finished `release` profile [optimized + debuginfo] target(s) in 0.11s
+     Running `target/release/examples/zq_calibrate --corpus /home/lilith/work/codec-eval/codec-corpus/CID22/CID22-512/validation --corpus /home/lilith/work/codec-eval/codec-corpus/CID22/CID22-512/training --corpus /home/lilith/work/codec-eval/codec-corpus/gb82 --corpus /home/lilith/work/codec-eval/codec-corpus/gb82-sc --corpus /home/lilith/work/codec-eval/codec-corpus/clic2025/training --corpus /home/lilith/work/codec-eval/codec-corpus/clic2025/final-test --max-images 1024`
+[zq_calibrate] 347 image(s) across 6 corpora, 17 q values × 7 targets
+  progress: 5/347
+  progress: 10/347
+  progress: 15/347
+  progress: 20/347
+  progress: 25/347
+  progress: 30/347
+  progress: 35/347
+  progress: 40/347
+  progress: 45/347
+  progress: 50/347
+  progress: 55/347
+  progress: 60/347
+  progress: 65/347
+  progress: 70/347
+  progress: 75/347
+  progress: 80/347
+  progress: 85/347
+  progress: 90/347
+  progress: 95/347
+  progress: 100/347
+  progress: 105/347
+  progress: 110/347
+  progress: 115/347
+  progress: 120/347
+  progress: 125/347
+  progress: 130/347
+  progress: 135/347
+  progress: 140/347
+  progress: 145/347
+  progress: 150/347
+  progress: 155/347
+  progress: 160/347
+  progress: 165/347
+  progress: 170/347
+  progress: 175/347
+  progress: 180/347
+  progress: 185/347
+  progress: 190/347
+  progress: 195/347
+  progress: 200/347
+  progress: 205/347
+  progress: 210/347
+  progress: 215/347
+  progress: 220/347
+  progress: 225/347
+  progress: 230/347
+  progress: 235/347
+  progress: 240/347
+  progress: 245/347
+  progress: 250/347
+  progress: 255/347
+  progress: 260/347
+  progress: 265/347
+  progress: 270/347
+  progress: 275/347
+  progress: 280/347
+  progress: 285/347
+  progress: 290/347
+  progress: 295/347
+  progress: 300/347
+  progress: 305/347
+  progress: 310/347
+  progress: 315/347
+  progress: 320/347
+  progress: 325/347
+  progress: 330/347
+  progress: 335/347
+  progress: 340/347
+  progress: 345/347
+
+=== Calibration anchors per bucket ===
+
+// PhotoNatural (n=72)
+const PHOTONATURAL: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=72, p25=20 p50=20 p75=20
+    (60.0, 25.0),  // n=72, p25=20 p50=25 p75=30
+    (75.0, 65.0),  // n=72, p25=60 p50=65 p75=70
+    (80.0, 80.0),  // n=72, p25=75 p50=80 p75=85
+    (85.0, 90.0),  // n=72, p25=90 p50=90 p75=90
+    (90.0, 95.0),  // n=72, p25=95 p50=95 p75=100
+    (95.0, 100.0),  // n=72, p25=100 p50=100 p75=100
+];
+
+// PhotoDetailed (n=140)
+const PHOTODETAILED: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=140, p25=20 p50=20 p75=20
+    (60.0, 30.0),  // n=140, p25=25 p50=30 p75=45
+    (75.0, 75.0),  // n=140, p25=70 p50=75 p75=80
+    (80.0, 85.0),  // n=140, p25=80 p50=85 p75=90
+    (85.0, 95.0),  // n=140, p25=90 p50=95 p75=95
+    (90.0, 100.0),  // n=140, p25=100 p50=100 p75=100
+    (95.0, 100.0),  // n=140, p25=100 p50=100 p75=100
+];
+
+// PhotoFlat (n=85)
+const PHOTOFLAT: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=85, p25=20 p50=20 p75=20
+    (60.0, 20.0),  // n=85, p25=20 p50=20 p75=25
+    (75.0, 60.0),  // n=85, p25=50 p50=60 p75=70
+    (80.0, 75.0),  // n=85, p25=70 p50=75 p75=85
+    (85.0, 90.0),  // n=85, p25=90 p50=90 p75=95
+    (90.0, 100.0),  // n=85, p25=95 p50=100 p75=100
+    (95.0, 100.0),  // n=85, p25=100 p50=100 p75=100
+];
+
+// Illustration (n=4)
+const ILLUSTRATION: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=4, p25=20 p50=20 p75=20
+    (60.0, 20.0),  // n=4, p25=20 p50=20 p75=20
+    (75.0, 40.0),  // n=4, p25=25 p50=40 p75=40
+    (80.0, 65.0),  // n=4, p25=45 p50=65 p75=70
+    (85.0, 85.0),  // n=4, p25=75 p50=85 p75=85
+    (90.0, 100.0),  // n=4, p25=95 p50=100 p75=100
+    (95.0, 100.0),  // n=4, p25=100 p50=100 p75=100
+];
+
+// ScreenContent (n=46)
+const SCREENCONTENT: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=46, p25=20 p50=20 p75=20
+    (60.0, 20.0),  // n=46, p25=20 p50=20 p75=20
+    (75.0, 50.0),  // n=46, p25=30 p50=50 p75=60
+    (80.0, 70.0),  // n=46, p25=60 p50=70 p75=85
+    (85.0, 85.0),  // n=46, p25=80 p50=85 p75=95
+    (90.0, 100.0),  // n=46, p25=95 p50=100 p75=100
+    (95.0, 100.0),  // n=46, p25=100 p50=100 p75=100
+];
+

--- a/benchmarks/zq_pareto_2026-04-28.summary.md
+++ b/benchmarks/zq_pareto_2026-04-28.summary.md
@@ -1,0 +1,104 @@
+# Zq controller — Pareto-optimal config selection findings
+
+**Date:** 2026-04-28  
+**Sweep:** 347 images × 4 sizes (tiny=64, small=256, medium=1024, native) × 8 encoder configs × 21 q values (0–100 step 5) = **233,184 (image, size, config, q) measurements**  
+**Wall time:** 462 s on Ryzen 9 7950X with 16 threads  
+**Raw data:** `benchmarks/zq_pareto_2026-04-28.tsv` (35 MB, gitignored — see `.gitignore`)  
+**Per-image features:** `benchmarks/zq_pareto_features_2026-04-28.tsv` (384 KB, gitignored)  
+**Reproduce:** `cargo run --release -p zenjpeg --features 'target-zq trellis' --example zq_pareto_calibrate`  
+**Fit:** `python3 scripts/zq_pareto_fit.py --pareto benchmarks/zq_pareto_2026-04-28.tsv --features benchmarks/zq_pareto_features_2026-04-28.tsv > benchmarks/zq_pareto_fit_2026-04-28.log`  
+
+## Harness-bug correction (recorded for posterity)
+
+The first sweep run produced byte-identical bytes/zensim across config 0 (`ycbcr_444_baseline`) vs config 2 (`ycbcr_444_progressive`), and analogously 1 vs 3. Cause: `EncoderConfig::ycbcr` defaults `scan_mode` to `ProgressiveScanMode::Progressive`, so passing `progressive(Progressive)` was a no-op — both "baseline" and "progressive" configs ran progressive. Fixed by explicitly setting `progressive(ProgressiveScanMode::Baseline)` on non-progressive configs. Sweep re-run; the numbers below are post-fix.
+
+## Headline result
+
+The current Zq scaffold (single-config bucket+LUT, fixed `ycbcr_420_baseline`) **ships 35–85 % more bytes than Pareto-optimal at zq target ≥ 85**. At zq ≤ 70 the overhead is small; the high-quality regime is where config choice dominates.
+
+## Per-zq-target Pareto-overhead (bucket-1 scaffold vs Pareto-optimal)
+
+| zq target | n   | mean bytes overhead | p50    | p75     |
+|----------:|----:|--------------------:|-------:|--------:|
+| 40        | 270 | +2.1 %              | +0.0 % | +1.7 %  |
+| 50        | 269 | +2.2 %              | +0.0 % | +1.7 %  |
+| 60        | 267 | +3.5 %              | +0.6 % | +3.4 %  |
+| 65        | 267 | +6.8 %              | +1.6 % | +6.2 %  |
+| 70        | 265 | +10.1 %             | +4.1 % | +11.1 % |
+| 75        | 261 | +16.2 %             | +7.4 % | +15.2 % |
+| 80        | 243 | +16.8 %             | +11.6 %| +19.4 % |
+| 85        | 232 | **+34.8 %**         | +22.2 %| +42.2 % |
+| 88        | 211 | **+53.8 %**         | +33.9 %| +63.5 % |
+| 90        | 169 | **+65.5 %**         | +32.4 %| +110.2 %|
+| 92        | 116 | **+85.4 %**         | +80.1 %| +109.6 %|
+| 95        |  22 | +3.9 %              | +4.7 % | +6.2 %  |
+
+## Optimal config by zq target (val set)
+
+| zq  | ycbcr_420_base | ycbcr_420_prog | ycbcr_420_auto | xyb_444 | xyb_420 | ycbcr_444_auto | ycbcr_444_base | ycbcr_444_prog |
+|----:|---------------:|---------------:|---------------:|--------:|--------:|---------------:|---------------:|---------------:|
+|  40 | **59.7 %**     | 29.3 %         | 0.2 %          | 1.3 %   | 1.9 %   | 0.3 %          | 3.9 %          | 3.4 %          |
+|  50 | **54.6 %**     | 32.7 %         | 0.3 %          | 1.8 %   | 2.7 %   | 0.4 %          | 4.3 %          | 3.2 %          |
+|  60 | **43.3 %**     | 39.0 %         | 2.0 %          | 3.7 %   | 3.5 %   | 0.3 %          | 5.0 %          | 3.0 %          |
+|  65 | **37.7 %**     | 36.3 %         | 8.9 %          | 6.0 %   | 1.8 %   | 0.5 %          | 6.0 %          | 2.9 %          |
+|  70 | 26.2 %         | 23.1 %         | **28.0 %**     | 7.4 %   | 1.7 %   | 2.2 %          | 9.1 %          | 2.2 %          |
+|  75 | 16.8 %         | 11.0 %         | **37.2 %**     | 16.3 %  | 1.5 %   | 5.6 %          | 9.9 %          | 1.7 %          |
+|  80 | 11.6 %         | 7.8 %          | **30.7 %**     | 25.6 %  | 3.7 %   | 9.9 %          | 8.9 %          | 1.8 %          |
+|  85 | 4.6 %          | 3.3 %          | 14.2 %         | **37.9 %**| 6.3 % | 17.2 %         | 10.7 %         | 5.8 %          |
+|  90 | 2.7 %          | 4.3 %          | 7.0 %          | **39.1 %**| 23.3 %| 14.6 %         | 4.7 %          | 4.3 %          |
+|  95 | 1.4 %          | 1.5 %          | 3.2 %          | 2.0 %   | **56.5 %**| 8.7 %       | 2.1 %          | 24.6 %         |
+
+## Phase transitions in the optimal-config curve
+
+- **zq ≤ 65**: `ycbcr_420` (baseline + progressive combined: 79–82 %) dominates. Progressive variant carries ~30–39 % share. The classic "web JPEG" regime.
+- **70 ≤ zq ≤ 80**: `ycbcr_420_auto_optimize` (hybrid trellis at L=14.5) takes over (28–37 % share). XYB rises to 16–26 %.
+- **85 ≤ zq ≤ 90**: `xyb_444_baseline` is king (38–39 %). The wider XYB dynamic range starts paying off. `ycbcr_*_auto_optimize` is the runner-up.
+- **zq ≥ 92**: switch to `xyb_420_baseline` — once chroma resolution is preserved by Y-quality, halving chroma is the cheapest knob to spend. Notable: `ycbcr_444_progressive` resurfaces at zq=95 (24.6 %) — a different operating point where YCbCr 4:4:4 progressive Huffman-optimization beats XYB.
+
+## Progressive scan IS Pareto-relevant
+
+Combined ycbcr_420 (baseline + progressive) shares: ~80 % at zq ≤ 65, dropping to ~10 % at zq ≥ 85. Progressive is most valuable at low-to-mid quality where Huffman optimization pays the largest relative price. Earlier finding that "progressive was 0 % optimal" was a harness-bug artifact.
+
+## Per-config starting-q regression
+
+We trained `predict_starting_q(features, target_zq)` for each of 8 configs via least-squares on a 278-image training split (69 held out for validation). Held-out RMSE 8.3–11.1 q points. See `benchmarks/zq_pareto_fit_2026-04-28.log` for the weights vector.
+
+## Search space NOT covered (follow-up axes)
+
+The 8-config grid here covers `(color_mode, sub, scan, auto_optimize)` but holds these axes fixed at defaults:
+
+- **Separate chroma quality** (`EncoderConfig::chroma_quality` / `chroma_distance_scale`). The user's a-priori knowledge is that chroma sampling AND chroma quality vary materially with image features (chroma_complexity / cb-cr_peak_sharpness). Sweeping chroma_quality offset {-15, -10, -5, 0, +5, +10} would 6× the cell count. Important follow-up.
+- **Chroma subsampling 4:2:2 (`HalfHorizontal` and `HalfVertical`)**: only 4:4:4 and 4:2:0 swept here.
+- **Trellis lambda** (when `auto_optimize=false`): hybrid trellis at L=14.5 only via auto_optimize. Lambdas 8 / 12 / 18 / 25 unswept.
+- **Dequant bias** (`Decoder::dequant_bias`): decoder-side, doesn't affect this sweep but should appear in the final controller's tuning surface for round-trip RD.
+
+Filed as follow-up sweeps in `imazen/zenjpeg#128`.
+
+## Implications for the controller (architectural)
+
+The current `Quality::Zq(target)` API operates within a fixed `EncoderConfig` — color_mode, sub, scan, auto_optimize are all set by the caller before quality is decided. To deliver "smallest bytes at zensim ≥ T", **the controller must choose those knobs** based on `(target_zq, image_features)`.
+
+But the caller may need *some* dimensions fixed (e.g., HDR pipeline forces XYB; streaming UX requires progressive scan; decoder constraint caps at 4:2:0). Proposed shape:
+
+```rust
+let cfg = EncoderConfig::for_perceptual_target(target_zq)
+    .with_constraints(
+        ZqConstraints::default()
+            .require_color_mode(ColorMode::Xyb)            // optional
+            .require_progressive(true)                     // optional
+            .max_chroma_subsampling(Subsampling::Quarter)  // optional
+            .forbid_auto_optimize()                        // optional
+            .chroma_quality_range(60..=100)                // optional
+    )
+    .build_with_features(&analysis);
+```
+
+Defaults (no constraints): controller free-chooses everything. Constraints scope-restrict the search; the controller picks the unconstrained dimensions Pareto-optimally from the trained model.
+
+## What this PR ships
+
+- The harness (`examples/zq_pareto_calibrate.rs`), analysis tool (`scripts/zq_pareto_fit.py`), and emitter (`scripts/zq_emit_rust.py`).
+- The single-config bucket-LUT scaffold (`encode/zq.rs`) — recalibrated on the 347-image corpus.
+- This summary documenting the size of the gap and the path forward.
+
+The Pareto-controller follow-up (capture the 35-85 % byte savings + accept caller constraints + add chroma quality sweep) is `imazen/zenjpeg#128`.

--- a/benchmarks/zq_pareto_fit_2026-04-28.log
+++ b/benchmarks/zq_pareto_fit_2026-04-28.log
@@ -1,0 +1,76 @@
+# Loading benchmarks/zq_pareto_2026-04-28b.tsv...
+# Loaded 1388 (image, size) cells
+# Loaded 1388 feature rows × 19 columns
+# Joined keys: 1388
+
+## Train/val split
+- val images: 69
+- train images: 278
+
+## Pareto-front summary 
+- (image, size) cells: 1388 
+- median |Pareto front|: 40.0  (a perfect single-config dominator would give 1)
+
+### Optimal-config frequency across all (image, size, zq_target) labels:
+- config 1 (ycbcr_420_baseline): 3638 (22.2%)
+- config 4 (xyb_444_baseline): 2911 (17.8%)
+- config 3 (ycbcr_420_progressive): 2643 (16.2%)
+- config 6 (ycbcr_420_auto_optimize): 2070 (12.7%)
+- config 5 (xyb_420_baseline): 1924 (11.8%)
+- config 7 (ycbcr_444_auto_optimize): 1203 (7.4%)
+- config 0 (ycbcr_444_baseline): 1094 (6.7%)
+- config 2 (ycbcr_444_progressive): 880 (5.4%)
+
+## Per-config regression — predict starting_q given (features, zq)
+
+### config 0 (ycbcr_444_baseline)
+- train n=12917, val n=3232
+- val RMSE: 11.13  bias: +0.36
+- weights = [16.0477, -138.9837, 230.952, 0.0003, -0.8828, 38.5038, -60.6975, 55.2309, -57.5656, 41.8486, -68.6869, -42.4601, 26.5839, -14.4772, 50.6614, -13.6024, 50.0944, -0.1448, 0.8638, -0.011, 1.1834, 0.0004, -0.5167]
+### config 1 (ycbcr_420_baseline)
+- train n=10476, val n=2592
+- val RMSE: 9.29  bias: -0.37
+- weights = [-3.8961, -115.2817, 229.9978, 0.001, -2.9465, -6.4698, -1.1237, 29.353, -27.609, 23.8655, -46.3561, -11.4236, -8.7966, -16.2735, 62.0281, -14.144, 53.6846, 0.0477, 0.8065, 0.1206, 0.3623, 0.0004, 1.6308]
+### config 2 (ycbcr_444_progressive)
+- train n=12917, val n=3232
+- val RMSE: 11.13  bias: +0.36
+- weights = [16.0477, -138.9837, 230.952, 0.0003, -0.8828, 38.5038, -60.6975, 55.2309, -57.5656, 41.8486, -68.6869, -42.4601, 26.5839, -14.4772, 50.6614, -13.6024, 50.0944, -0.1448, 0.8638, -0.011, 1.1834, 0.0004, -0.5167]
+### config 3 (ycbcr_420_progressive)
+- train n=10476, val n=2592
+- val RMSE: 9.29  bias: -0.37
+- weights = [-3.8961, -115.2817, 229.9978, 0.001, -2.9465, -6.4698, -1.1237, 29.353, -27.609, 23.8655, -46.3561, -11.4236, -8.7966, -16.2735, 62.0281, -14.144, 53.6846, 0.0477, 0.8065, 0.1206, 0.3623, 0.0004, 1.6308]
+### config 4 (xyb_444_baseline)
+- train n=13093, val n=3268
+- val RMSE: 10.95  bias: +0.50
+- weights = [36.3379, -151.4802, 236.9282, 0.0002, -1.323, 57.1821, -88.4853, 10.2012, -7.2657, 31.8978, -57.2003, -65.8404, 61.4758, -13.8686, 44.8787, -10.197, 38.5808, -0.2741, 0.925, -0.0345, 1.2113, 0.0006, -1.369]
+### config 5 (xyb_420_baseline)
+- train n=12734, val n=3196
+- val RMSE: 9.02  bias: +0.02
+- weights = [9.6226, -80.7736, 189.462, 0.0006, -2.3968, 2.4621, -18.5855, -126.8169, 150.0206, 17.8803, -37.017, -39.9085, 32.0508, -10.8835, 39.7057, -8.663, 33.6279, -0.1058, 0.9068, 0.0075, 0.2237, 0.0004, 0.335]
+### config 6 (ycbcr_420_auto_optimize)
+- train n=10520, val n=2600
+- val RMSE: 8.32  bias: -0.25
+- weights = [14.4694, -154.2255, 255.8865, 0.001, -2.7704, -11.549, 1.6463, 45.6728, -44.8191, 24.3874, -45.5847, -18.1858, -0.2004, -14.0646, 52.4442, -13.5261, 49.6839, 0.0384, 0.8039, 0.1093, 0.551, 0.0004, 1.2761]
+### config 7 (ycbcr_444_auto_optimize)
+- train n=12932, val n=3234
+- val RMSE: 10.65  bias: +0.45
+- weights = [30.9221, -166.2621, 248.0084, 0.0003, -0.8913, 45.6468, -71.0653, 82.529, -87.5045, 39.8173, -64.5218, -47.215, 32.4662, -13.9171, 45.1015, -12.7421, 46.1246, -0.1613, 0.7729, -0.0157, 1.3319, 0.0004, -0.8281]
+
+## Pareto-overhead (bytes vs ideal, config-naive)
+
+zq_tgt | n | mean overhead | p50 | p75 |
+-------|---|---------------|-----|-----|
+ 40    | 270 | +2.1%       | +0.0% | +1.7% |
+ 50    | 269 | +2.2%       | +0.0% | +1.7% |
+ 60    | 267 | +3.5%       | +0.6% | +3.4% |
+ 65    | 267 | +6.8%       | +1.6% | +6.2% |
+ 70    | 265 | +10.1%       | +4.1% | +11.1% |
+ 75    | 261 | +16.2%       | +7.4% | +15.2% |
+ 80    | 243 | +16.8%       | +11.6% | +19.4% |
+ 85    | 232 | +34.8%       | +22.2% | +42.2% |
+ 88    | 211 | +53.8%       | +33.9% | +63.5% |
+ 90    | 169 | +65.5%       | +32.4% | +110.2% |
+ 92    | 116 | +85.4%       | +80.1% | +109.6% |
+ 95    |  22 | +3.9%       | +4.7% | +6.2% |
+
+Interpretation: overhead is bytes-vs-Pareto for the bucket-1-naive (ycbcr_420_baseline) controller. Positive = the naive controller ships more bytes than necessary; negative = the chosen target wasn't reached and the scaffold falls back.

--- a/docs/zq-streaming-diffmap-design.md
+++ b/docs/zq-streaming-diffmap-design.md
@@ -1,0 +1,205 @@
+# Per-window streaming diffmap measurement (zenjpeg #113 PR-F)
+
+Design doc for the per-window streaming diffmap measurement layer of the
+target-zq closed-loop encoder. Context: the iteration loop currently
+runs a full-image diffmap per pass, which dominates encode cost on large
+images. This doc proposes amortizing the cost via a per-window streaming
+consumer in zensim.
+
+Status: design only. No implementation yet. Coordination needed with
+upstream zensim before zenjpeg-side wiring.
+
+## Problem
+
+Today's iteration loop in `BytesEncoder::finish_with_metrics` (after
+PR-B / #117) does, per pass:
+
+```
+encode → decode → compute_with_ref_and_diffmap (FULL IMAGE) → adjust
+```
+
+`compute_with_ref_and_diffmap` cost on a 4K image is ~91 ms threaded,
+~366 ms single-threaded (per zensim README). For typical 2-pass
+encodes, the diffmap cost is ~30–50 % of total time. On larger images
+this fraction grows — at 8K it dominates.
+
+## Goal
+
+Replace the full-image measurement with a per-window streaming consumer
+that:
+
+1. Accepts strips of distorted pixels as the encoder produces them
+   (every K iMCU rows, where K is small — 4 to 8 strips per encode).
+2. Maintains rolling `ScaleAccumulators` against a precomputed source
+   reference.
+3. Emits per-strip "score contribution" deltas the controller can use
+   between pass boundaries.
+4. Finalizes to the canonical full-image score within FP epsilon.
+
+Cost model:
+- One-time: `PrecomputedReference::new` on source (~half a full-image
+  diffmap cost). Reused across all passes.
+- Per strip: ~`width * STRIP_INNER` pixel cost. STRIP_INNER = 16 in
+  zensim today; aligns with one 4:2:0 iMCU row.
+
+For the iteration loop this means: pass cost ≈ encode + IDCT-back +
+per-strip metric, all scaling linearly with image area but with smaller
+per-pixel constants than full-image diffmap.
+
+## Proposed upstream zensim API
+
+```rust
+// New public type in zensim::streaming.
+
+/// Per-strip streaming consumer that accumulates distorted-side
+/// contributions against a precomputed source reference. Produces a
+/// canonical full-image DiffmapResult on finalize.
+pub struct StreamingDiffmap<'a> {
+    /// Borrow of the precomputed source pyramid; never modified.
+    reference: &'a PrecomputedReference,
+    /// Internal per-scale accumulators, shape mirrors the reference's
+    /// pyramid.
+    scales: Vec<ScaleAccumulators>,
+    /// User-supplied diffmap shaping options.
+    options: DiffmapOptions,
+    /// Rows pushed so far; finalized when this hits image height.
+    rows_pushed: usize,
+}
+
+impl<'a> StreamingDiffmap<'a> {
+    pub fn new(
+        reference: &'a PrecomputedReference,
+        options: DiffmapOptions,
+    ) -> Self;
+
+    /// Push `rows` rows of distorted pixels starting at `strip_y` in
+    /// the source coordinate system. `rows` must be a multiple of
+    /// STRIP_INNER (16) except possibly the final strip.
+    ///
+    /// Returns `Some((score_contribution, ...))` when this push
+    /// completes a full strip's accumulators; `None` while waiting
+    /// for more rows. The score contribution is the delta this strip
+    /// adds to the running full-image score.
+    pub fn push_distorted_strip(
+        &mut self,
+        distorted: &impl ImageSource,
+        strip_y: usize,
+        rows: usize,
+    ) -> Option<StripContribution>;
+
+    /// Linear-planar variant for encoder pipelines that already have
+    /// linear-RGB f32 strips on hand (no need to interleave back to
+    /// RGB8 just to feed the metric).
+    pub fn push_distorted_strip_linear_planar(
+        &mut self,
+        planes: [&[f32]; 3],
+        strip_y: usize,
+        rows: usize,
+        stride: usize,
+    ) -> Option<StripContribution>;
+
+    /// Finalize and return the full DiffmapResult. Must be called
+    /// after exactly `image_height` rows have been pushed.
+    pub fn finalize(self) -> DiffmapResult;
+
+    /// Instantaneous estimate of the full-image score from
+    /// already-finalized strip accumulators. Useful for early-stop
+    /// heuristics; final value comes from `finalize`.
+    pub fn current_score(&self) -> f32;
+}
+
+pub struct StripContribution {
+    /// Strip's contribution to the running zensim score (signed delta).
+    pub score_delta: f32,
+    /// Per-block diffmap for the strip rows that just completed
+    /// (block-aligned, length = blocks_w * (rows / 8)).
+    pub block_diffmap: Vec<f32>,
+}
+```
+
+## Multi-scale boundary handling
+
+zensim is multi-scale (4 levels, 2× downsampled each, per the v0.2
+profile). Scale 3 = 8× downsampled, so features at row Y depend on
+rows Y±32 at full resolution. A pure-window measurement that only sees
+[Y, Y+STRIP] has wrong features near the strip edges.
+
+The internal `streaming.rs` already handles this with rolling band
+buffers — `STRIP_INNER = 16` rows of "valid" output backed by
+lookahead/lookback for higher-scale context. The proposed
+`StreamingDiffmap` consumer just exposes that internal state machine
+publicly; the boundary math is already correct.
+
+**Test-slice validation strategy** (per #113 user direction):
+
+1. Pick a corpus of test images (CID22 + screen content, ~30 images).
+2. For each image, encode at q=80, decode.
+3. Compute one-shot `compute_with_ref_and_diffmap` → reference score S₀.
+4. Compute strip-by-strip via `StreamingDiffmap::push_distorted_strip`
+   → finalized score S_n.
+5. Assert |S_n − S₀| < ε for ε = 1e-4 (FP rounding tolerance).
+6. Repeat with non-aligned slice subsets (e.g. push the first 7 strips,
+   skip 1, push the rest) to catch any "valid only when aligned"
+   regressions in the boundary handling.
+
+## zenjpeg-side changes (after upstream lands)
+
+`zq.rs::run_iteration_loop` would become:
+
+```rust
+let mut streaming = StreamingDiffmap::new(&pre, DiffmapOptions::default());
+
+// Pass 0: encode, push strips into streaming consumer as they're
+// finalized by the strip processor.
+for strip in encoder.strips() {
+    let decoded_strip = idct_back(strip);
+    if let Some(contrib) = streaming.push_distorted_strip(&decoded_strip, ...) {
+        // Per-strip controller hook: adjust AQ for next strip based on
+        // contrib.block_diffmap.
+        controller.observe(strip_y, contrib);
+    }
+}
+let result = streaming.finalize();
+```
+
+This collapses encode + measure into a single pass with strip-level
+feedback. The per-pass full-image diffmap cost vanishes; what's left is
+just the IDCT-back of the just-encoded blocks (which we have in
+memory anyway).
+
+## Open questions
+
+1. **Per-strip score deltas vs only-finalize semantics?** If callers
+   only ever use `finalize()`, the per-strip return value is overhead.
+   Maybe have two modes: `StreamingDiffmap::silent()` and
+   `::with_strip_feedback()`.
+
+2. **Memory ownership of accumulators.** The internal
+   `ScaleAccumulators` are sized by the source pyramid. For a 4K image
+   that's ~50 MB of f32 buffers. Should `StreamingDiffmap::new` take
+   `&mut PrecomputedReference` to allow pooling, or is allocate-per-call
+   fine?
+
+3. **`current_score()` precision.** Strip-level streaming inherently
+   has slight pyramid-fusion-order differences from one-shot. The
+   "canonical full-image score" comes from `finalize()`; `current_score`
+   is an estimate. Does that estimate need a documented error bar?
+
+## Tracking
+
+- zenjpeg #113 PR-F (this design): zenjpeg/docs/zq-streaming-diffmap-design.md
+- Upstream zensim issue: TODO (to be filed after this design lands)
+- Existing experimental ctor exposure (zensim/--diffmap-public-ctors
+  workspace): supersede / discard once StreamingDiffmap lands —
+  internal-ctor exposure isn't needed if the public consumer covers
+  the use case.
+
+## Order of operations
+
+1. Open upstream zensim issue with this design (link this doc).
+2. Land the internal `StreamingDiffmap` API in zensim.
+3. Ship a zensim release with the new public API.
+4. zenjpeg PR-F: bump zensim dep, replace `compute_with_ref_and_diffmap`
+   with the streaming consumer in `run_iteration_loop`.
+5. Validate convergence behavior didn't regress (zq_target tests
+   should pass unchanged; per-pass time should drop on large images).

--- a/scripts/zq_emit_rust.py
+++ b/scripts/zq_emit_rust.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Emit Rust source for the Pareto-trained Zq controller.
+
+Reads the JSON output of zq_pareto_fit.py (--emit-json mode) and writes
+a Rust file that:
+  1. Defines the 8-config enum (matches harness's ConfigSpec table).
+  2. Bakes per-config regression coefficients as `const`.
+  3. Provides `predict_zq(features, target_zq) -> (config_id, starting_q)`
+     that runs the per-config regressors, classifies (smallest predicted
+     bytes), returns (chosen_config, predicted_q).
+
+Output is hand-pasted into `zenjpeg/src/encode/zq.rs`.
+"""
+
+import argparse
+import json
+import sys
+
+
+def emit(json_path, out_path):
+    with open(json_path) as f:
+        fit = json.load(f)
+
+    cfg_names = fit["configs"]
+    feature_cols = fit["feature_cols"]
+    weights = fit["weights"]  # cfg_id -> [w0, w1, ...]
+
+    src = ["// Auto-generated from scripts/zq_emit_rust.py — do not hand-edit.",
+           f"// Source: {json_path}",
+           "",
+           "/// Pareto-trained zq controller — predict (config, starting_q) from "
+           "(features, zq_target).",
+           "#[allow(dead_code)]",
+           "pub(crate) struct ParetoZqModel;",
+           ""]
+
+    for cfg_id, cfg_name in cfg_names.items():
+        ws = weights.get(str(cfg_id))
+        if ws is None:
+            continue
+        src.append(f"// config {cfg_id}: {cfg_name}")
+        src.append(f"const W_{cfg_name.upper()}: &[f32; {len(ws)}] = &[")
+        for w in ws:
+            src.append(f"    {w:+.6e},")
+        src.append("];")
+        src.append("")
+
+    print("\n".join(src), file=open(out_path, "w") if out_path else sys.stdout)
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--json", required=True)
+    p.add_argument("--out", default=None)
+    a = p.parse_args()
+    emit(a.json, a.out)

--- a/scripts/zq_pareto_fit.py
+++ b/scripts/zq_pareto_fit.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""
+Offline Pareto-front analysis + regression fit for the Zq perceptual-target controller.
+
+Input:
+  - benchmarks/zq_pareto_<DATE>.tsv          : (image, size, config, q) → (bytes, zensim)
+  - benchmarks/zq_pareto_<DATE>_features.tsv : (image, size) → zenanalyze features
+
+Output (stdout):
+  - Per-(image, size) Pareto front statistics
+  - Optimal (config, q) labels at every target_zq for every (image, size)
+  - Trained regression coefficients: (features, target_zq) → predicted_starting_q
+    per config. Plus a config-classifier: (features, target_zq) → best_config_id.
+  - Held-out validation error.
+
+Usage:
+  python3 scripts/zq_pareto_fit.py \
+    --pareto benchmarks/zq_pareto_2026-04-28.tsv \
+    --features benchmarks/zq_pareto_2026-04-28_features.tsv \
+    [--zq-targets 40,50,60,70,80,85,90,95] \
+    [--holdout-frac 0.2] \
+    [--seed 0]
+"""
+
+import argparse
+import csv
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# Configuration (must mirror the Rust harness's ConfigSpec table) -------
+CONFIGS = {
+    0: "ycbcr_444_baseline",
+    1: "ycbcr_420_baseline",
+    2: "ycbcr_444_progressive",
+    3: "ycbcr_420_progressive",
+    4: "xyb_444_baseline",
+    5: "xyb_420_baseline",
+    6: "ycbcr_420_auto_optimize",
+    7: "ycbcr_444_auto_optimize",
+}
+
+DEFAULT_ZQ_TARGETS = [40, 50, 60, 65, 70, 75, 80, 85, 88, 90, 92, 95]
+SIZE_RANK = {"tiny": 0, "small": 1, "medium": 2, "large": 3}
+
+
+def load_pareto(path):
+    """Load the (image, size, config, q) → (bytes, zensim) TSV.
+
+    Returns dict[(image, size_class)] -> list of (config_id, q, bytes, zensim).
+    Skips rows where bytes/zensim are blank (encode failure)."""
+    rows = defaultdict(list)
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for r in rdr:
+            if not r["bytes"] or not r["zensim"]:
+                continue
+            try:
+                key = (r["image_path"], r["size_class"])
+                rows[key].append((
+                    int(r["config_id"]),
+                    int(r["q"]),
+                    int(r["bytes"]),
+                    float(r["zensim"]),
+                ))
+            except (ValueError, KeyError):
+                continue
+    return rows
+
+
+def load_features(path):
+    """Load per-(image, size_class) feature row.
+
+    Returns dict[(image, size_class)] -> dict[feature_name -> float], plus
+    the ordered list of feature column names."""
+    feats = {}
+    cols = []
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for fld in rdr.fieldnames or []:
+            if fld.startswith("feat_"):
+                cols.append(fld)
+        for r in rdr:
+            key = (r["image_path"], r["size_class"])
+            row = {}
+            for c in cols:
+                v = r[c]
+                try:
+                    row[c] = float(v) if v else 0.0
+                except ValueError:
+                    row[c] = 0.0
+            feats[key] = row
+    return feats, cols
+
+
+def pareto_front(points):
+    """Given a list of (config_id, q, bytes, zensim), return the subset
+    that's Pareto-optimal in the (-bytes, +zensim) sense.
+
+    A point is dominated iff some other point has fewer-or-equal bytes
+    AND >= zensim AND strict-better in at least one. We keep undominated."""
+    pts = sorted(points, key=lambda p: (p[2], -p[3]))  # by bytes asc, zensim desc
+    front = []
+    best_z = -math.inf
+    for p in pts:
+        if p[3] > best_z:
+            front.append(p)
+            best_z = p[3]
+    return front
+
+
+def best_at_zq(points, target_zq):
+    """Smallest-bytes (config, q) achieving zensim >= target_zq.
+
+    Returns (config_id, q, bytes, zensim) or None if no point meets target."""
+    feasible = [p for p in points if p[3] >= target_zq]
+    if not feasible:
+        return None
+    return min(feasible, key=lambda p: (p[2], p[1]))  # by bytes, tiebreak by q
+
+
+def lstsq(X, y):
+    """Plain least-squares: returns w such that X @ w ≈ y.
+
+    Closed-form normal-equation solver, no numpy dep."""
+    n_rows = len(X)
+    n_cols = len(X[0]) if n_rows else 0
+    # XtX = X^T X
+    XtX = [[0.0] * n_cols for _ in range(n_cols)]
+    Xty = [0.0] * n_cols
+    for r in range(n_rows):
+        for i in range(n_cols):
+            xi = X[r][i]
+            Xty[i] += xi * y[r]
+            for j in range(i, n_cols):
+                XtX[i][j] += xi * X[r][j]
+    for i in range(n_cols):
+        for j in range(i):
+            XtX[i][j] = XtX[j][i]
+    # Solve via Cholesky of XtX + small ridge for numerical stability.
+    eps = 1e-6
+    for i in range(n_cols):
+        XtX[i][i] += eps
+    L = [[0.0] * n_cols for _ in range(n_cols)]
+    for i in range(n_cols):
+        for j in range(i + 1):
+            s = XtX[i][j] - sum(L[i][k] * L[j][k] for k in range(j))
+            if i == j:
+                if s <= 0:
+                    return [0.0] * n_cols
+                L[i][j] = math.sqrt(s)
+            else:
+                L[i][j] = s / L[j][j]
+    # Forward solve L · v = Xty
+    v = [0.0] * n_cols
+    for i in range(n_cols):
+        v[i] = (Xty[i] - sum(L[i][k] * v[k] for k in range(i))) / L[i][i]
+    # Back-solve L^T · w = v
+    w = [0.0] * n_cols
+    for i in reversed(range(n_cols)):
+        w[i] = (v[i] - sum(L[k][i] * w[k] for k in range(i + 1, n_cols))) / L[i][i]
+    return w
+
+
+def build_design_matrix(feature_rows, feature_cols, zq_target):
+    """Build a feature matrix with light non-linearity.
+
+    Columns:
+      [0]   1.0 (intercept)
+      [1]   zq_target
+      [2]   zq_target ** 2
+      [3..] selected features (raw + log1p of saturating features)
+    """
+    SELECTED = [
+        "feat_variance",
+        "feat_edge_density",
+        "feat_chroma_complexity",
+        "feat_uniformity",
+        "feat_flat_color_block_ratio",
+        "feat_high_freq_energy_ratio",
+        "feat_luma_histogram_entropy",
+        "feat_cb_peak_sharpness",
+        "feat_cr_peak_sharpness",
+        "feat_distinct_color_bins",
+    ]
+    SELECTED = [c for c in SELECTED if c in feature_cols]
+    X = []
+    for row in feature_rows:
+        r = [
+            1.0,
+            zq_target / 100.0,
+            (zq_target / 100.0) ** 2,
+        ]
+        for c in SELECTED:
+            v = row.get(c, 0.0)
+            r.append(v)
+            r.append(math.log1p(max(0.0, v)))
+        X.append(r)
+    return X, SELECTED
+
+
+def median(xs):
+    s = sorted(xs)
+    n = len(s)
+    if n == 0:
+        return float("nan")
+    if n % 2:
+        return float(s[n // 2])
+    return (s[n // 2 - 1] + s[n // 2]) / 2.0
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--pareto", required=True)
+    p.add_argument("--features", required=True)
+    p.add_argument(
+        "--zq-targets",
+        default=",".join(str(z) for z in DEFAULT_ZQ_TARGETS),
+        help="Comma-separated zq_targets to fit at",
+    )
+    p.add_argument("--holdout-frac", type=float, default=0.2)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument(
+        "--per-config-fit",
+        action="store_true",
+        help="Fit one regression per config (default: also fit a single shared model)",
+    )
+    args = p.parse_args()
+
+    targets = [int(x) for x in args.zq_targets.split(",")]
+
+    print(f"# Loading {args.pareto}...", file=sys.stderr)
+    pareto = load_pareto(args.pareto)
+    print(f"# Loaded {len(pareto)} (image, size) cells", file=sys.stderr)
+    feats, feat_cols = load_features(args.features)
+    print(f"# Loaded {len(feats)} feature rows × {len(feat_cols)} columns", file=sys.stderr)
+
+    # ----- Build label set: per (image, size, target_zq) → (config*, q*).
+    # Drop cells where features are missing OR no Pareto point meets any target.
+    keys = sorted(set(pareto.keys()) & set(feats.keys()))
+    print(f"# Joined keys: {len(keys)}", file=sys.stderr)
+
+    labels = defaultdict(dict)  # (image, size) -> {zq_target -> (cfg, q, bytes, zensim)}
+    pareto_sizes = []
+    config_choices = defaultdict(int)
+    for key in keys:
+        front = pareto_front(pareto[key])
+        pareto_sizes.append(len(front))
+        for tz in targets:
+            best = best_at_zq(pareto[key], tz)
+            if best is not None:
+                labels[key][tz] = best
+                config_choices[best[0]] += 1
+
+    print(
+        f"\n## Pareto-front summary",
+        f"\n- (image, size) cells: {len(keys)}",
+        f"\n- median |Pareto front|: {median(pareto_sizes):.1f}  (a perfect single-config dominator would give 1)",
+    )
+    print("\n### Optimal-config frequency across all (image, size, zq_target) labels:")
+    total_labels = sum(config_choices.values())
+    for cfg_id in sorted(config_choices.keys(), key=lambda c: -config_choices[c]):
+        n = config_choices[cfg_id]
+        pct = 100 * n / total_labels if total_labels else 0
+        print(f"- config {cfg_id} ({CONFIGS[cfg_id]}): {n} ({pct:.1f}%)")
+
+    # Held-out split: split *images* (not (image, size, zq)) so a single
+    # source can't leak between train and val.
+    import random
+    rng = random.Random(args.seed)
+    images = sorted({k[0] for k in keys})
+    rng.shuffle(images)
+    n_val = max(1, int(len(images) * args.holdout_frac))
+    val_images = set(images[:n_val])
+    train_images = set(images[n_val:])
+    print(f"\n## Train/val split", file=sys.stderr)
+    print(f"- val images: {len(val_images)}", file=sys.stderr)
+    print(f"- train images: {len(train_images)}", file=sys.stderr)
+
+    train_keys = [k for k in keys if k[0] in train_images]
+    val_keys = [k for k in keys if k[0] in val_images]
+
+    # ----- Per-config regression: predict optimal_q within each config for
+    # the subset of (image, size, zq) where THAT config was on the Pareto
+    # front (or close enough). Each config has its own fit so feature
+    # interactions are kept inside one config.
+    print(f"\n## Per-config regression — predict starting_q given (features, zq)\n")
+    for cfg_id in sorted(CONFIGS.keys()):
+        # Collect samples: for every (key, tz), if cfg_id appears in
+        # pareto[key] AT zq_target ≥ tz, the smallest q within cfg_id
+        # achieving zensim ≥ tz is our regression label.
+        train_X_rows = []
+        train_y = []
+        for key in train_keys:
+            pts_in_cfg = [(c, q, b, z) for (c, q, b, z) in pareto[key] if c == cfg_id]
+            if not pts_in_cfg:
+                continue
+            for tz in targets:
+                feasible = [p for p in pts_in_cfg if p[3] >= tz]
+                if not feasible:
+                    continue
+                # Smallest-q-meeting-target within this config.
+                best_q = min(feasible, key=lambda p: (p[1], p[2]))[1]
+                fr = feats.get(key)
+                if fr is None:
+                    continue
+                # Build single-row design.
+                X1, _ = build_design_matrix([fr], feat_cols, tz)
+                train_X_rows.append(X1[0])
+                train_y.append(float(best_q))
+        if not train_X_rows:
+            print(f"### config {cfg_id} ({CONFIGS[cfg_id]}): NO TRAINING DATA")
+            continue
+        w = lstsq(train_X_rows, train_y)
+        # Validation error.
+        val_errs = []
+        for key in val_keys:
+            pts_in_cfg = [(c, q, b, z) for (c, q, b, z) in pareto[key] if c == cfg_id]
+            if not pts_in_cfg:
+                continue
+            for tz in targets:
+                feasible = [p for p in pts_in_cfg if p[3] >= tz]
+                if not feasible:
+                    continue
+                best_q = min(feasible, key=lambda p: (p[1], p[2]))[1]
+                fr = feats.get(key)
+                if fr is None:
+                    continue
+                X1, _ = build_design_matrix([fr], feat_cols, tz)
+                pred = sum(xi * wi for xi, wi in zip(X1[0], w))
+                val_errs.append(pred - best_q)
+        rmse = math.sqrt(sum(e * e for e in val_errs) / max(1, len(val_errs))) if val_errs else float("nan")
+        bias = sum(val_errs) / max(1, len(val_errs)) if val_errs else float("nan")
+        print(f"### config {cfg_id} ({CONFIGS[cfg_id]})")
+        print(f"- train n={len(train_X_rows)}, val n={len(val_errs)}")
+        print(f"- val RMSE: {rmse:.2f}  bias: {bias:+.2f}")
+        print(f"- weights = {[round(x, 4) for x in w]}")
+
+    # ----- Pareto-Pareto choice metric: at each (val image, val zq), measure
+    # the bytes-cost of the per-config-best-q vs the actual Pareto best.
+    print(f"\n## Pareto-overhead (bytes vs ideal, config-naive)\n")
+    overhead_by_zq = defaultdict(list)
+    for key in val_keys:
+        for tz in targets:
+            best = labels[key].get(tz)
+            if not best:
+                continue
+            ideal_bytes = best[2]
+            # Find smallest-bytes-meeting-tz across all configs (the actual
+            # Pareto-optimal).
+            actual_bytes = ideal_bytes  # by construction
+            # Compare to the bytes of (any-config, smallest q meeting tz)
+            # we'd ship if we used the bucket-naive zq_to_q heuristic.
+            # The current scaffold uses ApproxJpegli(some_q), which lands
+            # at config 1 (ycbcr_420_baseline); use that as the reference.
+            scaffold_pts = [(c, q, b, z) for (c, q, b, z) in pareto[key] if c == 1 and z >= tz]
+            if not scaffold_pts:
+                continue
+            scaffold_bytes = min(scaffold_pts, key=lambda p: p[2])[2]
+            overhead_by_zq[tz].append((scaffold_bytes - actual_bytes) / actual_bytes)
+    print("zq_tgt | n | mean overhead | p50 | p75 |")
+    print("-------|---|---------------|-----|-----|")
+    for tz in targets:
+        vs = overhead_by_zq.get(tz, [])
+        if not vs:
+            continue
+        vs_s = sorted(vs)
+        n = len(vs_s)
+        mean = sum(vs_s) / n
+        p50 = vs_s[n // 2]
+        p75 = vs_s[(n * 3) // 4]
+        print(f"{tz:3d}    | {n:3d} | {100 * mean:+.1f}%       | {100 * p50:+.1f}% | {100 * p75:+.1f}% |")
+    print(
+        "\nInterpretation: overhead is bytes-vs-Pareto for the bucket-1-naive "
+        "(ycbcr_420_baseline) controller. Positive = the naive controller ships "
+        "more bytes than necessary; negative = the chosen target wasn't reached "
+        "and the scaffold falls back."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/zenjpeg/Cargo.toml
+++ b/zenjpeg/Cargo.toml
@@ -93,6 +93,9 @@ zentone = { workspace = true, optional = true }
 zenresize = { workspace = true, optional = true }
 # Self-documenting node definitions for pipeline integration
 # zennode = { path = "../../zennode/zennode", optional = true, default-features = false, features = ["derive"] }
+# Perceptual metric used by Quality::Zq target-perceptual-quality variants
+# (issue #113). Pulled in only when the `target-zq` feature is enabled.
+zensim = { workspace = true, optional = true }
 
 [dev-dependencies]
 wide = { workspace = true }
@@ -207,6 +210,11 @@ __wasm-simd = []
 ultrahdr = ["decoder", "ultrahdr-core/std", "ultrahdr-core/tonemap", "dep:half", "dep:zentone"]
 # zencodec trait implementations (EncoderConfig, DecoderConfig, etc.)
 zencodec = ["decoder"]
+# Target-perceptual-quality (`Quality::Zq` / `Quality::ZqExplicit`) closed-loop
+# encoder. Iterates encode + decode + zensim diffmap to land at a perceptual
+# score target (issue #113). Pulls in `decoder` (for re-decoding each pass)
+# and the zensim crate (for the perceptual metric).
+target-zq = ["decoder", "dep:zensim"]
 # Layout pipeline: lossless transforms + lossy decode→resize→encode.
 # Geometry/constraint solving (FitMode) and EXIF-orientation bridge live in
 # zenresize itself; orientation group algebra comes from zenpixels (re-exported

--- a/zenjpeg/benchmarks/zq_calibration_2026-04-27.log
+++ b/zenjpeg/benchmarks/zq_calibration_2026-04-27.log
@@ -1,0 +1,78 @@
+warning: jpegli-internals-sys@0.1.0: Using pre-built jpegli from "/home/lilith/work/zen/zenjpeg/internal/jpegli-cpp/build"
+warning: jpegli-internals-sys@0.1.0: ✓ Building with instrumented C++ FFI (jpegli_test_ffi)
+    Finished `release` profile [optimized + debuginfo] target(s) in 0.10s
+     Running `target/release/examples/zq_calibrate --corpus /tmp/zq_calib_corpus --max-images 80`
+[zq_calibrate] 76 image(s), 17 q values × 7 targets
+  progress: 5/76
+  progress: 10/76
+  progress: 15/76
+  progress: 20/76
+  progress: 25/76
+  progress: 30/76
+  progress: 35/76
+  progress: 40/76
+  progress: 45/76
+  progress: 50/76
+  progress: 55/76
+  progress: 60/76
+  progress: 65/76
+  progress: 70/76
+  progress: 75/76
+
+=== Calibration anchors per bucket ===
+
+// PhotoNatural (n=7)
+const PHOTONATURAL: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=7, p25=20 p50=20 p75=20
+    (60.0, 25.0),  // n=7, p25=20 p50=25 p75=25
+    (75.0, 60.0),  // n=7, p25=55 p50=60 p75=65
+    (80.0, 75.0),  // n=7, p25=70 p50=75 p75=80
+    (85.0, 90.0),  // n=7, p25=85 p50=90 p75=90
+    (90.0, 95.0),  // n=7, p25=95 p50=95 p75=100
+    (95.0, 100.0),  // n=7, p25=100 p50=100 p75=100
+];
+
+// PhotoDetailed (n=36)
+const PHOTODETAILED: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=36, p25=20 p50=20 p75=20
+    (60.0, 25.0),  // n=36, p25=20 p50=25 p75=40
+    (75.0, 70.0),  // n=36, p25=60 p50=70 p75=75
+    (80.0, 80.0),  // n=36, p25=75 p50=80 p75=85
+    (85.0, 90.0),  // n=36, p25=90 p50=90 p75=95
+    (90.0, 100.0),  // n=36, p25=95 p50=100 p75=100
+    (95.0, 100.0),  // n=36, p25=100 p50=100 p75=100
+];
+
+// PhotoFlat (n=13)
+const PHOTOFLAT: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=13, p25=20 p50=20 p75=20
+    (60.0, 20.0),  // n=13, p25=20 p50=20 p75=20
+    (75.0, 60.0),  // n=13, p25=45 p50=60 p75=65
+    (80.0, 75.0),  // n=13, p25=65 p50=75 p75=80
+    (85.0, 90.0),  // n=13, p25=85 p50=90 p75=95
+    (90.0, 100.0),  // n=13, p25=95 p50=100 p75=100
+    (95.0, 100.0),  // n=13, p25=100 p50=100 p75=100
+];
+
+// Illustration (n=1)
+const ILLUSTRATION: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=1, p25=20 p50=20 p75=20
+    (60.0, 20.0),  // n=1, p25=20 p50=20 p75=20
+    (75.0, 40.0),  // n=1, p25=40 p50=40 p75=40
+    (80.0, 65.0),  // n=1, p25=65 p50=65 p75=65
+    (85.0, 85.0),  // n=1, p25=85 p50=85 p75=85
+    (90.0, 100.0),  // n=1, p25=100 p50=100 p75=100
+    (95.0, 100.0),  // n=1, p25=100 p50=100 p75=100
+];
+
+// ScreenContent (n=19)
+const SCREENCONTENT: &[(f32, f32)] = &[
+    (40.0, 20.0),  // n=19, p25=20 p50=20 p75=20
+    (60.0, 20.0),  // n=19, p25=20 p50=20 p75=20
+    (75.0, 45.0),  // n=19, p25=40 p50=45 p75=60
+    (80.0, 70.0),  // n=19, p25=65 p50=70 p75=75
+    (85.0, 85.0),  // n=19, p25=85 p50=85 p75=90
+    (90.0, 95.0),  // n=19, p25=95 p50=95 p75=100
+    (95.0, 100.0),  // n=19, p25=100 p50=100 p75=100
+];
+

--- a/zenjpeg/examples/zq_calibrate.rs
+++ b/zenjpeg/examples/zq_calibrate.rs
@@ -1,0 +1,219 @@
+//! Calibrate per-bucket starting-q values for `Quality::Zq` (#113 PR-D).
+//!
+//! For each (content_bucket, target_zq) combination, finds the smallest
+//! jpegli quality that lands at-or-above target zq when encoded with
+//! default streaming AQ (no controller). Prints the values in the format
+//! that [`zenjpeg::encode::zq::zq_to_starting_jpegli_q_for_bucket`] expects.
+//!
+//! The output of this binary is meant to be hand-pasted into the anchor
+//! tables in `src/encode/zq.rs`. Re-run when:
+//!  - The streaming AQ pipeline changes (e.g. new SIMD path, new perceptual
+//!    weighting).
+//!  - The zensim profile is replaced (calibration is profile-relative).
+//!  - The corpus shifts substantially (new content types).
+//!
+//! Usage:
+//!   cargo run --release -p zenjpeg --features target-zq \
+//!     --example zq_calibrate -- --corpus /path/to/corpus
+//!
+//! Default corpus is CID22 validation (40 photo images). For a richer fit
+//! pass `--corpus /path/to/mixed-content/dir` covering screen content +
+//! illustration too.
+
+#![cfg(feature = "target-zq")]
+
+use enough::Unstoppable;
+use std::path::PathBuf;
+use zenjpeg::analyze::analyze_rgb8;
+use zenjpeg::decode::Decoder;
+use zenjpeg::encode::{ChromaSubsampling, EncoderConfig, PixelLayout, Quality};
+use zensim::{DiffmapWeighting, RgbSlice, Zensim, ZensimProfile};
+
+const ZQ_TARGETS: &[f32] = &[40.0, 60.0, 75.0, 80.0, 85.0, 90.0, 95.0];
+const Q_GRID: &[u8] = &[
+    20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100,
+];
+
+struct Args {
+    corpus: PathBuf,
+    max_images: usize,
+}
+
+fn parse_args() -> Args {
+    let mut corpus =
+        PathBuf::from("/home/lilith/work/codec-eval/codec-corpus/CID22/CID22-512/validation");
+    let mut max_images = 64;
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--corpus" => corpus = PathBuf::from(it.next().unwrap()),
+            "--max-images" => max_images = it.next().unwrap().parse().expect("max-images uint"),
+            other => panic!("unknown arg: {other}"),
+        }
+    }
+    Args { corpus, max_images }
+}
+
+fn load_png(path: &std::path::Path) -> (Vec<u8>, u32, u32) {
+    let img =
+        image::open(path).unwrap_or_else(|e| panic!("failed to load {}: {e}", path.display()));
+    let rgb = img.to_rgb8();
+    (rgb.as_raw().clone(), rgb.width(), rgb.height())
+}
+
+fn encode_and_score(
+    z: &Zensim,
+    pre: &zensim::PrecomputedReference,
+    rgb: &[u8],
+    w: u32,
+    h: u32,
+    q: u8,
+) -> f32 {
+    let cfg = EncoderConfig::ycbcr(Quality::ApproxJpegli(q as f32), ChromaSubsampling::Quarter);
+    let jpeg = cfg
+        .encode_bytes(rgb, w, h, PixelLayout::Rgb8Srgb)
+        .expect("encode");
+    let dec = Decoder::new()
+        .decode(&jpeg, Unstoppable)
+        .expect("decode")
+        .into_pixels_u8()
+        .expect("u8 pixels");
+    let chunks: &[[u8; 3]] = dec.as_chunks::<3>().0;
+    let dec_slice = RgbSlice::new(chunks, w as usize, h as usize);
+    z.compute_with_ref_and_diffmap(pre, &dec_slice, DiffmapWeighting::Trained)
+        .expect("zensim")
+        .score() as f32
+}
+
+/// For one image, find smallest q with score >= target_zq for each
+/// target. Returns Vec of (target_zq, smallest_q) tuples.
+fn fit_image(
+    z: &Zensim,
+    pre: &zensim::PrecomputedReference,
+    rgb: &[u8],
+    w: u32,
+    h: u32,
+) -> Vec<(f32, u8)> {
+    // Encode at every q in the grid once; record score → use these to
+    // pick smallest q meeting each target.
+    let mut q_score: Vec<(u8, f32)> = Q_GRID
+        .iter()
+        .map(|&q| (q, encode_and_score(z, pre, rgb, w, h, q)))
+        .collect();
+    q_score.sort_by_key(|&(q, _)| q);
+
+    ZQ_TARGETS
+        .iter()
+        .map(|&zq| {
+            let q = q_score
+                .iter()
+                .find(|&&(_, score)| score >= zq)
+                .map(|&(q, _)| q)
+                .unwrap_or(100);
+            (zq, q)
+        })
+        .collect()
+}
+
+fn main() {
+    let args = parse_args();
+    let z = Zensim::new(ZensimProfile::latest());
+
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(&args.corpus)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e}", args.corpus.display()))
+        .filter_map(|r| r.ok().map(|e| e.path()))
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("png"))
+        .collect();
+    paths.sort();
+    paths.truncate(args.max_images);
+    eprintln!(
+        "[zq_calibrate] {} image(s), {} q values × {} targets",
+        paths.len(),
+        Q_GRID.len(),
+        ZQ_TARGETS.len()
+    );
+
+    // Per-bucket tabulation. For each bucket, we'll accumulate the
+    // smallest q per target across all images in that bucket, then take
+    // the median (a single typical anchor that hits target on most
+    // bucket-members at-or-above target).
+    use std::collections::HashMap;
+    let mut by_bucket: HashMap<&'static str, Vec<Vec<(f32, u8)>>> = HashMap::new();
+
+    for (i, path) in paths.iter().enumerate() {
+        let (rgb, w, h) = load_png(path);
+        let features = analyze_rgb8(&rgb, w, h);
+        let bucket_label: &'static str = match (
+            features.text_likelihood,
+            features.screen_content_likelihood,
+            features.uniformity,
+            features.flat_color_block_ratio,
+            features.high_freq_energy_ratio,
+            features.edge_density,
+            features.cb_peak_sharpness,
+            features.cr_peak_sharpness,
+            features.chroma_complexity,
+        ) {
+            (txt, _, _, _, _, _, cb_p, _, c) if txt > 0.55 && (c > 0.04 || cb_p > 5.0) => {
+                "Illustration"
+            }
+            (txt, _, _, _, _, _, _, _, _) if txt > 0.55 => "ScreenContent",
+            (_, scr, _, _, _, _, _, _, _) if scr > 0.5 => "ScreenContent",
+            (_, _, u, f, _, _, _, _, _) if u > 0.55 || f > 0.25 => "PhotoFlat",
+            (_, _, _, _, hf, ed, cb_p, cr_p, _)
+                if hf > 0.30 || ed > 0.18 || cb_p > 8.0 || cr_p > 8.0 =>
+            {
+                "PhotoDetailed"
+            }
+            _ => "PhotoNatural",
+        };
+
+        let src_chunks: &[[u8; 3]] = rgb.as_chunks::<3>().0;
+        let src_slice = RgbSlice::new(src_chunks, w as usize, h as usize);
+        let pre = z.precompute_reference(&src_slice).expect("precompute");
+        let fits = fit_image(&z, &pre, &rgb, w, h);
+
+        by_bucket.entry(bucket_label).or_default().push(fits);
+
+        if (i + 1) % 5 == 0 {
+            eprintln!("  progress: {}/{}", i + 1, paths.len());
+        }
+    }
+
+    // Median per (bucket, target) → final anchor.
+    println!("\n=== Calibration anchors per bucket ===\n");
+    let bucket_order = [
+        "PhotoNatural",
+        "PhotoDetailed",
+        "PhotoFlat",
+        "Illustration",
+        "ScreenContent",
+    ];
+    for &bucket in &bucket_order {
+        match by_bucket.get(bucket) {
+            None => {
+                println!("// {}: NO IMAGES IN CORPUS", bucket);
+                continue;
+            }
+            Some(rows) => {
+                let n = rows.len();
+                println!("// {} (n={})", bucket, n);
+                println!("const {}: &[(f32, f32)] = &[", bucket.to_uppercase());
+                for (i, &target) in ZQ_TARGETS.iter().enumerate() {
+                    let mut qs: Vec<u8> = rows.iter().map(|r| r[i].1).collect();
+                    qs.sort();
+                    let median = qs[n / 2];
+                    println!(
+                        "    ({:.1}, {:.1}),  // n={n}, p25={} p50={median} p75={}",
+                        target,
+                        median as f32,
+                        qs[n / 4],
+                        qs[(3 * n) / 4],
+                    );
+                    let _ = target;
+                }
+                println!("];\n");
+            }
+        }
+    }
+}

--- a/zenjpeg/examples/zq_calibrate.rs
+++ b/zenjpeg/examples/zq_calibrate.rs
@@ -24,10 +24,26 @@
 
 use enough::Unstoppable;
 use std::path::PathBuf;
-use zenjpeg::analyze::analyze_rgb8;
+use zenanalyze::analyze_features_rgb8;
+use zenanalyze::feature::{AnalysisFeature, AnalysisQuery, FeatureSet};
 use zenjpeg::decode::Decoder;
 use zenjpeg::encode::{ChromaSubsampling, EncoderConfig, PixelLayout, Quality};
 use zensim::{DiffmapWeighting, RgbSlice, Zensim, ZensimProfile};
+
+/// Features the bucket-classification heuristic in `main()` reads.
+/// Mirrors the field set used by `zenjpeg::encode::adaptive::infer_bucket`.
+fn calibrate_features() -> FeatureSet {
+    FeatureSet::new()
+        .with(AnalysisFeature::TextLikelihood)
+        .with(AnalysisFeature::ScreenContentLikelihood)
+        .with(AnalysisFeature::Uniformity)
+        .with(AnalysisFeature::FlatColorBlockRatio)
+        .with(AnalysisFeature::HighFreqEnergyRatio)
+        .with(AnalysisFeature::EdgeDensity)
+        .with(AnalysisFeature::CbPeakSharpness)
+        .with(AnalysisFeature::CrPeakSharpness)
+        .with(AnalysisFeature::ChromaComplexity)
+}
 
 const ZQ_TARGETS: &[f32] = &[40.0, 60.0, 75.0, 80.0, 85.0, 90.0, 95.0];
 const Q_GRID: &[u8] = &[
@@ -35,23 +51,30 @@ const Q_GRID: &[u8] = &[
 ];
 
 struct Args {
-    corpus: PathBuf,
+    corpora: Vec<PathBuf>,
     max_images: usize,
 }
 
 fn parse_args() -> Args {
-    let mut corpus =
-        PathBuf::from("/home/lilith/work/codec-eval/codec-corpus/CID22/CID22-512/validation");
-    let mut max_images = 64;
+    let mut corpora: Vec<PathBuf> = Vec::new();
+    let mut max_images = 1024;
     let mut it = std::env::args().skip(1);
     while let Some(arg) = it.next() {
         match arg.as_str() {
-            "--corpus" => corpus = PathBuf::from(it.next().unwrap()),
+            "--corpus" => corpora.push(PathBuf::from(it.next().unwrap())),
             "--max-images" => max_images = it.next().unwrap().parse().expect("max-images uint"),
             other => panic!("unknown arg: {other}"),
         }
     }
-    Args { corpus, max_images }
+    if corpora.is_empty() {
+        corpora.push(PathBuf::from(
+            "/home/lilith/work/codec-eval/codec-corpus/CID22/CID22-512/validation",
+        ));
+    }
+    Args {
+        corpora,
+        max_images,
+    }
 }
 
 fn load_png(path: &std::path::Path) -> (Vec<u8>, u32, u32) {
@@ -119,16 +142,23 @@ fn main() {
     let args = parse_args();
     let z = Zensim::new(ZensimProfile::latest());
 
-    let mut paths: Vec<PathBuf> = std::fs::read_dir(&args.corpus)
-        .unwrap_or_else(|e| panic!("read_dir {}: {e}", args.corpus.display()))
-        .filter_map(|r| r.ok().map(|e| e.path()))
-        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("png"))
-        .collect();
+    let mut paths: Vec<PathBuf> = Vec::new();
+    for corpus in &args.corpora {
+        let entries = std::fs::read_dir(corpus)
+            .unwrap_or_else(|e| panic!("read_dir {}: {e}", corpus.display()));
+        for entry in entries.filter_map(|r| r.ok()) {
+            let p = entry.path();
+            if p.extension().and_then(|s| s.to_str()) == Some("png") {
+                paths.push(p);
+            }
+        }
+    }
     paths.sort();
     paths.truncate(args.max_images);
     eprintln!(
-        "[zq_calibrate] {} image(s), {} q values × {} targets",
+        "[zq_calibrate] {} image(s) across {} corpora, {} q values × {} targets",
         paths.len(),
+        args.corpora.len(),
         Q_GRID.len(),
         ZQ_TARGETS.len()
     );
@@ -140,19 +170,21 @@ fn main() {
     use std::collections::HashMap;
     let mut by_bucket: HashMap<&'static str, Vec<Vec<(f32, u8)>>> = HashMap::new();
 
+    let query = AnalysisQuery::new(calibrate_features());
     for (i, path) in paths.iter().enumerate() {
         let (rgb, w, h) = load_png(path);
-        let features = analyze_rgb8(&rgb, w, h);
+        let analysis = analyze_features_rgb8(&rgb, w, h, &query);
+        let f = |feat: AnalysisFeature| analysis.get_f32(feat).unwrap_or(0.0);
         let bucket_label: &'static str = match (
-            features.text_likelihood,
-            features.screen_content_likelihood,
-            features.uniformity,
-            features.flat_color_block_ratio,
-            features.high_freq_energy_ratio,
-            features.edge_density,
-            features.cb_peak_sharpness,
-            features.cr_peak_sharpness,
-            features.chroma_complexity,
+            f(AnalysisFeature::TextLikelihood),
+            f(AnalysisFeature::ScreenContentLikelihood),
+            f(AnalysisFeature::Uniformity),
+            f(AnalysisFeature::FlatColorBlockRatio),
+            f(AnalysisFeature::HighFreqEnergyRatio),
+            f(AnalysisFeature::EdgeDensity),
+            f(AnalysisFeature::CbPeakSharpness),
+            f(AnalysisFeature::CrPeakSharpness),
+            f(AnalysisFeature::ChromaComplexity),
         ) {
             (txt, _, _, _, _, _, cb_p, _, c) if txt > 0.55 && (c > 0.04 || cb_p > 5.0) => {
                 "Illustration"

--- a/zenjpeg/examples/zq_pareto_calibrate.rs
+++ b/zenjpeg/examples/zq_pareto_calibrate.rs
@@ -1,0 +1,614 @@
+//! Comprehensive Pareto-front calibration harness for the Zq /
+//! perceptual-target controller.
+//!
+//! Sweeps four axes per the global benchmark-discipline rule:
+//!   - **size**: tiny (64), small (256), medium (1024), large (native)
+//!   - **config**: ycbcr/xyb × 4:4:4/4:2:0 × baseline/progressive ±
+//!     auto-optimize (8 representative configs covering the knobs that
+//!     materially shift the q→zq curve and encoded bytes)
+//!   - **q**: 0..=100 step 5 (21 points; full coverage including the
+//!     low-q regime that web-focused codecs ship for)
+//!   - **content**: tiny + photo + screen + line-art + mixed via the
+//!     usual codec-eval corpora
+//!
+//! Per (image, size, config, q) we emit one TSV row capturing
+//! `bytes + zensim + encode_ms`. Per-image zenanalyze features are
+//! captured separately so offline regression can join them in.
+//!
+//! This harness produces the data; the offline analysis (in a sibling
+//! script / Rust binary) computes per-(image, size, config, target_zq)
+//! Pareto-optimal `(config, q)` and trains the regression that the
+//! perceptual-target controller bakes in.
+//!
+//! Usage:
+//!   cargo run --release -p zenjpeg --features target-zq \
+//!     --example zq_pareto_calibrate -- \
+//!       --corpus /path/to/photos \
+//!       --corpus /path/to/screens \
+//!       --output benchmarks/zq_pareto_<DATE>.tsv \
+//!       --features-output benchmarks/zq_pareto_features_<DATE>.tsv \
+//!       [--max-images N] [--sizes 64,256,1024,native] [--threads N]
+//!
+//! Output is appended row-by-row so a partial run is still useful;
+//! a crash mid-sweep doesn't lose prior cells.
+
+#![cfg(feature = "target-zq")]
+
+use enough::Unstoppable;
+use rayon::prelude::*;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Instant;
+use zenanalyze::analyze_features_rgb8;
+use zenanalyze::feature::{AnalysisFeature, AnalysisQuery, FeatureSet};
+use zenjpeg::decode::Decoder;
+use zenjpeg::encode::{ChromaSubsampling, EncoderConfig, PixelLayout, Quality, XybSubsampling};
+use zensim::{DiffmapWeighting, RgbSlice, Zensim, ZensimProfile};
+
+// ---------------------------------------------------------------------
+// Sweep grid
+// ---------------------------------------------------------------------
+
+/// Quality grid: full 0..100 step 5 per the source-informing-benchmark rule.
+const Q_GRID: &[u8] = &[
+    0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100,
+];
+
+/// Default size axis. `0` means "use native dimensions" (large).
+/// Sized by max(width, height) — preserve aspect via image::imageops::resize
+/// with Lanczos3 (high-quality downsample).
+const DEFAULT_SIZES: &[u32] = &[64, 256, 1024, 0];
+
+/// One encoder configuration variant. The set below covers the knobs
+/// that materially shift bytes and the q→zq mapping. Trellis lambda
+/// and dequant bias are reachable as further axes; start with these
+/// 8 because each is a single-flag flip with an obvious user-visible
+/// meaning, and we can extend later from the same TSV without a
+/// re-run if we add new configs that happen to include any in this
+/// initial set.
+#[derive(Clone, Copy)]
+struct ConfigSpec {
+    name: &'static str,
+    /// Encoded as a small-int feature for the trained model.
+    id: u8,
+    color_mode: ColorMode,
+    sub: SubChoice,
+    progressive: bool,
+    auto_optimize: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ColorMode {
+    YCbCr,
+    Xyb,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SubChoice {
+    /// 4:4:4 — no chroma downsample
+    Full,
+    /// 4:2:0 — h2v2
+    Quarter,
+}
+
+const CONFIGS: &[ConfigSpec] = &[
+    ConfigSpec {
+        name: "ycbcr_444_baseline",
+        id: 0,
+        color_mode: ColorMode::YCbCr,
+        sub: SubChoice::Full,
+        progressive: false,
+        auto_optimize: false,
+    },
+    ConfigSpec {
+        name: "ycbcr_420_baseline",
+        id: 1,
+        color_mode: ColorMode::YCbCr,
+        sub: SubChoice::Quarter,
+        progressive: false,
+        auto_optimize: false,
+    },
+    ConfigSpec {
+        name: "ycbcr_444_progressive",
+        id: 2,
+        color_mode: ColorMode::YCbCr,
+        sub: SubChoice::Full,
+        progressive: true,
+        auto_optimize: false,
+    },
+    ConfigSpec {
+        name: "ycbcr_420_progressive",
+        id: 3,
+        color_mode: ColorMode::YCbCr,
+        sub: SubChoice::Quarter,
+        progressive: true,
+        auto_optimize: false,
+    },
+    ConfigSpec {
+        name: "xyb_444_baseline",
+        id: 4,
+        color_mode: ColorMode::Xyb,
+        sub: SubChoice::Full,
+        progressive: false,
+        auto_optimize: false,
+    },
+    ConfigSpec {
+        name: "xyb_420_baseline",
+        id: 5,
+        color_mode: ColorMode::Xyb,
+        sub: SubChoice::Quarter,
+        progressive: false,
+        auto_optimize: false,
+    },
+    ConfigSpec {
+        name: "ycbcr_420_auto_optimize",
+        id: 6,
+        color_mode: ColorMode::YCbCr,
+        sub: SubChoice::Quarter,
+        progressive: true,
+        auto_optimize: true,
+    },
+    ConfigSpec {
+        name: "ycbcr_444_auto_optimize",
+        id: 7,
+        color_mode: ColorMode::YCbCr,
+        sub: SubChoice::Full,
+        progressive: true,
+        auto_optimize: true,
+    },
+];
+
+// ---------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------
+
+struct Args {
+    corpora: Vec<PathBuf>,
+    sizes: Vec<u32>,
+    output: PathBuf,
+    features_output: PathBuf,
+    max_images: usize,
+    threads: usize,
+}
+
+fn parse_args() -> Args {
+    let mut corpora: Vec<PathBuf> = Vec::new();
+    let mut sizes: Vec<u32> = Vec::new();
+    let mut max_images = 1024;
+    let mut threads = 0;
+    let date = chrono_today();
+    let mut output = PathBuf::from(format!("benchmarks/zq_pareto_{date}.tsv"));
+    let mut features_output = PathBuf::from(format!("benchmarks/zq_pareto_features_{date}.tsv"));
+
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--corpus" => corpora.push(PathBuf::from(it.next().unwrap())),
+            "--sizes" => {
+                let s = it.next().unwrap();
+                for tok in s.split(',') {
+                    if tok == "native" {
+                        sizes.push(0);
+                    } else {
+                        sizes.push(tok.parse().expect("size must be uint or 'native'"));
+                    }
+                }
+            }
+            "--output" => output = PathBuf::from(it.next().unwrap()),
+            "--features-output" => features_output = PathBuf::from(it.next().unwrap()),
+            "--max-images" => max_images = it.next().unwrap().parse().expect("max-images uint"),
+            "--threads" => threads = it.next().unwrap().parse().expect("threads uint"),
+            other => panic!("unknown arg: {other}"),
+        }
+    }
+    if corpora.is_empty() {
+        // Default mixed corpus covering all 5 content classes.
+        for d in [
+            "/home/lilith/work/codec-eval/codec-corpus/CID22/CID22-512/validation",
+            "/home/lilith/work/codec-eval/codec-corpus/CID22/CID22-512/training",
+            "/home/lilith/work/codec-eval/codec-corpus/gb82",
+            "/home/lilith/work/codec-eval/codec-corpus/gb82-sc",
+            "/home/lilith/work/codec-eval/codec-corpus/clic2025/training",
+            "/home/lilith/work/codec-eval/codec-corpus/clic2025/final-test",
+        ] {
+            corpora.push(PathBuf::from(d));
+        }
+    }
+    if sizes.is_empty() {
+        sizes = DEFAULT_SIZES.to_vec();
+    }
+    Args {
+        corpora,
+        sizes,
+        output,
+        features_output,
+        max_images,
+        threads,
+    }
+}
+
+fn chrono_today() -> String {
+    // Use system date — we don't pull chrono just for this.
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    // Compute YYYY-MM-DD from epoch seconds (UTC, naive).
+    let days = (secs / 86400) as i64;
+    // Days from 1970-01-01 → calendar date (Howard Hinnant's algorithm).
+    let z = days + 719468;
+    let era = (if z >= 0 { z } else { z - 146096 }) / 146097;
+    let doe = (z - era * 146097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = (yoe as i64) + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{:04}-{:02}-{:02}", y, m, d)
+}
+
+// ---------------------------------------------------------------------
+// Image loading + size-axis variants
+// ---------------------------------------------------------------------
+
+fn load_png(path: &std::path::Path) -> (Vec<u8>, u32, u32) {
+    let img =
+        image::open(path).unwrap_or_else(|e| panic!("failed to load {}: {e}", path.display()));
+    let rgb = img.to_rgb8();
+    (rgb.as_raw().clone(), rgb.width(), rgb.height())
+}
+
+/// Resize an RGB8 image to fit within `target_max` on its longer side
+/// while preserving aspect. `target_max == 0` returns the input as-is.
+fn resize_to(rgb: &[u8], w: u32, h: u32, target_max: u32) -> (Vec<u8>, u32, u32) {
+    if target_max == 0 || (w.max(h) <= target_max) {
+        return (rgb.to_vec(), w, h);
+    }
+    let scale = target_max as f32 / w.max(h) as f32;
+    let new_w = ((w as f32 * scale).round() as u32).max(1);
+    let new_h = ((h as f32 * scale).round() as u32).max(1);
+    let buf = image::ImageBuffer::<image::Rgb<u8>, Vec<u8>>::from_raw(w, h, rgb.to_vec())
+        .expect("rgb8 buffer");
+    let resized =
+        image::imageops::resize(&buf, new_w, new_h, image::imageops::FilterType::Lanczos3);
+    (resized.into_raw(), new_w, new_h)
+}
+
+// ---------------------------------------------------------------------
+// Encoding + scoring
+// ---------------------------------------------------------------------
+
+fn build_encoder(spec: ConfigSpec, q: u8) -> EncoderConfig {
+    let quality = Quality::ApproxJpegli(q as f32);
+    let mut cfg = match spec.color_mode {
+        ColorMode::YCbCr => {
+            let sub = match spec.sub {
+                SubChoice::Full => ChromaSubsampling::None,
+                SubChoice::Quarter => ChromaSubsampling::Quarter,
+            };
+            EncoderConfig::ycbcr(quality, sub)
+        }
+        ColorMode::Xyb => {
+            // XYB has its own subsampling enum (only B-channel).
+            let xyb_sub = match spec.sub {
+                SubChoice::Full => XybSubsampling::Full,
+                SubChoice::Quarter => XybSubsampling::BQuarter,
+            };
+            EncoderConfig::xyb(quality, xyb_sub)
+        }
+    };
+    // NOTE: zenjpeg's `EncoderConfig::ycbcr/xyb` defaults to
+    // `ProgressiveScanMode::Progressive`. To actually compare progressive
+    // vs baseline we must EXPLICITLY set Baseline when spec.progressive
+    // is false; passing Progressive when already-default is a no-op and
+    // produces byte-identical output.
+    if spec.progressive {
+        cfg = cfg.progressive(zenjpeg::encode::ProgressiveScanMode::Progressive);
+    } else {
+        cfg = cfg.progressive(zenjpeg::encode::ProgressiveScanMode::Baseline);
+    }
+    #[cfg(feature = "trellis")]
+    if spec.auto_optimize {
+        cfg = cfg.auto_optimize(true);
+    }
+    cfg
+}
+
+/// One encode + decode + zensim score.
+/// Returns (encoded_bytes, zensim_score, encode_ms, total_ms).
+fn encode_decode_score(
+    z: &Zensim,
+    pre: &zensim::PrecomputedReference,
+    rgb: &[u8],
+    w: u32,
+    h: u32,
+    spec: ConfigSpec,
+    q: u8,
+) -> Option<(usize, f32, f64, f64)> {
+    let cfg = build_encoder(spec, q);
+    let total_start = Instant::now();
+    let encode_start = Instant::now();
+    let jpeg = match cfg.encode_bytes(rgb, w, h, PixelLayout::Rgb8Srgb) {
+        Ok(j) => j,
+        Err(_) => return None, // some configs reject some inputs (e.g., XYB at q=0)
+    };
+    let encode_ms = encode_start.elapsed().as_secs_f64() * 1000.0;
+    let dec = match Decoder::new().decode(&jpeg, Unstoppable) {
+        Ok(d) => match d.into_pixels_u8() {
+            Some(p) => p,
+            None => return None,
+        },
+        Err(_) => return None,
+    };
+    let chunks: &[[u8; 3]] = dec.as_chunks::<3>().0;
+    let dec_slice = RgbSlice::new(chunks, w as usize, h as usize);
+    let zensim_score =
+        match z.compute_with_ref_and_diffmap(pre, &dec_slice, DiffmapWeighting::Trained) {
+            Ok(r) => r.score() as f32,
+            Err(_) => return None,
+        };
+    let total_ms = total_start.elapsed().as_secs_f64() * 1000.0;
+    Some((jpeg.len(), zensim_score, encode_ms, total_ms))
+}
+
+// ---------------------------------------------------------------------
+// Feature extraction (per image-size; identical across configs+q)
+// ---------------------------------------------------------------------
+
+/// Every feature we want as a column. Order is the column order in the
+/// features TSV. Composites + experimental land here so the regression
+/// can learn from them; if those cargo features aren't on, the
+/// corresponding columns get None and we emit empty.
+fn full_feature_set() -> FeatureSet {
+    FeatureSet::SUPPORTED
+}
+
+fn feature_columns() -> Vec<AnalysisFeature> {
+    use AnalysisFeature::*;
+    let mut cols = Vec::new();
+    // Walk every supported feature; include only the ones that ship in
+    // this build so the column count matches what we can populate.
+    for f in [
+        Variance,
+        EdgeDensity,
+        ChromaComplexity,
+        CbSharpness,
+        CrSharpness,
+        Uniformity,
+        FlatColorBlockRatio,
+        DistinctColorBins,
+        CbHorizSharpness,
+        CbVertSharpness,
+        CbPeakSharpness,
+        CrHorizSharpness,
+        CrVertSharpness,
+        CrPeakSharpness,
+        HighFreqEnergyRatio,
+        LumaHistogramEntropy,
+        AlphaPresent,
+        AlphaUsedFraction,
+        AlphaBimodalScore,
+    ] {
+        cols.push(f);
+    }
+    // composites — present only when zenanalyze was built with that flag.
+    #[cfg(feature = "composites_passthrough")]
+    {
+        cols.push(TextLikelihood);
+        cols.push(ScreenContentLikelihood);
+        cols.push(NaturalLikelihood);
+    }
+    // We rely on AnalysisResults::get_f32 returning None for unknown
+    // features; the writer below converts None to the empty TSV cell.
+    cols
+}
+
+fn feature_value_str(
+    analysis: &zenanalyze::feature::AnalysisResults,
+    f: AnalysisFeature,
+) -> String {
+    if let Some(v) = analysis.get_f32(f) {
+        format!("{v:.6}")
+    } else if let Some(v) = analysis.get(f) {
+        // Could be U32 or Bool — render generically.
+        match v {
+            zenanalyze::feature::FeatureValue::F32(x) => format!("{x:.6}"),
+            zenanalyze::feature::FeatureValue::U32(x) => format!("{x}"),
+            zenanalyze::feature::FeatureValue::Bool(b) => format!("{}", b as u8),
+            _ => String::new(),
+        }
+    } else {
+        String::new()
+    }
+}
+
+// ---------------------------------------------------------------------
+// Main loop
+// ---------------------------------------------------------------------
+
+fn main() {
+    let args = parse_args();
+    if args.threads > 0 {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(args.threads)
+            .build_global()
+            .ok();
+    }
+
+    let z = Zensim::new(ZensimProfile::latest());
+
+    let mut paths: Vec<PathBuf> = Vec::new();
+    for corpus in &args.corpora {
+        let entries = std::fs::read_dir(corpus)
+            .unwrap_or_else(|e| panic!("read_dir {}: {e}", corpus.display()));
+        for entry in entries.filter_map(|r| r.ok()) {
+            let p = entry.path();
+            if p.extension().and_then(|s| s.to_str()) == Some("png") {
+                paths.push(p);
+            }
+        }
+    }
+    paths.sort();
+    paths.truncate(args.max_images);
+
+    let cells = paths.len() * args.sizes.len() * CONFIGS.len() * Q_GRID.len();
+    eprintln!(
+        "[zq_pareto_calibrate] {} images × {} sizes × {} configs × {} q values = {} cells",
+        paths.len(),
+        args.sizes.len(),
+        CONFIGS.len(),
+        Q_GRID.len(),
+        cells,
+    );
+    eprintln!("[zq_pareto_calibrate] output: {}", args.output.display());
+    eprintln!(
+        "[zq_pareto_calibrate] features:  {}",
+        args.features_output.display()
+    );
+
+    // Open output files in append mode. Write headers if files are new.
+    if let Some(parent) = args.output.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let main_is_new = !args.output.exists();
+    let main_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&args.output)
+        .expect("open output");
+    let main_file = Mutex::new(main_file);
+    if main_is_new {
+        let mut f = main_file.lock().unwrap();
+        writeln!(
+            f,
+            "image_path\tsize_class\twidth\theight\tconfig_id\tconfig_name\tq\tbytes\tzensim\tencode_ms\ttotal_ms"
+        )
+        .ok();
+    }
+
+    let feat_is_new = !args.features_output.exists();
+    let feat_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&args.features_output)
+        .expect("open features output");
+    let feat_file = Mutex::new(feat_file);
+    let cols = feature_columns();
+    if feat_is_new {
+        let mut f = feat_file.lock().unwrap();
+        write!(f, "image_path\tsize_class\twidth\theight").ok();
+        for c in &cols {
+            write!(f, "\tfeat_{}", c.name()).ok();
+        }
+        writeln!(f).ok();
+    }
+
+    // Build the work units. We unwrap (image, size) up-front (to avoid
+    // re-reading + re-resizing for every config). Each work unit is one
+    // (image, size) cell, expanded to (CONFIGS × Q_GRID) inner work.
+    let query = AnalysisQuery::new(full_feature_set());
+    let started = Instant::now();
+    let unit_count = paths.len() * args.sizes.len();
+    let done = std::sync::atomic::AtomicUsize::new(0);
+
+    let work_units: Vec<(PathBuf, u32)> = paths
+        .iter()
+        .flat_map(|path| args.sizes.iter().map(move |&sz| (path.clone(), sz)))
+        .collect();
+    work_units.par_iter().for_each(|(path, target_size)| {
+        let target_size = *target_size;
+        // Load + resize.
+        let (rgb_native, w_native, h_native) = load_png(path);
+        let (rgb, w, h) = resize_to(&rgb_native, w_native, h_native, target_size);
+        let size_class = match target_size {
+            64 => "tiny",
+            256 => "small",
+            1024 => "medium",
+            0 => "large",
+            _ => "custom",
+        };
+
+        // Per-image features (analyzed once at this size).
+        let analysis = analyze_features_rgb8(&rgb, w, h, &query);
+        {
+            let mut f = feat_file.lock().unwrap();
+            write!(f, "{}\t{}\t{}\t{}", path.display(), size_class, w, h).ok();
+            for c in &cols {
+                write!(f, "\t{}", feature_value_str(&analysis, *c)).ok();
+            }
+            writeln!(f).ok();
+            f.flush().ok();
+        }
+
+        // Pre-compute zensim reference once.
+        let src_chunks: &[[u8; 3]] = rgb.as_chunks::<3>().0;
+        let src_slice = RgbSlice::new(src_chunks, w as usize, h as usize);
+        let pre = z.precompute_reference(&src_slice).expect("precompute");
+
+        // Cartesian over configs × q.
+        for spec in CONFIGS {
+            for &q in Q_GRID {
+                let row = encode_decode_score(&z, &pre, &rgb, w, h, *spec, q);
+                let mut f = main_file.lock().unwrap();
+                match row {
+                    Some((bytes, zensim, encode_ms, total_ms)) => {
+                        writeln!(
+                            f,
+                            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.4}\t{:.3}\t{:.3}",
+                            path.display(),
+                            size_class,
+                            w,
+                            h,
+                            spec.id,
+                            spec.name,
+                            q,
+                            bytes,
+                            zensim,
+                            encode_ms,
+                            total_ms,
+                        )
+                        .ok();
+                    }
+                    None => {
+                        // Record a row with empty bytes/zensim to mark
+                        // the failure — keeps the cell index dense.
+                        writeln!(
+                            f,
+                            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t\t\t\t",
+                            path.display(),
+                            size_class,
+                            w,
+                            h,
+                            spec.id,
+                            spec.name,
+                            q,
+                        )
+                        .ok();
+                    }
+                }
+            }
+            main_file.lock().unwrap().flush().ok();
+        }
+
+        let n = done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        if n % 4 == 0 || n == unit_count {
+            let dt = started.elapsed().as_secs_f64();
+            let rate = n as f64 / dt;
+            let eta = (unit_count - n) as f64 / rate;
+            eprintln!(
+                "  progress: {}/{}  ({:.1}/sec, ETA {:.0}s)",
+                n, unit_count, rate, eta
+            );
+        }
+    });
+
+    eprintln!(
+        "[zq_pareto_calibrate] done in {:.0}s, output at {}",
+        started.elapsed().as_secs_f64(),
+        args.output.display(),
+    );
+}

--- a/zenjpeg/src/encode/adaptive.rs
+++ b/zenjpeg/src/encode/adaptive.rs
@@ -320,9 +320,14 @@ impl AdaptiveMetric {
     fn from_quality(q: &Quality) -> Self {
         match q {
             Quality::ApproxButteraugli(_) => AdaptiveMetric::Butter,
-            Quality::ApproxSsim2(_) | Quality::ApproxJpegli(_) | Quality::ApproxMozjpeg(_) => {
-                AdaptiveMetric::Ssim2
-            }
+            // Zq is calibrated against zensim, which is the same family
+            // as ssim2 (multi-scale perceptual). The adaptive oracle's
+            // ssim2 trees are the closest behavioral match.
+            Quality::ApproxSsim2(_)
+            | Quality::ApproxJpegli(_)
+            | Quality::ApproxMozjpeg(_)
+            | Quality::Zq(_)
+            | Quality::ZqExplicit(_) => AdaptiveMetric::Ssim2,
         }
     }
 }

--- a/zenjpeg/src/encode/adaptive.rs
+++ b/zenjpeg/src/encode/adaptive.rs
@@ -334,9 +334,11 @@ impl AdaptiveMetric {
 
 /// Coarse content classification distilled from analyzer features —
 /// matches the oracle's 5-bucket taxonomy as closely as the analyzer
-/// signals allow. Internal only; not part of the public surface.
+/// signals allow. Internal only (not part of the public surface) but
+/// `pub(crate)` so target-zq calibration in `super::zq` can route the
+/// per-bucket starting-q lookup.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum InferredBucket {
+pub(crate) enum InferredBucket {
     PhotoNatural,
     PhotoDetailed,
     PhotoFlat,
@@ -344,7 +346,7 @@ enum InferredBucket {
     ScreenContent,
 }
 
-fn infer_bucket(r: &AnalysisResults) -> InferredBucket {
+pub(crate) fn infer_bucket(r: &AnalysisResults) -> InferredBucket {
     // CALIBRATION-PENDING (2026-04-27, zenanalyze 0.1.x):
     // The peak (`cb_peak_sharpness > 5.0`, `cr_peak_sharpness > 8.0`)
     // and high-freq (`high_freq_energy_ratio > 0.30`) cutoffs below

--- a/zenjpeg/src/encode/aq_controller.rs
+++ b/zenjpeg/src/encode/aq_controller.rs
@@ -1,0 +1,126 @@
+//! Per-iMCU AQ-strength controller hook (issue #113, PR-A scaffold).
+//!
+//! Sits between [`StreamingAQ`](crate::quant::aq::streaming::StreamingAQ)
+//! emitting per-iMCU AQ strengths and [`StripProcessor::quantize_prev_pending_imcu`]
+//! consuming them. A controller may scale the strengths in place; with no
+//! controller installed (the default), the strength buffer is passed through
+//! unmodified and the encode is byte-identical to the pre-controller path.
+//!
+//! This is the injection point that future layers of the target-zensim
+//! closed-loop encoder build on:
+//!
+//! - **Layer 2** (this PR): trait + injection point. No reference impl yet.
+//! - **Layer 3** (PR-C): a measurement driver pushes
+//!   [`WindowObservation`]s back to the controller via [`AqController::observe`].
+//! - **Layer 4** (PR-D): `PiAqController` reference implementation.
+//!
+//! The trait surface is intentionally `pub(crate)` until the public
+//! `Quality::TargetZensim` API lands. Reference: GitHub issue #113.
+
+use core::ops::Range;
+
+/// Observation pushed back to the controller from the per-window
+/// measurement loop (Layer 3, PR-C). Carries the iMCU range that was
+/// measured, the *predicted* zensim contribution from the controller's
+/// model, and the *actual* contribution measured from the just-quantized
+/// blocks.
+///
+/// `predicted - measured` is the controller error signal.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Fields are read by Layer 3+; PR-A only constructs/passes.
+pub(crate) struct WindowObservation {
+    /// Range of iMCU rows covered by this observation (half-open).
+    pub imcu_range: Range<usize>,
+    /// Zensim contribution this window actually produced, as accumulated
+    /// by [`zensim::PrecomputedReference`]-backed streaming math.
+    pub measured_zensim_contribution: f32,
+    /// Predicted contribution at the time the controller chose its
+    /// per-iMCU AQ scale. Used as the error baseline.
+    pub predicted_zensim_contribution: f32,
+}
+
+/// Hook for adjusting per-iMCU AQ strengths during a streaming encode.
+///
+/// `adjust` is called once per iMCU row, immediately after `StreamingAQ`
+/// finalizes that iMCU's strengths and before the strip processor
+/// quantizes the corresponding f32 DCT blocks. Implementations may
+/// scale, clamp, or otherwise mutate `strengths` in place.
+///
+/// `observe` is called by the per-window measurement driver (Layer 3,
+/// PR-C) to push measured zensim contributions back to the controller.
+/// Default no-op so simple controllers don't need to implement it.
+///
+/// Intentionally object-safe (`dyn AqController`) — controllers carry
+/// their own state (PI accumulators, classification, etc.) and
+/// `StripProcessor` holds at most one boxed instance. `Debug` is a
+/// supertrait so `StripProcessor`'s `#[derive(Debug)]` keeps working.
+pub(crate) trait AqController: Send + core::fmt::Debug {
+    /// Called once per iMCU row after `StreamingAQ` emits strengths and
+    /// before quantization consumes them.
+    ///
+    /// `strengths` is the slice the strip processor will pass directly
+    /// to `quantize_prev_pending_imcu`; mutations are reflected
+    /// downstream. `imcu_idx` is the 0-based index of the iMCU row this
+    /// call is adjusting (monotonic across the encode).
+    fn adjust(&mut self, strengths: &mut [f32], imcu_idx: usize);
+
+    /// Push a per-window measurement back to the controller. Default
+    /// implementation drops the observation; non-feedback controllers
+    /// (e.g. fixed-bias) don't need to override.
+    ///
+    /// Currently unused — Layer 3 measurement driver lands in PR-C.
+    #[allow(unused_variables, dead_code)]
+    fn observe(&mut self, window: WindowObservation) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A controller that records every `adjust` call. Used by the
+    /// scaffolding test to confirm the trait is wired correctly.
+    #[derive(Debug)]
+    struct RecordingController {
+        seen: Vec<(usize, Vec<f32>)>,
+    }
+    impl AqController for RecordingController {
+        fn adjust(&mut self, strengths: &mut [f32], imcu_idx: usize) {
+            self.seen.push((imcu_idx, strengths.to_vec()));
+        }
+    }
+
+    /// Sanity: the trait is object-safe and a boxed controller can be
+    /// driven through `&mut dyn AqController`.
+    #[test]
+    fn controller_is_object_safe() {
+        let mut ctrl: Box<dyn AqController> = Box::new(RecordingController { seen: vec![] });
+        let mut strengths = [0.1f32, 0.2, 0.3];
+        ctrl.adjust(&mut strengths, 0);
+        ctrl.adjust(&mut strengths, 1);
+        // Push an observation through the default no-op `observe`.
+        ctrl.observe(WindowObservation {
+            imcu_range: 0..2,
+            measured_zensim_contribution: 0.0,
+            predicted_zensim_contribution: 0.0,
+        });
+    }
+
+    /// A controller can scale strengths in place; the change is visible
+    /// to the caller (this is what the strip processor relies on).
+    #[test]
+    fn adjust_scales_in_place() {
+        #[derive(Debug)]
+        struct DoubleEverything;
+        impl AqController for DoubleEverything {
+            fn adjust(&mut self, strengths: &mut [f32], _imcu_idx: usize) {
+                for s in strengths {
+                    *s *= 2.0;
+                }
+            }
+        }
+        let mut ctrl: Box<dyn AqController> = Box::new(DoubleEverything);
+        let mut strengths = [0.10f32, 0.20];
+        ctrl.adjust(&mut strengths, 0);
+        assert_eq!(strengths, [0.20, 0.40]);
+    }
+}

--- a/zenjpeg/src/encode/byte_encoders.rs
+++ b/zenjpeg/src/encode/byte_encoders.rs
@@ -15,7 +15,13 @@ use crate::error::{Error, Result};
 /// Encoder for raw byte input with explicit pixel layout.
 ///
 /// This encoder wraps `StreamingEncoder` to provide true streaming encoding
-/// without buffering the entire image in memory.
+/// without buffering the entire image in memory — except when the
+/// configured [`super::encoder_types::Quality`] is a target-perceptual-
+/// quality variant ([`super::encoder_types::Quality::Zq`] or
+/// [`super::encoder_types::Quality::ZqExplicit`]). In those modes the
+/// encoder must re-encode the same image multiple times to converge on
+/// the perceptual target, so it buffers all incoming pixels until
+/// [`Self::finish_with_metrics`] is called.
 pub struct BytesEncoder {
     /// v2 config (no longer holds metadata)
     config: EncoderConfig,
@@ -24,7 +30,7 @@ pub struct BytesEncoder {
     /// Image dimensions
     width: u32,
     height: u32,
-    /// Inner streaming encoder (handles actual encoding)
+    /// Inner streaming encoder (handles actual encoding when NOT in Zq mode).
     inner: StreamingEncoder,
     /// ICC profile (per-image metadata)
     icc_profile: Option<alloc::vec::Vec<u8>>,
@@ -32,6 +38,12 @@ pub struct BytesEncoder {
     exif_data: Option<super::exif::Exif>,
     /// XMP data (per-image metadata)
     xmp_data: Option<alloc::vec::Vec<u8>>,
+    /// Pixel buffer for the closed-loop target-zq iteration path.
+    /// `Some` when `config.quality.is_zq_target()`; pushes route into
+    /// here instead of the inner streaming encoder. `None` for the
+    /// regular streaming path — pushes go straight into `inner`.
+    /// Capacity = `width * height * bytes_per_pixel`.
+    zq_pixel_buffer: Option<alloc::vec::Vec<u8>>,
 }
 
 impl BytesEncoder {
@@ -69,8 +81,33 @@ impl BytesEncoder {
             ));
         }
 
-        // Build and start the streaming encoder with config from v2
+        // Build and start the streaming encoder with config from v2.
+        //
+        // For target-zq quality variants, the inner encoder is built using
+        // `Quality::to_internal()` (which resolves Zq → starting jpegli q).
+        // It serves as the pass-0 encoder when the iteration loop runs.
         let inner = Self::build_streaming_encoder(&config, width, height, layout)?;
+
+        // When in target-zq mode AND the `target-zq` feature is enabled,
+        // allocate a pixel buffer so we can re-encode the same image
+        // across iteration passes. The streaming path is bypassed
+        // entirely in that case (see `push`/`push_packed`). Without the
+        // feature, Zq variants degrade to ApproxJpegli at the resolved
+        // starting quality (no iteration, no measurement).
+        let zq_pixel_buffer = if cfg!(feature = "target-zq") && config.quality.is_zq_target() {
+            let bpp = layout.bytes_per_pixel();
+            let total = (width as usize)
+                .checked_mul(height as usize)
+                .and_then(|n| n.checked_mul(bpp))
+                .ok_or_else(|| Error::invalid_dimensions(width, height, "buffer size overflow"))?;
+            let mut buf = alloc::vec::Vec::new();
+            buf.try_reserve_exact(total).map_err(|_| {
+                Error::invalid_dimensions(width, height, "could not allocate Zq pixel buffer")
+            })?;
+            Some(buf)
+        } else {
+            None
+        };
 
         Ok(Self {
             config,
@@ -81,6 +118,7 @@ impl BytesEncoder {
             icc_profile,
             exif_data,
             xmp_data,
+            zq_pixel_buffer,
         })
     }
 
@@ -208,8 +246,13 @@ impl BytesEncoder {
             return Err(Error::stride_too_small(self.width, stride_bytes));
         }
 
-        // Validate row count
-        let current_rows = self.inner.rows_pushed() as u32;
+        // Validate row count. In Zq mode, rows pushed are tracked by the
+        // buffer length; in streaming mode, by the inner encoder.
+        let current_rows: u32 = if let Some(buf) = &self.zq_pixel_buffer {
+            (buf.len() / min_stride) as u32
+        } else {
+            self.inner.rows_pushed() as u32
+        };
         let new_total = current_rows + rows as u32;
         if new_total > self.height {
             return Err(Error::too_many_rows(self.height, new_total));
@@ -221,13 +264,22 @@ impl BytesEncoder {
             return Err(Error::invalid_buffer_size(expected_size, data.len()));
         }
 
-        // Push rows to streaming encoder
-        if stride_bytes == min_stride {
-            // Packed data - can push directly
+        if let Some(buf) = self.zq_pixel_buffer.as_mut() {
+            // Target-zq path: store packed rows for later iteration.
+            for row in 0..rows {
+                if stop.should_stop() {
+                    return Err(Error::cancelled());
+                }
+                let src_start = row * stride_bytes;
+                let src_end = src_start + min_stride;
+                buf.extend_from_slice(&data[src_start..src_end]);
+            }
+        } else if stride_bytes == min_stride {
+            // Streaming path, packed data — direct push.
             self.inner
                 .push_rows_with_stop(&data[..rows * min_stride], rows, &stop)?;
         } else {
-            // Strided data - push row by row
+            // Streaming path, strided data — row by row.
             for row in 0..rows {
                 if stop.should_stop() {
                     return Err(Error::cancelled());
@@ -294,13 +346,23 @@ impl BytesEncoder {
     /// Get number of rows pushed so far.
     #[must_use]
     pub fn rows_pushed(&self) -> u32 {
-        self.inner.rows_pushed() as u32
+        if let Some(buf) = &self.zq_pixel_buffer {
+            let bpp = self.layout.bytes_per_pixel();
+            let row_bytes = self.width as usize * bpp;
+            if row_bytes == 0 {
+                0
+            } else {
+                (buf.len() / row_bytes) as u32
+            }
+        } else {
+            self.inner.rows_pushed() as u32
+        }
     }
 
     /// Get number of rows remaining.
     #[must_use]
     pub fn rows_remaining(&self) -> u32 {
-        self.height - self.inner.rows_pushed() as u32
+        self.height - self.rows_pushed()
     }
 
     /// Get allocation statistics from the strip processor.
@@ -317,10 +379,32 @@ impl BytesEncoder {
         self.layout
     }
 
+    /// Install a per-iMCU `AqController` on the inner streaming encoder.
+    /// Used by the target-zq iteration loop in [`super::zq`] to scale
+    /// streaming AQ multiplicatively between passes. Not exposed
+    /// publicly — the public API is [`super::Quality::Zq`].
+    #[allow(dead_code)] // wired only on the Zq path; #[cfg(test)] callers exist via __test-utils.
+    pub(crate) fn set_aq_controller(
+        &mut self,
+        ctrl: Option<Box<dyn super::aq_controller::AqController>>,
+    ) {
+        self.inner.set_aq_controller(ctrl);
+    }
+
     // === Finish ===
 
     /// Finish encoding, return JPEG bytes.
+    ///
+    /// For target-zq quality variants, this transparently routes through
+    /// [`Self::finish_with_metrics`] and discards the metrics — call
+    /// `finish_with_metrics` directly if you need them.
     pub fn finish(self) -> Result<Vec<u8>> {
+        // Target-zq path: iteration loop owns finishing.
+        #[cfg(feature = "target-zq")]
+        if self.zq_pixel_buffer.is_some() {
+            let (bytes, _metrics) = self.finish_with_metrics()?;
+            return Ok(bytes);
+        }
         let mut output = Vec::new();
         self.finish_into(&mut output)?;
         Ok(output)
@@ -331,6 +415,9 @@ impl BytesEncoder {
     /// This is the most efficient way to complete encoding as it avoids
     /// intermediate allocations. The buffer is cleared before writing.
     ///
+    /// For target-zq quality variants, transparently routes through
+    /// [`Self::finish_with_metrics`].
+    ///
     /// # Example
     ///
     /// ```rust,ignore
@@ -339,6 +426,14 @@ impl BytesEncoder {
     /// // output now contains the JPEG data
     /// ```
     pub fn finish_into(mut self, output: &mut Vec<u8>) -> Result<()> {
+        // Target-zq path: iteration writes its own bytes.
+        #[cfg(feature = "target-zq")]
+        if self.zq_pixel_buffer.is_some() {
+            let (bytes, _metrics) = self.finish_with_metrics()?;
+            output.clear();
+            output.extend_from_slice(&bytes);
+            return Ok(());
+        }
         let rows_pushed = self.inner.rows_pushed() as u32;
         if rows_pushed != self.height {
             return Err(Error::incomplete_image(self.height, rows_pushed));
@@ -428,6 +523,80 @@ impl BytesEncoder {
         self.finish_into(&mut jpeg)?;
         output.write_all(&jpeg)?;
         Ok(output)
+    }
+
+    /// Finish encoding and return JPEG bytes plus
+    /// [`super::zq::EncodeMetrics`].
+    ///
+    /// For non-target-zq quality variants, returns minimal metrics
+    /// (`achieved_score = NaN`, `targets_met = true`) and the same
+    /// bytes [`Self::finish`] would. For target-zq variants
+    /// ([`super::Quality::Zq`] / [`super::Quality::ZqExplicit`]) and
+    /// when the `target-zq` feature is enabled, this triggers the
+    /// closed-loop iteration: encode → decode → measure → adjust
+    /// per-block AQ → repeat, returning the smallest-bytes feasible
+    /// candidate observed across `max_passes`.
+    ///
+    /// Errors when [`super::zq::ZqTarget::max_undershoot`] or
+    /// [`super::zq::BlockArtifactBound::max_overshoot`] strictness was
+    /// set and the achieved value falls outside that band.
+    pub fn finish_with_metrics(mut self) -> Result<(Vec<u8>, super::zq::EncodeMetrics)> {
+        #[cfg(feature = "target-zq")]
+        if let (Some(buf), Some(target)) =
+            (self.zq_pixel_buffer.take(), self.config.quality.zq_target())
+        {
+            // Validate complete row count was pushed.
+            let bpp = self.layout.bytes_per_pixel();
+            let row_bytes = self.width as usize * bpp;
+            let pushed_rows = if row_bytes == 0 {
+                0
+            } else {
+                buf.len() / row_bytes
+            };
+            if pushed_rows != self.height as usize {
+                return Err(Error::incomplete_image(self.height, pushed_rows as u32));
+            }
+
+            let ctx = super::zq::IterationContext {
+                config: &self.config,
+                width: self.width,
+                height: self.height,
+                layout: self.layout,
+                pixels: &buf,
+                target,
+            };
+            let (mut bytes, metrics) = super::zq::run_iteration_loop(ctx)?;
+
+            // Inject metadata after iteration. Each per-pass encode ran
+            // without metadata; the same post-encode injection helpers
+            // used by `finish_into` apply here.
+            if let Some(ref exif) = self.exif_data
+                && let Some(exif_bytes) = exif.to_bytes()
+            {
+                inject_exif_inplace(&mut bytes, &exif_bytes);
+            }
+            if let Some(ref xmp_data) = self.xmp_data {
+                inject_xmp_inplace(&mut bytes, xmp_data);
+            }
+            if let Some(ref icc_data) = self.icc_profile {
+                inject_icc_profile_inplace(&mut bytes, icc_data);
+            }
+
+            let final_len = bytes.len();
+            return Ok((
+                bytes,
+                super::zq::EncodeMetrics {
+                    bytes: final_len,
+                    ..metrics
+                },
+            ));
+        }
+
+        // Non-Zq path: existing single-pass encode + minimal metrics.
+        let mut bytes = Vec::new();
+        self.finish_into(&mut bytes)?;
+        let metrics = super::zq::EncodeMetrics::no_target(bytes.len());
+        Ok((bytes, metrics))
     }
 }
 

--- a/zenjpeg/src/encode/byte_encoders.rs
+++ b/zenjpeg/src/encode/byte_encoders.rs
@@ -349,11 +349,10 @@ impl BytesEncoder {
         if let Some(buf) = &self.zq_pixel_buffer {
             let bpp = self.layout.bytes_per_pixel();
             let row_bytes = self.width as usize * bpp;
-            if row_bytes == 0 {
-                0
-            } else {
-                (buf.len() / row_bytes) as u32
-            }
+            buf.len()
+                .checked_div(row_bytes)
+                .map(|n| n as u32)
+                .unwrap_or(0)
         } else {
             self.inner.rows_pushed() as u32
         }
@@ -540,6 +539,7 @@ impl BytesEncoder {
     /// Errors when [`super::zq::ZqTarget::max_undershoot`] or
     /// [`super::zq::BlockArtifactBound::max_overshoot`] strictness was
     /// set and the achieved value falls outside that band.
+    #[cfg_attr(not(feature = "target-zq"), allow(unused_mut))]
     pub fn finish_with_metrics(mut self) -> Result<(Vec<u8>, super::zq::EncodeMetrics)> {
         #[cfg(feature = "target-zq")]
         if let (Some(buf), Some(target)) =

--- a/zenjpeg/src/encode/encoder_types.rs
+++ b/zenjpeg/src/encode/encoder_types.rs
@@ -22,6 +22,25 @@ pub enum Quality {
     /// Approximate Butteraugli distance target.
     /// Range: 0.0+ (lower = better). <1.0 excellent, <3.0 good.
     ApproxButteraugli(f32),
+
+    /// Target perceptual quality in `zq` units (issue #113).
+    ///
+    /// `zq` is calibrated against zensim score so that the encoder lands
+    /// at roughly the same PERCEIVED quality regardless of content type.
+    /// Unlike `ApproxJpegli` (which is a fixed algorithmic knob), `Zq`
+    /// triggers a closed-loop encode: the encoder iterates per-block
+    /// quantization until the achieved zensim score is at or above
+    /// `target` (within the default budget).
+    ///
+    /// Range: ~30–100 useful, with 75–90 the typical web/CDN range.
+    /// Uses [`zq::ZqTarget::default()`] for everything except the target
+    /// value; for explicit budget/strictness control, use
+    /// [`Quality::ZqExplicit`].
+    Zq(f32),
+
+    /// Target perceptual quality with explicit iteration policy
+    /// (issue #113). See [`zq::ZqTarget`] for the per-knob semantics.
+    ZqExplicit(crate::encode::zq::ZqTarget),
 }
 
 impl Default for Quality {
@@ -50,6 +69,11 @@ impl From<i32> for Quality {
 
 impl Quality {
     /// Convert to internal quality value (0.0-100.0 scale).
+    ///
+    /// For [`Quality::Zq`] / [`Quality::ZqExplicit`] this returns the
+    /// STARTING jpegli quality for the iteration loop's first pass, NOT
+    /// the eventual achieved quality. The closed-loop encoder adjusts
+    /// per-block AQ from this baseline.
     #[must_use]
     pub fn to_internal(&self) -> f32 {
         match self {
@@ -57,6 +81,27 @@ impl Quality {
             Quality::ApproxMozjpeg(q) => mozjpeg_to_internal(*q),
             Quality::ApproxSsim2(score) => ssim2_to_internal(*score),
             Quality::ApproxButteraugli(dist) => butteraugli_to_internal(*dist),
+            Quality::Zq(zq) => crate::encode::zq::zq_to_starting_jpegli_q(*zq),
+            Quality::ZqExplicit(t) => crate::encode::zq::zq_to_starting_jpegli_q(t.target),
+        }
+    }
+
+    /// Whether this quality variant triggers the closed-loop iteration
+    /// path (i.e. requires the decoder + zensim measurement on each
+    /// pass). Returns `false` for the existing one-shot variants.
+    #[must_use]
+    pub fn is_zq_target(&self) -> bool {
+        matches!(self, Quality::Zq(_) | Quality::ZqExplicit(_))
+    }
+
+    /// Resolve to a [`crate::encode::zq::ZqTarget`] when this is a
+    /// closed-loop variant. Returns `None` for the one-shot variants.
+    #[must_use]
+    pub fn zq_target(&self) -> Option<crate::encode::zq::ZqTarget> {
+        match self {
+            Quality::Zq(zq) => Some(crate::encode::zq::ZqTarget::new(*zq)),
+            Quality::ZqExplicit(t) => Some(*t),
+            _ => None,
         }
     }
 

--- a/zenjpeg/src/encode/mod.rs
+++ b/zenjpeg/src/encode/mod.rs
@@ -34,7 +34,9 @@
 // by an unrelated commit on main); wiring it in here makes the file
 // actually reachable.
 mod adaptive;
+pub(crate) mod aq_controller;
 mod blocks;
+
 #[doc(hidden)]
 pub mod chroma;
 #[doc(hidden)]
@@ -45,6 +47,10 @@ pub(crate) mod scan_optimize;
 #[doc(hidden)]
 pub mod scan_script;
 mod serialize;
+/// Target perceptual-quality (`zq`) types and helpers (issue #113).
+///
+/// See [`Quality::Zq`] and [`Quality::ZqExplicit`] for the entry points.
+pub mod zq;
 
 #[doc(hidden)]
 pub mod config;

--- a/zenjpeg/src/encode/streaming.rs
+++ b/zenjpeg/src/encode/streaming.rs
@@ -113,6 +113,16 @@ impl StreamingEncoder {
         &self.processor.quant
     }
 
+    /// Install a per-iMCU [`super::aq_controller::AqController`] on the
+    /// underlying strip processor. Used by the target-zq iteration loop
+    /// in [`super::zq`].
+    pub(crate) fn set_aq_controller(
+        &mut self,
+        ctrl: Option<Box<dyn super::aq_controller::AqController>>,
+    ) {
+        self.processor.set_aq_controller(ctrl);
+    }
+
     /// Creates a new streaming encoder builder with the given dimensions.
     ///
     /// Use the builder methods to configure quality, subsampling, etc.

--- a/zenjpeg/src/encode/strip/mod.rs
+++ b/zenjpeg/src/encode/strip/mod.rs
@@ -583,6 +583,19 @@ pub struct StripProcessor {
     // === Reusable AQ strengths buffer ===
     /// Buffer for AQ strengths from process_y_strip_into (avoids per-strip allocation)
     aq_strengths_buffer: Vec<f32>,
+
+    // === Per-iMCU AQ controller hook (issue #113, PR-A) ===
+    /// Optional controller invoked between `StreamingAQ` emitting per-iMCU
+    /// strengths and `quantize_prev_pending_imcu` consuming them. `None`
+    /// (default) is the byte-identity path — locked-hash tests verify
+    /// this. Future layers (Layers 3–4 of #113) install a real controller
+    /// to drive a target-zensim closed loop.
+    ///
+    /// Counts iMCU rows for which `adjust` has been called, so the
+    /// controller sees a monotonic 0-based index even when AQ buffers
+    /// arrive in irregular shapes (e.g. zero-length flush at EOI).
+    aq_controller: Option<Box<dyn crate::encode::aq_controller::AqController>>,
+    aq_controller_imcu_idx: usize,
 }
 
 impl StripProcessor {
@@ -873,6 +886,10 @@ impl StripProcessor {
             // Reusable AQ strengths buffer (one iMCU row worth of blocks)
             // Size: blocks_per_row * v_samp_factor (max 2 for 4:2:0)
             aq_strengths_buffer: vec![0.0f32; pending_y_capacity],
+
+            // No AQ controller installed by default (#113 PR-A scaffold).
+            aq_controller: None,
+            aq_controller_imcu_idx: 0,
         })
     }
 
@@ -954,6 +971,30 @@ impl StripProcessor {
     #[cfg(feature = "boundary-rd")]
     pub(crate) fn set_boundary_rd(&mut self, flat: Option<BoundaryRdFlat>) {
         self.boundary_rd = flat.map(BoundaryRdState::new);
+    }
+
+    /// Install a per-iMCU AQ-strength controller (#113 PR-A scaffold).
+    ///
+    /// `Some(ctrl)` enables the hook in `process_strip_common`: the
+    /// controller's `adjust` is invoked once per iMCU row, immediately
+    /// after `StreamingAQ` finalizes that iMCU's strengths and before
+    /// quantization consumes them. `None` (the default) leaves the
+    /// strength buffer untouched — encode is byte-identical to the
+    /// pre-controller path.
+    ///
+    /// The iMCU index passed to `adjust` is reset whenever a new
+    /// controller is installed.
+    ///
+    /// Currently unused inside the crate — wired up by external callers
+    /// in PR-D (target-zensim closed loop). The compiler's dead-code lint
+    /// is silenced until then.
+    #[allow(dead_code)]
+    pub(crate) fn set_aq_controller(
+        &mut self,
+        ctrl: Option<Box<dyn crate::encode::aq_controller::AqController>>,
+    ) {
+        self.aq_controller = ctrl;
+        self.aq_controller_imcu_idx = 0;
     }
 
     /// Sets trellis quantization configuration.
@@ -1211,7 +1252,17 @@ impl StripProcessor {
         // This is the key optimization: quantize to i16 immediately instead of storing f32.
         if let Some(count) = aq_count {
             // Use mem::take to avoid borrow conflict (moves buffer, no allocation)
-            let temp_buffer = std::mem::take(&mut self.aq_strengths_buffer);
+            let mut temp_buffer = std::mem::take(&mut self.aq_strengths_buffer);
+
+            // Per-iMCU AQ controller hook (#113 PR-A). Default is `None`,
+            // which leaves `temp_buffer` untouched — encode is byte-identical
+            // to the pre-controller path. Locked-hash regression tests verify
+            // this is preserved (see tests/bundled/locked_values.rs).
+            if let Some(ctrl) = self.aq_controller.as_mut() {
+                ctrl.adjust(&mut temp_buffer[..count], self.aq_controller_imcu_idx);
+                self.aq_controller_imcu_idx += 1;
+            }
+
             self.quantize_prev_pending_imcu(&temp_buffer[..count]);
             self.aq_strengths_buffer = temp_buffer;
             self.pending.clear_prev();
@@ -2358,6 +2409,70 @@ mod tests {
                 psnr,
                 height
             );
+        }
+    }
+
+    /// AqController scaffold (#113 PR-A): the hook is invoked once per
+    /// iMCU row with a monotonic index. The trait requires `Send`, so
+    /// the test stashes its log in a thread_local instead of `Rc<RefCell>`.
+    /// We exercise the live encode path via `process_strip` and verify
+    /// the controller saw at least one call with monotonic indices and
+    /// non-empty strength slices.
+    #[test]
+    fn aq_controller_hook_is_called_per_imcu() {
+        use crate::encode::aq_controller::AqController;
+        use core::cell::RefCell;
+
+        thread_local! {
+            static LOG: RefCell<Vec<(usize, usize)>> = const { RefCell::new(Vec::new()) };
+        }
+
+        #[derive(Debug)]
+        struct Recorder;
+        impl AqController for Recorder {
+            fn adjust(&mut self, strengths: &mut [f32], imcu_idx: usize) {
+                LOG.with(|l| l.borrow_mut().push((imcu_idx, strengths.len())));
+            }
+        }
+
+        LOG.with(|l| l.borrow_mut().clear());
+
+        let width = 64usize;
+        let height = 64usize;
+        let mut rgb = vec![0u8; width * height * 3];
+        for y in 0..height {
+            for x in 0..width {
+                let idx = (y * width + x) * 3;
+                rgb[idx] = ((x * 4) & 0xFF) as u8;
+                rgb[idx + 1] = ((y * 4) & 0xFF) as u8;
+                rgb[idx + 2] = (((x + y) * 2) & 0xFF) as u8;
+            }
+        }
+
+        let mut processor = StripProcessor::new(width, height, Subsampling::S420, PixelFormat::Rgb)
+            .expect("processor creation");
+        processor.set_aq_controller(Some(Box::new(Recorder)));
+
+        let strip_h = processor.strip_height();
+        for strip_y in (0..height).step_by(strip_h) {
+            let h = strip_h.min(height - strip_y);
+            let row_size = width * 3;
+            let strip = &rgb[strip_y * row_size..(strip_y + h) * row_size];
+            processor
+                .process_strip(strip, strip_y)
+                .expect("process_strip");
+        }
+
+        let log = LOG.with(|l| l.borrow().clone());
+        // 64-row 4:2:0 image is 4 iMCU rows (16 px per iMCU). StreamingAQ
+        // holds back the first iMCU as lookahead for fuzzy erosion, so
+        // the trailing emission lands at flush time (not exercised by
+        // process_strip alone). What this test pins down: the hook
+        // fires, indices are monotonic from 0, slices are non-empty.
+        assert!(!log.is_empty(), "controller adjust never called");
+        for (n, (idx, len)) in log.iter().enumerate() {
+            assert_eq!(*idx, n, "imcu_idx must be monotonic from 0");
+            assert!(*len > 0, "strength slice must not be empty");
         }
     }
 }

--- a/zenjpeg/src/encode/zq.rs
+++ b/zenjpeg/src/encode/zq.rs
@@ -250,22 +250,19 @@ impl EncodeMetrics {
 }
 
 /// Maps a user-facing zq value to a starting jpegli-quality estimate for
-/// the iteration loop's first pass.
-///
-/// This is a small lookup table calibrated from the
-/// `examples/method_b_real.rs` corpus run (CID22 + screen content). The
-/// goal is "first pass lands close enough to target that 1–2 correction
-/// passes can refine it"; precision isn't required.
+/// the iteration loop's first pass — content-bucket-naive variant.
 ///
 /// Identity-ish in the typical user range (zq 70–95 maps to jpegli q 70–95).
-/// The iteration loop in `BytesEncoder` corrects from here.
+/// The iteration loop in `BytesEncoder` corrects from here. Used as the
+/// fallback when bucket-aware calibration is unavailable.
+///
+/// See [`zq_to_starting_jpegli_q_for_bucket`] for the bucket-aware form,
+/// which lands closer to target on the first pass and reduces the
+/// correction budget needed.
 #[must_use]
 pub(crate) fn zq_to_starting_jpegli_q(zq: f32) -> f32 {
-    // Empirical: streaming-AQ zensim score at jpegli q lands roughly
-    // 1–3 zq points above the q value on photos, 1–2 below on dense
-    // screen content. Picking q ≈ zq + 1 as the starting point makes
-    // pass 1 land at-or-above target on most images, leaving headroom
-    // for the controller to claw bytes.
+    // Average across content types — picks q ≈ zq + 1 in the photo
+    // range, slightly higher at the top end where the metric saturates.
     const ANCHORS: &[(f32, f32)] = &[
         (40.0, 38.0),
         (60.0, 58.0),
@@ -275,21 +272,121 @@ pub(crate) fn zq_to_starting_jpegli_q(zq: f32) -> f32 {
         (90.0, 93.0),
         (95.0, 97.0),
     ];
+    interpolate_anchors(zq, ANCHORS)
+}
 
-    if zq <= ANCHORS[0].0 {
-        return ANCHORS[0].1;
+/// Linear interpolation over a sorted (zq, jpegli_q) anchor table.
+/// Clamps to endpoints outside the bracketed range.
+fn interpolate_anchors(zq: f32, anchors: &[(f32, f32)]) -> f32 {
+    if anchors.is_empty() {
+        return zq;
     }
-    if zq >= ANCHORS[ANCHORS.len() - 1].0 {
-        return ANCHORS[ANCHORS.len() - 1].1.min(100.0);
+    if zq <= anchors[0].0 {
+        return anchors[0].1;
     }
-    for w in ANCHORS.windows(2) {
+    let last = anchors[anchors.len() - 1];
+    if zq >= last.0 {
+        return last.1.min(100.0);
+    }
+    for w in anchors.windows(2) {
         let (lo, hi) = (w[0], w[1]);
         if zq >= lo.0 && zq <= hi.0 {
             let t = (zq - lo.0) / (hi.0 - lo.0);
             return lo.1 + t * (hi.1 - lo.1);
         }
     }
-    zq // unreachable
+    zq
+}
+
+/// Bucket-aware starting-q calibration. Uses the same anchor-interpolation
+/// pattern as [`zq_to_starting_jpegli_q`] but with a separate table per
+/// content bucket. Each bucket's anchors come from the
+/// `examples/zq_calibrate.rs` corpus harness — initial values below are
+/// hand-distilled from the predictor experiment's per-content
+/// observations until the harness produces a fitted replacement.
+///
+/// Why per-bucket: streaming-AQ score-vs-q curves differ meaningfully by
+/// content type. Screen content needs ~5–8 q points more than photos to
+/// reach the same zq target (text/edges have less perceptual headroom);
+/// flat photos need slightly less. The bucket-naive average misses both
+/// ends, costing extra iterations.
+#[must_use]
+pub(crate) fn zq_to_starting_jpegli_q_for_bucket(
+    zq: f32,
+    bucket: crate::encode::adaptive::InferredBucket,
+) -> f32 {
+    use crate::encode::adaptive::InferredBucket as B;
+    // Anchors are (target_zq, starting_jpegli_q). Median of per-image
+    // smallest-q-meeting-target values, fit by `examples/zq_calibrate.rs`
+    // on a 76-image corpus (CID22 validation + gb82 photos + gb82-sc
+    // screen content). Re-run the harness to refit if the streaming AQ
+    // pipeline or the zensim profile changes.
+    //
+    // Per-bucket sample counts at fit time:
+    //   PhotoNatural   n=7
+    //   PhotoDetailed  n=36
+    //   PhotoFlat      n=13
+    //   Illustration   n=1  (single sample; treat with skepticism, the
+    //                       table will be refined when more illustration
+    //                       content joins the calibration corpus)
+    //   ScreenContent  n=19
+    //
+    // The harness output also reports p25/p75 per anchor for spread
+    // inspection — see `/tmp/zq_calibrate_full.log` snapshot or re-run.
+    const PHOTO_NATURAL: &[(f32, f32)] = &[
+        (40.0, 20.0),
+        (60.0, 25.0),
+        (75.0, 60.0),
+        (80.0, 75.0),
+        (85.0, 90.0),
+        (90.0, 95.0),
+        (95.0, 100.0),
+    ];
+    const PHOTO_DETAILED: &[(f32, f32)] = &[
+        (40.0, 20.0),
+        (60.0, 25.0),
+        (75.0, 70.0),
+        (80.0, 80.0),
+        (85.0, 90.0),
+        (90.0, 100.0),
+        (95.0, 100.0),
+    ];
+    const PHOTO_FLAT: &[(f32, f32)] = &[
+        (40.0, 20.0),
+        (60.0, 20.0),
+        (75.0, 60.0),
+        (80.0, 75.0),
+        (85.0, 90.0),
+        (90.0, 100.0),
+        (95.0, 100.0),
+    ];
+    const ILLUSTRATION: &[(f32, f32)] = &[
+        (40.0, 20.0),
+        (60.0, 20.0),
+        (75.0, 40.0),
+        (80.0, 65.0),
+        (85.0, 85.0),
+        (90.0, 100.0),
+        (95.0, 100.0),
+    ];
+    const SCREEN_CONTENT: &[(f32, f32)] = &[
+        (40.0, 20.0),
+        (60.0, 20.0),
+        (75.0, 45.0),
+        (80.0, 70.0),
+        (85.0, 85.0),
+        (90.0, 95.0),
+        (95.0, 100.0),
+    ];
+
+    let anchors = match bucket {
+        B::PhotoNatural => PHOTO_NATURAL,
+        B::PhotoDetailed => PHOTO_DETAILED,
+        B::PhotoFlat => PHOTO_FLAT,
+        B::Illustration => ILLUSTRATION,
+        B::ScreenContent => SCREEN_CONTENT,
+    };
+    interpolate_anchors(zq, anchors)
 }
 
 // ============================================================================
@@ -545,9 +642,18 @@ pub(crate) fn run_iteration_loop(
         Err(_) => return run_single_pass(&ctx, None),
     };
 
-    // Pass 0: streaming-AQ baseline. Substitute Quality::Zq* with the
-    // resolved starting jpegli q to avoid recursion.
-    let starting_q = ctx.config.quality.to_internal();
+    // Pass 0: streaming-AQ baseline. Substitute Quality::Zq* with a
+    // bucket-aware starting jpegli q (avoids recursion AND lands closer
+    // to target than the bucket-naive lookup).
+    //
+    // Bucket detection runs the analyzer on the source pixels — same
+    // ~1ms cost as `EncoderConfig::adaptive`. Falls through to the
+    // bucket-naive lookup if analysis fails (e.g. tiny images).
+    let bucket = detect_bucket(ctx.pixels, ctx.width, ctx.height);
+    let starting_q = match (ctx.target.target, bucket) {
+        (zq, Some(b)) => zq_to_starting_jpegli_q_for_bucket(zq, b),
+        (zq, None) => zq_to_starting_jpegli_q(zq),
+    };
     let mut pass_config: EncoderConfig = ctx.config.clone();
     pass_config = pass_config.quality(Quality::ApproxJpegli(starting_q));
 
@@ -770,6 +876,22 @@ fn run_single_pass(
             targets_met: true,
         },
     ))
+}
+
+/// Run the analyzer on RGB8 source pixels and return an inferred content
+/// bucket for starting-q calibration. Returns `None` if the image is too
+/// small for the analyzer to produce meaningful features.
+#[cfg(feature = "target-zq")]
+fn detect_bucket(
+    pixels: &[u8],
+    width: u32,
+    height: u32,
+) -> Option<crate::encode::adaptive::InferredBucket> {
+    if width < 8 || height < 8 {
+        return None;
+    }
+    let features = crate::analyze::analyze_rgb8(pixels, width, height);
+    Some(crate::encode::adaptive::infer_bucket(&features))
 }
 
 /// Reinterpret a packed RGB byte slice as `[u8; 3]` chunks. Length must

--- a/zenjpeg/src/encode/zq.rs
+++ b/zenjpeg/src/encode/zq.rs
@@ -1,0 +1,837 @@
+//! Target perceptual-quality (`zq`) types for the closed-loop encoder.
+//!
+//! See [`crate::encode::Quality::Zq`] / [`crate::encode::Quality::ZqExplicit`]
+//! for usage. The encoder iteratively encodes the image, measures perceptual
+//! error against the source (using zensim diffmap), and adjusts per-block
+//! quantization until the target band is met or the iteration budget runs out.
+//!
+//! # Naming convention
+//!
+//! Throughout this module:
+//! - `_overshoot` = how much the achieved value may exceed the target/ceiling
+//! - `_undershoot` = how much the achieved value may fall below it
+//!
+//! Whether `_overshoot` or `_undershoot` is the "good" direction depends on
+//! the constraint:
+//!
+//! - [`ZqTarget::target`] is a quality FLOOR: overshoot = more quality
+//!   (good), undershoot = less quality (bad). Claw-back triggers on
+//!   overshoot; failure on undershoot.
+//! - [`BlockArtifactBound::ceiling`] is an error CEILING: overshoot = more
+//!   artifact (bad), undershoot = less artifact (good). Failure triggers on
+//!   overshoot; claw-back on undershoot.
+//!
+//! Defaults are tuned so the typical caller gets best-effort behavior with
+//! no surprise errors. Callers that need strict guarantees opt in via
+//! [`ZqTarget::max_undershoot`] (for the floor) or
+//! [`BlockArtifactBound::max_overshoot`] (for the ceiling).
+
+/// Explicit target-perceptual-quality specification.
+///
+/// Used via [`crate::encode::Quality::ZqExplicit`]. For the simple single-
+/// knob form, use [`crate::encode::Quality::Zq`] instead — that path uses
+/// `ZqTarget::default()` for everything except the target value.
+///
+/// Per-field naming convention is documented at the [module level][self].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ZqTarget {
+    /// IDEAL perceived quality (zq units). The encoder iterates to reach
+    /// or exceed this score within the [`Self::max_passes`] budget.
+    pub target: f32,
+
+    /// Distance ABOVE target the encoder will accept without further
+    /// iteration. `None` = ship the first feasible result (single pass
+    /// once target is met). `Some(t)` = if `achieved_score > target + t`,
+    /// iterate to recover bytes.
+    ///
+    /// Smaller value → tighter hug → more iteration cost on average.
+    /// Asymmetric by design: there is no over-target tolerance for
+    /// failure, only for waste.
+    ///
+    /// Default: `Some(1.5)`.
+    pub max_overshoot: Option<f32>,
+
+    /// Distance BELOW target the encoder will accept as a SUCCESSFUL
+    /// encode. `None` = best-effort, never error (default; encoder ships
+    /// whatever it managed within `max_passes`). `Some(t)` = if final
+    /// `achieved_score < target - t` after exhausting `max_passes`, the
+    /// encoder returns `Err`.
+    ///
+    /// Set this when you NEED a strictness guarantee (archival,
+    /// accessibility, SLA-bound serving). Permissive callers leave it
+    /// `None` and inspect [`EncodeMetrics::achieved_score`] themselves.
+    ///
+    /// Default: `None`.
+    pub max_undershoot: Option<f32>,
+
+    /// Optional per-block worst-case artifact bound. See
+    /// [`BlockArtifactBound`] for the inner knobs.
+    pub block_artifact: Option<BlockArtifactBound>,
+
+    /// Diffmap-driven correction-pass budget.
+    /// - `0` = single-pass (controller disabled; encoder behaves like
+    ///   `Quality::ApproxJpegli` at the resolved starting quality).
+    /// - `2` = default; one initial encode plus one correction pass.
+    /// - `4` = aggressive; up to four correction passes.
+    ///
+    /// Each pass costs roughly one base-encode + one zensim diffmap
+    /// computation.
+    pub max_passes: u8,
+}
+
+impl Default for ZqTarget {
+    fn default() -> Self {
+        Self {
+            target: 80.0,
+            max_overshoot: Some(1.5),
+            max_undershoot: None,
+            block_artifact: None,
+            max_passes: 2,
+        }
+    }
+}
+
+impl ZqTarget {
+    /// Construct a `ZqTarget` with the given target value and all other
+    /// fields at their defaults. Equivalent to
+    /// `ZqTarget { target, ..Default::default() }`.
+    #[must_use]
+    pub fn new(target: f32) -> Self {
+        Self {
+            target,
+            ..Default::default()
+        }
+    }
+
+    /// Builder-style override of [`Self::max_overshoot`].
+    #[must_use]
+    pub fn with_max_overshoot(mut self, v: Option<f32>) -> Self {
+        self.max_overshoot = v;
+        self
+    }
+
+    /// Builder-style override of [`Self::max_undershoot`].
+    #[must_use]
+    pub fn with_max_undershoot(mut self, v: Option<f32>) -> Self {
+        self.max_undershoot = v;
+        self
+    }
+
+    /// Builder-style override of [`Self::block_artifact`].
+    #[must_use]
+    pub fn with_block_artifact(mut self, v: Option<BlockArtifactBound>) -> Self {
+        self.block_artifact = v;
+        self
+    }
+
+    /// Builder-style override of [`Self::max_passes`].
+    #[must_use]
+    pub fn with_max_passes(mut self, n: u8) -> Self {
+        self.max_passes = n;
+        self
+    }
+}
+
+/// Per-block worst-case artifact bound. Companion to [`ZqTarget`].
+///
+/// `ceiling` is in zensim diffmap units (per-pixel perceptual error,
+/// averaged within an 8×8 block). The encoder tries to ensure no block's
+/// averaged diffmap exceeds `ceiling`. Like [`ZqTarget::target`], this is
+/// best-effort by default — if the budget runs out, the encoder ships
+/// what it has. Set [`Self::max_overshoot`] to make the bound strict
+/// (encoder errors if the final worst-block exceeds the threshold).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BlockArtifactBound {
+    /// Worst-case per-block perceptual error, in zensim diffmap units.
+    /// The encoder iterates toward "no block exceeds this".
+    pub ceiling: f32,
+
+    /// Distance ABOVE the ceiling the encoder will accept as a
+    /// SUCCESSFUL encode. `None` = best-effort, never error.
+    /// `Some(t)` = if final max-block-artifact > `ceiling + t` after
+    /// `max_passes`, the encoder returns `Err`.
+    ///
+    /// Set this when you NEED a per-block guarantee (subjective testing,
+    /// archival, accessibility).
+    ///
+    /// Default: `None`.
+    pub max_overshoot: Option<f32>,
+
+    /// Distance BELOW the ceiling that triggers byte-recovery iteration.
+    /// `None` = no per-block clawback (default; the score-side clawback
+    /// via [`ZqTarget::max_overshoot`] usually handles this incidentally).
+    /// `Some(t)` = if max-block-artifact < `ceiling - t`, iterate to
+    /// recover bytes.
+    ///
+    /// Surface for completeness + callers who want explicit per-block
+    /// clawback semantics.
+    ///
+    /// Default: `None`.
+    pub max_undershoot: Option<f32>,
+}
+
+impl BlockArtifactBound {
+    /// Construct a `BlockArtifactBound` with the given ceiling and all
+    /// other fields at their defaults (best-effort, no errors, no
+    /// per-block clawback).
+    #[must_use]
+    pub fn new(ceiling: f32) -> Self {
+        Self {
+            ceiling,
+            max_overshoot: None,
+            max_undershoot: None,
+        }
+    }
+
+    /// Builder-style override of [`Self::max_overshoot`].
+    #[must_use]
+    pub fn with_max_overshoot(mut self, v: Option<f32>) -> Self {
+        self.max_overshoot = v;
+        self
+    }
+
+    /// Builder-style override of [`Self::max_undershoot`].
+    #[must_use]
+    pub fn with_max_undershoot(mut self, v: Option<f32>) -> Self {
+        self.max_undershoot = v;
+        self
+    }
+}
+
+/// Outcome of a target-perceptual-quality encode.
+///
+/// Returned alongside the JPEG bytes from
+/// [`crate::encode::BytesEncoder::finish_with_metrics`] (and similar
+/// methods on other encoder facades). Callers inspect this when they want
+/// to know whether the encoder hit the target, how many passes it took,
+/// or what byte budget was actually spent.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub struct EncodeMetrics {
+    /// Final achieved zensim score of the shipped output, computed
+    /// against the source via zensim's `Trained` diffmap weighting.
+    /// `f32::NAN` if no measurement was performed (e.g. `max_passes=0`
+    /// or the decoder feature is unavailable).
+    pub achieved_score: f32,
+
+    /// Largest per-block diffmap value (averaged over the 8×8 block) in
+    /// the shipped output. `f32::NAN` if not measured.
+    pub achieved_max_block_artifact: f32,
+
+    /// Number of encode passes performed, including the initial pass.
+    /// `1` means single-pass (no correction).
+    pub passes_used: u8,
+
+    /// Encoded JPEG byte count.
+    pub bytes: usize,
+
+    /// Whether every active goal was met. `true` iff:
+    /// - achieved_score ≥ target, AND
+    /// - if `BlockArtifactBound` was set, achieved_max_block_artifact ≤ ceiling
+    ///
+    /// For non-`Zq` quality variants this is always `true` (no goal).
+    pub targets_met: bool,
+}
+
+impl EncodeMetrics {
+    /// Convenience: the metrics returned for a non-`Zq` quality variant
+    /// (no goal, no measurement). Bytes are still recorded.
+    pub(crate) fn no_target(bytes: usize) -> Self {
+        Self {
+            achieved_score: f32::NAN,
+            achieved_max_block_artifact: f32::NAN,
+            passes_used: 1,
+            bytes,
+            targets_met: true,
+        }
+    }
+}
+
+/// Maps a user-facing zq value to a starting jpegli-quality estimate for
+/// the iteration loop's first pass.
+///
+/// This is a small lookup table calibrated from the
+/// `examples/method_b_real.rs` corpus run (CID22 + screen content). The
+/// goal is "first pass lands close enough to target that 1–2 correction
+/// passes can refine it"; precision isn't required.
+///
+/// Identity-ish in the typical user range (zq 70–95 maps to jpegli q 70–95).
+/// The iteration loop in `BytesEncoder` corrects from here.
+#[must_use]
+pub(crate) fn zq_to_starting_jpegli_q(zq: f32) -> f32 {
+    // Empirical: streaming-AQ zensim score at jpegli q lands roughly
+    // 1–3 zq points above the q value on photos, 1–2 below on dense
+    // screen content. Picking q ≈ zq + 1 as the starting point makes
+    // pass 1 land at-or-above target on most images, leaving headroom
+    // for the controller to claw bytes.
+    const ANCHORS: &[(f32, f32)] = &[
+        (40.0, 38.0),
+        (60.0, 58.0),
+        (75.0, 75.0),
+        (80.0, 81.0),
+        (85.0, 87.0),
+        (90.0, 93.0),
+        (95.0, 97.0),
+    ];
+
+    if zq <= ANCHORS[0].0 {
+        return ANCHORS[0].1;
+    }
+    if zq >= ANCHORS[ANCHORS.len() - 1].0 {
+        return ANCHORS[ANCHORS.len() - 1].1.min(100.0);
+    }
+    for w in ANCHORS.windows(2) {
+        let (lo, hi) = (w[0], w[1]);
+        if zq >= lo.0 && zq <= hi.0 {
+            let t = (zq - lo.0) / (hi.0 - lo.0);
+            return lo.1 + t * (hi.1 - lo.1);
+        }
+    }
+    zq // unreachable
+}
+
+// ============================================================================
+// Internal: iteration loop wiring
+// ============================================================================
+
+use super::aq_controller::AqController;
+
+/// Per-iMCU multiplicative-scale controller. Each iMCU row carries a
+/// row of per-block scale factors that multiply the streaming-AQ output.
+///
+/// scale = 1.0 → no change. scale < 1.0 → tighter (more bits).
+/// scale > 1.0 → looser (fewer bits). Final AQ is clamped to `[0.0, 0.20]`
+/// by the strip processor.
+#[derive(Debug)]
+struct ScalingController {
+    /// `scales[imcu_idx]` = per-block scale factors for that iMCU row.
+    scales: alloc::vec::Vec<alloc::vec::Vec<f32>>,
+}
+
+impl AqController for ScalingController {
+    fn adjust(&mut self, strengths: &mut [f32], imcu_idx: usize) {
+        let row = match self.scales.get(imcu_idx) {
+            Some(r) => r,
+            None => return,
+        };
+        for (i, s) in strengths.iter_mut().enumerate() {
+            let scale = row.get(i).copied().unwrap_or(1.0);
+            *s = (*s * scale).clamp(0.0, 0.20);
+        }
+    }
+}
+
+/// Iteration-loop controller hyperparameters. Picked from the
+/// `examples/method_b_real.rs` corpus run; small surface so the public
+/// API doesn't expose them in v1.
+mod hp {
+    /// Per-pass cap on absolute scale change per block.
+    pub(super) const MAX_SCALE_DELTA: f32 = 0.20;
+    /// Lower clamp on cumulative scale.
+    pub(super) const MIN_SCALE: f32 = 0.40;
+    /// Upper clamp on cumulative scale.
+    pub(super) const MAX_SCALE: f32 = 1.80;
+}
+
+/// Compute the per-block multiplicative scale schedule for the next pass.
+///
+/// `prev_scales` and `block_dm` are flat per-block vectors in row-major
+/// order, length = blocks_w * blocks_h. The returned scales replace
+/// `prev_scales` for the next pass — they are CUMULATIVE, not deltas.
+///
+/// Policy:
+/// - Score below target → tighten the highest-error blocks (scale↓).
+/// - Block diffmap above peak ceiling → tighten THOSE blocks specifically.
+/// - Score in band, no ceiling violation → loosen the lowest-error
+///   blocks (scale↑) to recover bytes.
+fn next_scales(
+    prev_scales: &[f32],
+    block_dm: &[f32],
+    current_score: f32,
+    current_max_block: f32,
+    target: &ZqTarget,
+) -> alloc::vec::Vec<f32> {
+    let mut sorted = block_dm.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let p25 = sorted[sorted.len() / 4];
+    let p75 = sorted[(3 * sorted.len()) / 4];
+    let max = *sorted.last().unwrap_or(&0.0);
+
+    let score_violation = current_score < target.target;
+    let peak_violation = match target.block_artifact {
+        Some(b) => current_max_block > b.ceiling,
+        None => false,
+    };
+
+    // Where to tighten:
+    // - peak violation → tighten any block above the ceiling specifically
+    // - score violation → tighten the top-25% diffmap tail
+    // - both → tighten the union (handled via min)
+    let tighten_above = match (peak_violation, score_violation) {
+        (true, _) => target.block_artifact.unwrap().ceiling,
+        (false, true) => p75,
+        _ => f32::INFINITY,
+    };
+
+    // Where to loosen (claw back bytes): only if both score and peak are
+    // satisfied AND the current score is well into overshoot territory.
+    let in_band = !score_violation && !peak_violation;
+    let overshoot = current_score - target.target;
+    let claw_active = in_band
+        && match target.max_overshoot {
+            Some(t) => overshoot > t,
+            None => false,
+        };
+    let loosen_below = if claw_active { p25 } else { f32::NEG_INFINITY };
+
+    prev_scales
+        .iter()
+        .zip(block_dm.iter())
+        .map(|(&prev, &dm)| {
+            let delta = if dm > tighten_above {
+                let frac = ((dm - tighten_above) / (max - tighten_above).max(1e-6)).clamp(0.0, 1.0);
+                -hp::MAX_SCALE_DELTA * frac
+            } else if dm < loosen_below {
+                let frac = ((loosen_below - dm) / loosen_below.max(1e-6)).clamp(0.0, 1.0);
+                hp::MAX_SCALE_DELTA * frac
+            } else {
+                0.0
+            };
+            (prev + delta).clamp(hp::MIN_SCALE, hp::MAX_SCALE)
+        })
+        .collect()
+}
+
+/// Lay out a flat per-block scale vector into the iMCU-row schedule
+/// shape that [`AqController::adjust`] consumes.
+///
+/// `flat[bx + by * blocks_w]` is the scale for block `(bx, by)`.
+/// One iMCU row covers `v_samp` block rows of width `blocks_w`.
+fn flat_to_imcu_schedule(
+    flat: &[f32],
+    blocks_w: usize,
+    blocks_h: usize,
+    v_samp: usize,
+) -> alloc::vec::Vec<alloc::vec::Vec<f32>> {
+    let imcu_rows = blocks_h.div_ceil(v_samp);
+    let mut out = alloc::vec::Vec::with_capacity(imcu_rows);
+    for imcu_idx in 0..imcu_rows {
+        let mut row = alloc::vec::Vec::with_capacity(blocks_w * v_samp);
+        for vrow in 0..v_samp {
+            let by = imcu_idx * v_samp + vrow;
+            if by >= blocks_h {
+                break;
+            }
+            for bx in 0..blocks_w {
+                row.push(flat[by * blocks_w + bx]);
+            }
+        }
+        out.push(row);
+    }
+    out
+}
+
+/// Aggregate a full-resolution diffmap (`width × height` f32) into a
+/// per-block mean. Truncating divides for non-multiples-of-8 dims —
+/// the right/bottom edge sliver is dropped (matches the encoder's
+/// 8×8 block grid).
+fn aggregate_diffmap_to_blocks(
+    diffmap: &[f32],
+    width: usize,
+    height: usize,
+) -> alloc::vec::Vec<f32> {
+    const BLOCK: usize = 8;
+    let blocks_w = width / BLOCK;
+    let blocks_h = height / BLOCK;
+    let mut out = alloc::vec::Vec::with_capacity(blocks_w * blocks_h);
+    for by in 0..blocks_h {
+        for bx in 0..blocks_w {
+            let mut sum = 0.0f64;
+            for ly in 0..BLOCK {
+                for lx in 0..BLOCK {
+                    let x = bx * BLOCK + lx;
+                    let y = by * BLOCK + ly;
+                    sum += diffmap[y * width + x] as f64;
+                }
+            }
+            out.push((sum / (BLOCK * BLOCK) as f64) as f32);
+        }
+    }
+    out
+}
+
+/// Configuration, dimensions, and pixels captured by a
+/// [`crate::encode::BytesEncoder`] in target-zq mode. The iteration loop
+/// rebuilds a fresh `BytesEncoder` per pass from these.
+///
+/// Per-image metadata (ICC, EXIF, XMP) is intentionally NOT carried here
+/// — it's injected into the final JPEG bytes by `BytesEncoder` after the
+/// iteration loop returns, the same post-encode injection helpers used
+/// by the streaming `finish_into` path. The iteration loop itself
+/// produces metadata-free JPEGs to keep its inner encodes fast.
+#[cfg(feature = "target-zq")]
+pub(crate) struct IterationContext<'a> {
+    pub(crate) config: &'a crate::encode::EncoderConfig,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) layout: crate::encode::PixelLayout,
+    pub(crate) pixels: &'a [u8],
+    pub(crate) target: ZqTarget,
+}
+
+/// Run the closed-loop target-zq iteration. Returns the JPEG bytes of
+/// the best feasible candidate observed (smallest bytes among all
+/// passes that meet active goals; if no pass meets goals, the highest-
+/// score pass).
+///
+/// Errors only when:
+/// - Encoding errors out at any pass (propagated).
+/// - `max_undershoot` is set on `target` and the final achieved score
+///   is below `target.target - max_undershoot`.
+/// - `block_artifact.max_overshoot` is set and the final max-block
+///   artifact exceeds `ceiling + max_overshoot`.
+#[cfg(feature = "target-zq")]
+pub(crate) fn run_iteration_loop(
+    ctx: IterationContext<'_>,
+) -> crate::error::Result<(alloc::vec::Vec<u8>, EncodeMetrics)> {
+    use crate::encode::{EncoderConfig, Quality};
+    use zensim::{RgbSlice, Zensim, ZensimProfile};
+
+    let blocks_w = (ctx.width as usize) / 8;
+    let blocks_h = (ctx.height as usize) / 8;
+    if blocks_w == 0 || blocks_h == 0 {
+        // Image too small to do per-block correction; fall back to the
+        // single-pass starting-q encode.
+        return run_single_pass(&ctx, None);
+    }
+
+    // Vertical sampling factor of the luma plane in iMCUs. Determines
+    // how many block rows belong to a single iMCU emission. Covers
+    // every supported color mode + subsampling combo:
+    //
+    //   YCbCr 4:4:4, 4:2:2  → v_samp = 1
+    //   YCbCr 4:2:0, 4:4:0  → v_samp = 2
+    //   XYB Full            → v_samp = 1
+    //   XYB BQuarter        → v_samp = 2  (B is 2×2 downsampled, max v_samp=2)
+    //   Grayscale           → v_samp = 1
+    let v_samp = match ctx.config.color_mode {
+        crate::encode::ColorMode::YCbCr { subsampling } => {
+            subsampling.v_samp_factor_luma() as usize
+        }
+        crate::encode::ColorMode::Xyb { subsampling } => match subsampling {
+            crate::encode::XybSubsampling::BQuarter => 2,
+            crate::encode::XybSubsampling::Full => 1,
+        },
+        crate::encode::ColorMode::Grayscale => 1,
+    };
+
+    // Build the source ImageSource for zensim. Layout currently must be
+    // RGB8 — other layouts would require zenpixels conversion to drive
+    // zensim's per-channel pipeline. (XYB encoding accepts RGB8 input
+    // and converts internally; the source stays in sRGB8 here.)
+    if ctx.layout != crate::encode::PixelLayout::Rgb8Srgb {
+        // For non-RGB8 layouts, fall back to single-pass — extending
+        // the closed loop to other layouts is future work.
+        return run_single_pass(&ctx, None);
+    }
+
+    let z = Zensim::new(ZensimProfile::latest());
+    let src_chunks: &[[u8; 3]] = bytemuck_chunks(ctx.pixels);
+    let src_slice = RgbSlice::new(src_chunks, ctx.width as usize, ctx.height as usize);
+    let pre = match z.precompute_reference(&src_slice) {
+        Ok(p) => p,
+        Err(_) => return run_single_pass(&ctx, None),
+    };
+
+    // Pass 0: streaming-AQ baseline. Substitute Quality::Zq* with the
+    // resolved starting jpegli q to avoid recursion.
+    let starting_q = ctx.config.quality.to_internal();
+    let mut pass_config: EncoderConfig = ctx.config.clone();
+    pass_config = pass_config.quality(Quality::ApproxJpegli(starting_q));
+
+    let bytes0 = encode_pass(&pass_config, &ctx, None)?;
+    let (score0, dm0) = measure(&z, &pre, &bytes0, ctx.width, ctx.height)?;
+    let max0 = max_block(&dm0);
+
+    let mut best_bytes = bytes0.clone();
+    let mut best_score = score0;
+    let mut best_max = max0;
+    let mut best_feasible = is_feasible(score0, max0, &ctx.target);
+    let mut passes_used: u8 = 1;
+
+    if !is_feasible(score0, max0, &ctx.target) || ctx.target.max_passes == 0 {
+        // No iteration budget, or pass 0 already infeasible and we still
+        // have to exit cleanly: enter the loop below.
+    } else if let Some(t) = ctx.target.max_overshoot {
+        if score0 - ctx.target.target <= t {
+            // Already in band; ship pass 0.
+            return finalize(best_bytes, score0, max0, passes_used, &ctx.target);
+        }
+    } else {
+        // No claw-back budget configured; ship first feasible pass.
+        return finalize(best_bytes, score0, max0, passes_used, &ctx.target);
+    }
+
+    let mut current_scales = alloc::vec![1.0f32; blocks_w * blocks_h];
+    let mut current_dm = dm0;
+    let mut current_score = score0;
+    let mut current_max = max0;
+
+    for _pass in 1..=ctx.target.max_passes {
+        let next = next_scales(
+            &current_scales,
+            &current_dm,
+            current_score,
+            current_max,
+            &ctx.target,
+        );
+        let schedule = flat_to_imcu_schedule(&next, blocks_w, blocks_h, v_samp);
+        let ctrl: Box<dyn AqController> = Box::new(ScalingController { scales: schedule });
+        let bytes_n = encode_pass(&pass_config, &ctx, Some(ctrl))?;
+        let (score_n, dm_n) = measure(&z, &pre, &bytes_n, ctx.width, ctx.height)?;
+        let max_n = max_block(&dm_n);
+        passes_used = passes_used.saturating_add(1);
+
+        let cand_feasible = is_feasible(score_n, max_n, &ctx.target);
+        // Best-tracking: prefer feasible over infeasible, then smallest bytes.
+        let take = match (best_feasible, cand_feasible) {
+            (false, true) => true,
+            (true, false) => false,
+            (true, true) => bytes_n.len() < best_bytes.len(),
+            (false, false) => score_n > best_score,
+        };
+        if take {
+            best_bytes = bytes_n;
+            best_score = score_n;
+            best_max = max_n;
+            best_feasible = cand_feasible;
+        }
+
+        // Stop early if we just landed in the comfort band.
+        let in_band = cand_feasible
+            && match ctx.target.max_overshoot {
+                Some(t) => (score_n - ctx.target.target) <= t,
+                None => true,
+            };
+        if in_band {
+            break;
+        }
+
+        current_scales = next;
+        current_dm = dm_n;
+        current_score = score_n;
+        current_max = max_n;
+    }
+
+    finalize(best_bytes, best_score, best_max, passes_used, &ctx.target)
+}
+
+#[cfg(feature = "target-zq")]
+fn finalize(
+    bytes: alloc::vec::Vec<u8>,
+    score: f32,
+    max_block: f32,
+    passes_used: u8,
+    target: &ZqTarget,
+) -> crate::error::Result<(alloc::vec::Vec<u8>, EncodeMetrics)> {
+    // Strict-mode failure checks (see `ZqTarget::max_undershoot` and
+    // `BlockArtifactBound::max_overshoot` docs).
+    if let Some(slack) = target.max_undershoot {
+        if score < target.target - slack {
+            return Err(crate::error::Error::invalid_config(alloc::format!(
+                "target-zq encoder achieved score {:.3}, below floor {:.3} \
+                 (max_undershoot = {:.3}) after {} passes",
+                score,
+                target.target,
+                slack,
+                passes_used
+            )));
+        }
+    }
+    if let Some(b) = target.block_artifact {
+        if let Some(slack) = b.max_overshoot {
+            if max_block > b.ceiling + slack {
+                return Err(crate::error::Error::invalid_config(alloc::format!(
+                    "target-zq encoder achieved max-block-artifact {:.4}, \
+                     above ceiling {:.4} (max_overshoot = {:.4}) after {} passes",
+                    max_block,
+                    b.ceiling,
+                    slack,
+                    passes_used
+                )));
+            }
+        }
+    }
+    let targets_met = is_feasible(score, max_block, target);
+    let bytes_len = bytes.len();
+    Ok((
+        bytes,
+        EncodeMetrics {
+            achieved_score: score,
+            achieved_max_block_artifact: max_block,
+            passes_used,
+            bytes: bytes_len,
+            targets_met,
+        },
+    ))
+}
+
+#[cfg(feature = "target-zq")]
+fn is_feasible(score: f32, max_block: f32, target: &ZqTarget) -> bool {
+    let score_ok = score >= target.target;
+    let peak_ok = match target.block_artifact {
+        Some(b) => max_block <= b.ceiling,
+        None => true,
+    };
+    score_ok && peak_ok
+}
+
+#[cfg(feature = "target-zq")]
+fn max_block(dm: &[f32]) -> f32 {
+    dm.iter().copied().fold(0.0f32, f32::max)
+}
+
+/// Encode pixels via a fresh [`crate::encode::BytesEncoder`] built from
+/// `pass_config`. Optional `controller` is installed before pushing.
+#[cfg(feature = "target-zq")]
+fn encode_pass(
+    pass_config: &crate::encode::EncoderConfig,
+    ctx: &IterationContext<'_>,
+    controller: Option<Box<dyn AqController>>,
+) -> crate::error::Result<alloc::vec::Vec<u8>> {
+    use enough::Unstoppable;
+    let mut enc = pass_config.encode_from_bytes(ctx.width, ctx.height, ctx.layout)?;
+    if let Some(c) = controller {
+        enc.set_aq_controller(Some(c));
+    }
+    enc.push_packed(ctx.pixels, Unstoppable)?;
+    enc.finish()
+}
+
+/// Decode `jpeg`, compute zensim diffmap against `pre`, return
+/// (score, per-block diffmap).
+#[cfg(feature = "target-zq")]
+fn measure(
+    z: &zensim::Zensim,
+    pre: &zensim::PrecomputedReference,
+    jpeg: &[u8],
+    width: u32,
+    height: u32,
+) -> crate::error::Result<(f32, alloc::vec::Vec<f32>)> {
+    use enough::Unstoppable;
+    use zensim::{DiffmapWeighting, RgbSlice};
+    let dec = crate::decode::Decoder::new()
+        .decode(jpeg, Unstoppable)
+        .map_err(|e| {
+            crate::error::Error::invalid_config(alloc::format!(
+                "decode for measurement failed: {e}"
+            ))
+        })?;
+    let pixels = dec.into_pixels_u8().ok_or_else(|| {
+        crate::error::Error::invalid_config("decoder returned non-u8 pixels".into())
+    })?;
+    let chunks: &[[u8; 3]] = bytemuck_chunks(&pixels);
+    let dec_slice = RgbSlice::new(chunks, width as usize, height as usize);
+    let res = z
+        .compute_with_ref_and_diffmap(pre, &dec_slice, DiffmapWeighting::Trained)
+        .map_err(|e| {
+            crate::error::Error::invalid_config(alloc::format!(
+                "zensim compute_with_ref_and_diffmap failed: {e}"
+            ))
+        })?;
+    let dm = aggregate_diffmap_to_blocks(res.diffmap(), width as usize, height as usize);
+    Ok((res.score() as f32, dm))
+}
+
+/// Single-pass fallback: encode at the resolved starting q, no
+/// controller, no measurement. Used when target-zq mode can't run the
+/// full loop (image too small, layout unsupported, decoder feature off,
+/// etc.).
+#[cfg(feature = "target-zq")]
+fn run_single_pass(
+    ctx: &IterationContext<'_>,
+    _controller: Option<Box<dyn AqController>>,
+) -> crate::error::Result<(alloc::vec::Vec<u8>, EncodeMetrics)> {
+    use crate::encode::{EncoderConfig, Quality};
+    let starting_q = ctx.config.quality.to_internal();
+    let mut pass_config: EncoderConfig = ctx.config.clone();
+    pass_config = pass_config.quality(Quality::ApproxJpegli(starting_q));
+    let bytes = encode_pass(&pass_config, ctx, None)?;
+    let bytes_len = bytes.len();
+    Ok((
+        bytes,
+        EncodeMetrics {
+            achieved_score: f32::NAN,
+            achieved_max_block_artifact: f32::NAN,
+            passes_used: 1,
+            bytes: bytes_len,
+            targets_met: true,
+        },
+    ))
+}
+
+/// Reinterpret a packed RGB byte slice as `[u8; 3]` chunks. Length must
+/// be a multiple of 3; truncates excess.
+#[cfg(feature = "target-zq")]
+fn bytemuck_chunks(pixels: &[u8]) -> &[[u8; 3]] {
+    let n = pixels.len() / 3;
+    // SAFETY-equivalent via the `as_chunks` slice method (stable on
+    // recent rustc). All bytes in `pixels` are valid; we cast a flat
+    // u8 slice to a fixed-stride array slice of the same byte layout.
+    let (chunks, _) = pixels.as_chunks::<3>();
+    let _ = n;
+    chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zq_target_default_is_sensible() {
+        let t = ZqTarget::default();
+        assert_eq!(t.target, 80.0);
+        assert_eq!(t.max_overshoot, Some(1.5));
+        assert_eq!(t.max_undershoot, None);
+        assert!(t.block_artifact.is_none());
+        assert_eq!(t.max_passes, 2);
+    }
+
+    #[test]
+    fn zq_target_builder_chains() {
+        let t = ZqTarget::new(85.0)
+            .with_max_overshoot(Some(0.5))
+            .with_max_undershoot(Some(2.0))
+            .with_max_passes(3)
+            .with_block_artifact(Some(BlockArtifactBound::new(0.012)));
+        assert_eq!(t.target, 85.0);
+        assert_eq!(t.max_overshoot, Some(0.5));
+        assert_eq!(t.max_undershoot, Some(2.0));
+        assert_eq!(t.max_passes, 3);
+        assert!(t.block_artifact.is_some());
+        assert_eq!(t.block_artifact.unwrap().ceiling, 0.012);
+    }
+
+    #[test]
+    fn block_artifact_bound_default_is_best_effort() {
+        let b = BlockArtifactBound::new(0.020);
+        assert_eq!(b.ceiling, 0.020);
+        assert_eq!(b.max_overshoot, None);
+        assert_eq!(b.max_undershoot, None);
+    }
+
+    #[test]
+    fn zq_calibration_is_monotonic_and_in_range() {
+        // Small smoke check: starting q increases with zq, and stays
+        // within the jpegli-q range.
+        let mut prev = 0.0f32;
+        for zq in (40..=95).step_by(5) {
+            let q = zq_to_starting_jpegli_q(zq as f32);
+            assert!(q > prev, "non-monotonic at zq={zq}: {prev} -> {q}");
+            assert!((1.0..=100.0).contains(&q), "out of range at zq={zq}: {q}");
+            prev = q;
+        }
+    }
+}

--- a/zenjpeg/src/encode/zq.rs
+++ b/zenjpeg/src/encode/zq.rs
@@ -310,6 +310,7 @@ fn interpolate_anchors(zq: f32, anchors: &[(f32, f32)]) -> f32 {
 /// reach the same zq target (text/edges have less perceptual headroom);
 /// flat photos need slightly less. The bucket-naive average misses both
 /// ends, costing extra iterations.
+#[allow(dead_code)] // bucket-LUT path; called only from infer_bucket_from_pixels
 #[must_use]
 pub(crate) fn zq_to_starting_jpegli_q_for_bucket(
     zq: f32,
@@ -318,36 +319,39 @@ pub(crate) fn zq_to_starting_jpegli_q_for_bucket(
     use crate::encode::adaptive::InferredBucket as B;
     // Anchors are (target_zq, starting_jpegli_q). Median of per-image
     // smallest-q-meeting-target values, fit by `examples/zq_calibrate.rs`
-    // on a 76-image corpus (CID22 validation + gb82 photos + gb82-sc
-    // screen content). Re-run the harness to refit if the streaming AQ
-    // pipeline or the zensim profile changes.
+    // on a 347-image mixed corpus (CID22 validation + CID22 training +
+    // gb82 + gb82-sc + clic2025 training + clic2025 final-test).
+    // Re-run the harness to refit if the streaming AQ pipeline or the
+    // zensim profile changes.
     //
-    // Per-bucket sample counts at fit time:
-    //   PhotoNatural   n=7
-    //   PhotoDetailed  n=36
-    //   PhotoFlat      n=13
-    //   Illustration   n=1  (single sample; treat with skepticism, the
-    //                       table will be refined when more illustration
-    //                       content joins the calibration corpus)
-    //   ScreenContent  n=19
+    // Per-bucket sample counts at fit time (2026-04-28):
+    //   PhotoNatural   n=72
+    //   PhotoDetailed  n=140
+    //   PhotoFlat      n=85
+    //   Illustration   n=4   (still under-sampled — corpus needs more
+    //                        illustration content; values unchanged
+    //                        from the prior 1-sample fit anyway)
+    //   ScreenContent  n=46
     //
     // The harness output also reports p25/p75 per anchor for spread
-    // inspection — see `/tmp/zq_calibrate_full.log` snapshot or re-run.
+    // inspection — see `benchmarks/zq_calibration_2026-04-28.log` or
+    // re-run with `cargo run --release -p zenjpeg --features target-zq
+    // --example zq_calibrate`.
     const PHOTO_NATURAL: &[(f32, f32)] = &[
         (40.0, 20.0),
         (60.0, 25.0),
-        (75.0, 60.0),
-        (80.0, 75.0),
+        (75.0, 65.0),
+        (80.0, 80.0),
         (85.0, 90.0),
         (90.0, 95.0),
         (95.0, 100.0),
     ];
     const PHOTO_DETAILED: &[(f32, f32)] = &[
         (40.0, 20.0),
-        (60.0, 25.0),
-        (75.0, 70.0),
-        (80.0, 80.0),
-        (85.0, 90.0),
+        (60.0, 30.0),
+        (75.0, 75.0),
+        (80.0, 85.0),
+        (85.0, 95.0),
         (90.0, 100.0),
         (95.0, 100.0),
     ];
@@ -372,10 +376,10 @@ pub(crate) fn zq_to_starting_jpegli_q_for_bucket(
     const SCREEN_CONTENT: &[(f32, f32)] = &[
         (40.0, 20.0),
         (60.0, 20.0),
-        (75.0, 45.0),
+        (75.0, 50.0),
         (80.0, 70.0),
         (85.0, 85.0),
-        (90.0, 95.0),
+        (90.0, 100.0),
         (95.0, 100.0),
     ];
 
@@ -401,6 +405,7 @@ use super::aq_controller::AqController;
 /// scale = 1.0 → no change. scale < 1.0 → tighter (more bits).
 /// scale > 1.0 → looser (fewer bits). Final AQ is clamped to `[0.0, 0.20]`
 /// by the strip processor.
+#[allow(dead_code)] // scaffold for future controller wiring
 #[derive(Debug)]
 struct ScalingController {
     /// `scales[imcu_idx]` = per-block scale factors for that iMCU row.
@@ -423,6 +428,7 @@ impl AqController for ScalingController {
 /// Iteration-loop controller hyperparameters. Picked from the
 /// `examples/method_b_real.rs` corpus run; small surface so the public
 /// API doesn't expose them in v1.
+#[allow(dead_code)] // scaffold for future controller wiring
 mod hp {
     /// Per-pass cap on absolute scale change per block.
     pub(super) const MAX_SCALE_DELTA: f32 = 0.20;
@@ -443,6 +449,7 @@ mod hp {
 /// - Block diffmap above peak ceiling → tighten THOSE blocks specifically.
 /// - Score in band, no ceiling violation → loosen the lowest-error
 ///   blocks (scale↑) to recover bytes.
+#[allow(dead_code)] // scaffold for future controller wiring
 fn next_scales(
     prev_scales: &[f32],
     block_dm: &[f32],
@@ -506,6 +513,7 @@ fn next_scales(
 ///
 /// `flat[bx + by * blocks_w]` is the scale for block `(bx, by)`.
 /// One iMCU row covers `v_samp` block rows of width `blocks_w`.
+#[allow(dead_code)] // scaffold for future controller wiring
 fn flat_to_imcu_schedule(
     flat: &[f32],
     blocks_w: usize,
@@ -534,6 +542,7 @@ fn flat_to_imcu_schedule(
 /// per-block mean. Truncating divides for non-multiples-of-8 dims —
 /// the right/bottom edge sliver is dropped (matches the encoder's
 /// 8×8 block grid).
+#[allow(dead_code)] // scaffold for future controller wiring
 fn aggregate_diffmap_to_blocks(
     diffmap: &[f32],
     width: usize,
@@ -624,22 +633,15 @@ pub(crate) fn run_iteration_loop(
         crate::encode::ColorMode::Grayscale => 1,
     };
 
-    // Build the source ImageSource for zensim. Layout currently must be
-    // RGB8 — other layouts would require zenpixels conversion to drive
-    // zensim's per-channel pipeline. (XYB encoding accepts RGB8 input
-    // and converts internally; the source stays in sRGB8 here.)
-    if ctx.layout != crate::encode::PixelLayout::Rgb8Srgb {
-        // For non-RGB8 layouts, fall back to single-pass — extending
-        // the closed loop to other layouts is future work.
-        return run_single_pass(&ctx, None);
-    }
-
+    // Build the source PrecomputedReference for zensim. RGB8 sRGB and
+    // RgbF32Linear are the supported source layouts for the closed
+    // loop; other layouts (BGR, RGBA, 16-bit linear, YCbCr) fall
+    // through to single-pass — adding each is a small follow-up that
+    // mirrors the path taken below.
     let z = Zensim::new(ZensimProfile::latest());
-    let src_chunks: &[[u8; 3]] = bytemuck_chunks(ctx.pixels);
-    let src_slice = RgbSlice::new(src_chunks, ctx.width as usize, ctx.height as usize);
-    let pre = match z.precompute_reference(&src_slice) {
-        Ok(p) => p,
-        Err(_) => return run_single_pass(&ctx, None),
+    let pre = match build_source_reference(&z, ctx.layout, ctx.pixels, ctx.width, ctx.height) {
+        Some(p) => p,
+        None => return run_single_pass(&ctx, None),
     };
 
     // Pass 0: streaming-AQ baseline. Substitute Quality::Zq* with a
@@ -649,7 +651,7 @@ pub(crate) fn run_iteration_loop(
     // Bucket detection runs the analyzer on the source pixels — same
     // ~1ms cost as `EncoderConfig::adaptive`. Falls through to the
     // bucket-naive lookup if analysis fails (e.g. tiny images).
-    let bucket = detect_bucket(ctx.pixels, ctx.width, ctx.height);
+    let bucket = detect_bucket(ctx.layout, ctx.pixels, ctx.width, ctx.height);
     let starting_q = match (ctx.target.target, bucket) {
         (zq, Some(b)) => zq_to_starting_jpegli_q_for_bucket(zq, b),
         (zq, None) => zq_to_starting_jpegli_q(zq),
@@ -878,11 +880,81 @@ fn run_single_pass(
     ))
 }
 
-/// Run the analyzer on RGB8 source pixels and return an inferred content
+/// Build a [`zensim::PrecomputedReference`] from the source pixels,
+/// dispatching on layout. Returns `None` if the layout is unsupported
+/// (caller falls through to single-pass) or the build itself fails
+/// (e.g. dimensions too small for zensim).
+///
+/// Currently supports:
+///   - `Rgb8Srgb` — interleaved u8 sRGB (the typical case).
+///   - `RgbF32Linear` — interleaved f32 linear; deinterleaved into
+///     planar [R, G, B] for zensim's `linear_planar` constructor.
+///
+/// Other layouts return `None` for now. Adding them is a small follow-up
+/// (BGR8/RGBA8 just need swizzle, 16-bit linear needs scale-to-f32).
+#[cfg(feature = "target-zq")]
+fn build_source_reference(
+    z: &zensim::Zensim,
+    layout: crate::encode::PixelLayout,
+    pixels: &[u8],
+    width: u32,
+    height: u32,
+) -> Option<zensim::PrecomputedReference> {
+    use crate::encode::PixelLayout as L;
+    use zensim::RgbSlice;
+    let w = width as usize;
+    let h = height as usize;
+
+    match layout {
+        L::Rgb8Srgb => {
+            let chunks: &[[u8; 3]] = bytemuck_chunks(pixels);
+            let slice = RgbSlice::new(chunks, w, h);
+            z.precompute_reference(&slice).ok()
+        }
+        L::RgbF32Linear => {
+            // Reinterpret packed f32 bytes as &[f32]. Length must be a
+            // multiple of 4; the encoder validates this upstream.
+            let f32_count = pixels.len() / 4;
+            // SAFETY-equivalent: bytemuck would handle this with
+            // safe alignment guarantees, but we have a packed RGB f32
+            // buffer the user supplied — assume it's properly aligned.
+            // Use try_cast_slice via a manual chunks transmute.
+            //
+            // The pixels slice came from caller's Vec<u8>, so 4-byte
+            // alignment is uncertain. Use a copy-via-from_le_bytes path
+            // for portability (each pixel = 12 bytes = 3 f32).
+            let mut r = alloc::vec::Vec::with_capacity(w * h);
+            let mut g = alloc::vec::Vec::with_capacity(w * h);
+            let mut b = alloc::vec::Vec::with_capacity(w * h);
+            for i in 0..(w * h) {
+                let off = i * 12;
+                if off + 12 > pixels.len() {
+                    return None;
+                }
+                let r_v = f32::from_le_bytes(pixels[off..off + 4].try_into().ok()?);
+                let g_v = f32::from_le_bytes(pixels[off + 4..off + 8].try_into().ok()?);
+                let b_v = f32::from_le_bytes(pixels[off + 8..off + 12].try_into().ok()?);
+                r.push(r_v);
+                g.push(g_v);
+                b.push(b_v);
+            }
+            let _ = f32_count; // keep for future bytemuck path
+            z.precompute_reference_linear_planar([&r, &g, &b], w, h, w)
+                .ok()
+        }
+        // Other layouts: future work. Caller falls through to single-pass.
+        _ => None,
+    }
+}
+
+/// Run the analyzer on the source pixels and return an inferred content
 /// bucket for starting-q calibration. Returns `None` if the image is too
-/// small for the analyzer to produce meaningful features.
+/// small for the analyzer to produce meaningful features OR the layout
+/// isn't directly analyzer-compatible (currently RGB8 only — other
+/// layouts fall back to the bucket-naive starting-q calibration).
 #[cfg(feature = "target-zq")]
 fn detect_bucket(
+    layout: crate::encode::PixelLayout,
     pixels: &[u8],
     width: u32,
     height: u32,
@@ -890,8 +962,15 @@ fn detect_bucket(
     if width < 8 || height < 8 {
         return None;
     }
-    let features = crate::analyze::analyze_rgb8(pixels, width, height);
-    Some(crate::encode::adaptive::infer_bucket(&features))
+    if layout != crate::encode::PixelLayout::Rgb8Srgb {
+        // Bucket detection requires RGB8 source. For other layouts we
+        // fall back to the bucket-naive calibration; the controller
+        // still corrects from there.
+        return None;
+    }
+    let query = zenanalyze::feature::AnalysisQuery::new(zenanalyze::feature::FeatureSet::SUPPORTED);
+    let analysis = zenanalyze::analyze_features_rgb8(pixels, width, height, &query);
+    Some(crate::encode::adaptive::infer_bucket(&analysis))
 }
 
 /// Reinterpret a packed RGB byte slice as `[u8; 3]` chunks. Length must

--- a/zenjpeg/tests/zq_target.rs
+++ b/zenjpeg/tests/zq_target.rs
@@ -301,6 +301,45 @@ fn zq_works_with_xyb_full() {
 }
 
 #[test]
+fn zq_works_with_linear_f32_input() {
+    use zenjpeg::encode::XybSubsampling;
+    let (w, h) = (128u32, 128);
+    // Convert sRGB8 → linear f32 RGB. This is the typical XYB-input
+    // pipeline (pre-converted linear light from a higher-precision
+    // source).
+    let rgb_u8 = synthetic_image(w, h);
+    let mut rgb_f32 = vec![0u8; (w as usize) * (h as usize) * 12];
+    for i in 0..(w as usize) * (h as usize) {
+        for c in 0..3 {
+            let u = rgb_u8[i * 3 + c] as f32 / 255.0;
+            // sRGB → linear (approximate gamma 2.2; exact is fine too).
+            let lin = if u <= 0.04045 {
+                u / 12.92
+            } else {
+                ((u + 0.055) / 1.055).powf(2.4)
+            };
+            rgb_f32[i * 12 + c * 4..i * 12 + c * 4 + 4].copy_from_slice(&lin.to_le_bytes());
+        }
+    }
+    let config = EncoderConfig::xyb(Quality::Zq(80.0), XybSubsampling::BQuarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::RgbF32Linear)
+        .expect("encoder creation");
+    enc.push_packed(&rgb_f32, Unstoppable).expect("push");
+    let (jpeg, metrics) = enc
+        .finish_with_metrics()
+        .expect("XYB linear-f32 Zq encode should succeed");
+    assert!(!jpeg.is_empty());
+    // PR-E lets the iteration loop run on linear-f32 input — measurement
+    // uses zensim's linear_planar source path. achieved_score should be
+    // finite (NOT NaN, which would indicate single-pass fallback).
+    assert!(
+        metrics.achieved_score.is_finite(),
+        "linear-f32 path must run iteration loop, not fall through to single_pass"
+    );
+}
+
+#[test]
 fn non_zq_quality_does_not_iterate() {
     let (w, h) = (128u32, 128);
     let rgb = synthetic_image(w, h);

--- a/zenjpeg/tests/zq_target.rs
+++ b/zenjpeg/tests/zq_target.rs
@@ -1,0 +1,320 @@
+//! Integration tests for `Quality::Zq` / `Quality::ZqExplicit` (#113).
+//!
+//! These tests validate the public API contract: types compile, the
+//! iteration loop runs end-to-end, metrics are populated honestly, and
+//! the closed-loop encoder can hit a perceptual target on at least one
+//! synthetic image.
+//!
+//! These tests run only with `--features target-zq` since that's the
+//! feature that enables the iteration path. Without the feature,
+//! `Quality::Zq*` falls back to single-pass encoding at the resolved
+//! starting quality (covered by a separate test).
+
+#![cfg(feature = "target-zq")]
+
+use enough::Unstoppable;
+use zenjpeg::encode::zq::{BlockArtifactBound, ZqTarget};
+use zenjpeg::encode::{ChromaSubsampling, EncoderConfig, PixelLayout, Quality};
+
+/// Generate a 256×256 synthetic image with mixed smooth + textured regions.
+/// Roughly photo-shaped so the iteration loop has meaningful per-block
+/// diffmap variance to work with.
+fn synthetic_image(w: u32, h: u32) -> Vec<u8> {
+    let w = w as usize;
+    let h = h as usize;
+    let mut rgb = vec![0u8; w * h * 3];
+    for y in 0..h {
+        for x in 0..w {
+            let idx = (y * w + x) * 3;
+            // Smooth ramp + per-tile noise. Tiles 32×32; alternating
+            // "smooth gradient" and "textured" blocks.
+            let tx = x / 32;
+            let ty = y / 32;
+            let tile_smooth = (tx + ty) % 2 == 0;
+            let r_base = (x * 255 / w) as u8;
+            let g_base = (y * 255 / h) as u8;
+            let b_base = ((x + y) * 255 / (w + h)) as u8;
+            if tile_smooth {
+                rgb[idx] = r_base;
+                rgb[idx + 1] = g_base;
+                rgb[idx + 2] = b_base;
+            } else {
+                // Pseudo-random noise: deterministic from x,y.
+                let n = ((x.wrapping_mul(2654435761)) ^ (y.wrapping_mul(40503))) as u8;
+                rgb[idx] = r_base.saturating_add(n & 0x3F);
+                rgb[idx + 1] = g_base.saturating_sub((n >> 2) & 0x3F);
+                rgb[idx + 2] = b_base.saturating_add((n >> 4) & 0x3F);
+            }
+        }
+    }
+    rgb
+}
+
+#[test]
+fn zq_simple_form_encodes_and_returns_metrics() {
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::ycbcr(Quality::Zq(80.0), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .expect("encoder creation");
+    enc.push_packed(&rgb, Unstoppable).expect("push");
+    let (jpeg, metrics) = enc.finish_with_metrics().expect("finish_with_metrics");
+    assert!(!jpeg.is_empty(), "should produce some JPEG bytes");
+    assert!(
+        jpeg.len() == metrics.bytes,
+        "metrics.bytes must match jpeg.len()"
+    );
+    assert!(
+        metrics.passes_used >= 1 && metrics.passes_used <= 3,
+        "default budget = 2 passes, plus the initial pass = up to 3 total observed"
+    );
+    assert!(
+        metrics.achieved_score.is_finite(),
+        "iteration path always measures a final score"
+    );
+    // The synthetic image (noise tiles + gradient) is HARD: starting q=81
+    // typically lands well below target 80 on this content. We don't
+    // assert convergence quality here — that's the convergence test's
+    // job. We only assert the API contract: the encoder ran the loop,
+    // produced finite metrics, and reported targets_met honestly.
+    if metrics.achieved_score >= 80.0 {
+        assert!(metrics.targets_met, "score >= target should report met");
+    } else {
+        assert!(!metrics.targets_met, "score < target should NOT report met");
+    }
+}
+
+#[test]
+fn zq_explicit_form_respects_max_passes_zero() {
+    let (w, h) = (128u32, 128);
+    let rgb = synthetic_image(w, h);
+    let target = ZqTarget::new(75.0).with_max_passes(0);
+    let config = EncoderConfig::ycbcr(Quality::ZqExplicit(target), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (_jpeg, metrics) = enc.finish_with_metrics().unwrap();
+    assert_eq!(
+        metrics.passes_used, 1,
+        "max_passes=0 means single-pass (just the initial encode, no correction)"
+    );
+}
+
+#[test]
+fn zq_explicit_max_undershoot_strict_mode_catches_misses() {
+    let (w, h) = (128u32, 128);
+    let rgb = synthetic_image(w, h);
+    // Target zq=99 with strict floor — basically unreachable.
+    let target = ZqTarget::new(99.0)
+        .with_max_undershoot(Some(0.5))
+        .with_max_passes(2);
+    let config = EncoderConfig::ycbcr(Quality::ZqExplicit(target), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let res = enc.finish_with_metrics();
+    assert!(
+        res.is_err(),
+        "Zq target=99 with max_undershoot=0.5 should error on this image"
+    );
+}
+
+#[test]
+fn zq_with_block_artifact_bound_runs() {
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    let target = ZqTarget::new(80.0).with_block_artifact(Some(BlockArtifactBound::new(0.020)));
+    let config = EncoderConfig::ycbcr(Quality::ZqExplicit(target), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc.finish_with_metrics().unwrap();
+    assert!(!jpeg.is_empty());
+    assert!(metrics.achieved_max_block_artifact.is_finite());
+    // Block-artifact bound is 0.020 — at zq=80 on a well-behaved
+    // synthetic image, achieved should be well below this.
+    assert!(
+        metrics.achieved_max_block_artifact <= 0.030,
+        "max-block artifact {} unexpectedly high",
+        metrics.achieved_max_block_artifact
+    );
+}
+
+#[test]
+fn zq_block_artifact_max_overshoot_strict_mode_errors_on_unreachable_ceiling() {
+    let (w, h) = (128u32, 128);
+    let rgb = synthetic_image(w, h);
+    // Set a very tight ceiling that's basically impossible at low q.
+    let target = ZqTarget::new(60.0)
+        .with_block_artifact(Some(
+            BlockArtifactBound::new(0.0001).with_max_overshoot(Some(0.0001)),
+        ))
+        .with_max_passes(2);
+    let config = EncoderConfig::ycbcr(Quality::ZqExplicit(target), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let res = enc.finish_with_metrics();
+    assert!(
+        res.is_err(),
+        "block_artifact ceiling=0.0001 with strict overshoot=0.0001 should error"
+    );
+}
+
+#[test]
+fn quality_to_internal_resolves_zq_to_starting_q() {
+    // Sanity: zq → starting jpegli q is in a sensible range.
+    let zq75 = Quality::Zq(75.0);
+    let zq85 = Quality::Zq(85.0);
+    let zq95 = Quality::Zq(95.0);
+    assert!(zq75.to_internal() > 50.0 && zq75.to_internal() < 90.0);
+    assert!(zq85.to_internal() > 70.0 && zq85.to_internal() < 95.0);
+    assert!(zq95.to_internal() > 85.0 && zq95.to_internal() <= 100.0);
+}
+
+#[test]
+fn quality_zq_target_round_trip() {
+    let q = Quality::Zq(82.5);
+    assert!(q.is_zq_target());
+    let t = q.zq_target().expect("Zq has a ZqTarget");
+    assert_eq!(t.target, 82.5);
+
+    let explicit = ZqTarget::new(82.5)
+        .with_max_overshoot(Some(0.5))
+        .with_max_passes(3);
+    let q2 = Quality::ZqExplicit(explicit);
+    assert!(q2.is_zq_target());
+    let t2 = q2.zq_target().unwrap();
+    assert_eq!(t2.max_overshoot, Some(0.5));
+    assert_eq!(t2.max_passes, 3);
+}
+
+#[test]
+fn finish_works_on_zq_mode_without_metrics() {
+    // The plain finish() entry point must transparently route through
+    // the iteration loop when a Zq variant is configured (otherwise
+    // pushes-to-buffer would leave the inner streaming encoder with
+    // zero rows and finish() would error with incomplete_image).
+    let (w, h) = (128u32, 128);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::ycbcr(Quality::Zq(75.0), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let jpeg = enc.finish().expect("finish() should work in Zq mode");
+    assert!(!jpeg.is_empty());
+}
+
+#[test]
+fn zq_works_with_subsampling_444() {
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::ycbcr(Quality::Zq(80.0), ChromaSubsampling::None);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc
+        .finish_with_metrics()
+        .expect("4:4:4 Zq encode should succeed");
+    assert!(!jpeg.is_empty());
+    assert!(metrics.passes_used >= 1);
+    assert!(
+        metrics.achieved_score.is_finite(),
+        "4:4:4 must run iteration loop, not single-pass fallback"
+    );
+}
+
+#[test]
+fn zq_works_with_subsampling_422() {
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::ycbcr(Quality::Zq(80.0), ChromaSubsampling::HalfHorizontal);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc
+        .finish_with_metrics()
+        .expect("4:2:2 Zq encode should succeed");
+    assert!(!jpeg.is_empty());
+    assert!(metrics.achieved_score.is_finite());
+}
+
+#[test]
+fn zq_works_with_subsampling_440() {
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::ycbcr(Quality::Zq(80.0), ChromaSubsampling::HalfVertical);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc
+        .finish_with_metrics()
+        .expect("4:4:0 Zq encode should succeed");
+    assert!(!jpeg.is_empty());
+    assert!(metrics.achieved_score.is_finite());
+}
+
+#[test]
+fn zq_works_with_xyb_bquarter() {
+    use zenjpeg::encode::XybSubsampling;
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    // XYB encoding accepts RGB8 input (sRGB) and converts internally;
+    // the decoded JPEG is decoded back to RGB8 by the decoder so the
+    // diffmap measurement against the source RGB8 is well-defined.
+    let config = EncoderConfig::xyb(Quality::Zq(80.0), XybSubsampling::BQuarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc
+        .finish_with_metrics()
+        .expect("XYB BQuarter Zq encode should succeed");
+    assert!(!jpeg.is_empty());
+    assert!(metrics.achieved_score.is_finite());
+}
+
+#[test]
+fn zq_works_with_xyb_full() {
+    use zenjpeg::encode::XybSubsampling;
+    let (w, h) = (256u32, 256);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::xyb(Quality::Zq(80.0), XybSubsampling::Full);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc
+        .finish_with_metrics()
+        .expect("XYB Full Zq encode should succeed");
+    assert!(!jpeg.is_empty());
+    assert!(metrics.achieved_score.is_finite());
+}
+
+#[test]
+fn non_zq_quality_does_not_iterate() {
+    let (w, h) = (128u32, 128);
+    let rgb = synthetic_image(w, h);
+    let config = EncoderConfig::ycbcr(Quality::ApproxJpegli(85.0), ChromaSubsampling::Quarter);
+    let mut enc = config
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .unwrap();
+    enc.push_packed(&rgb, Unstoppable).unwrap();
+    let (jpeg, metrics) = enc.finish_with_metrics().unwrap();
+    assert!(!jpeg.is_empty());
+    assert_eq!(metrics.passes_used, 1, "non-Zq is single-pass");
+    assert!(
+        metrics.achieved_score.is_nan(),
+        "non-Zq doesn't measure perceptual score"
+    );
+    assert!(metrics.targets_met, "non-Zq has no goal — vacuously met");
+}


### PR DESCRIPTION
## Summary

Combined PR for the #113 Zq controller stack + comprehensive Pareto-config sweep. Supersedes #117 + #118 (both closed).

## What ships

1. **Linear-f32 input support** for `Quality::Zq`.
2. **Rebase fixups** — call sites ported to the published `zenanalyze` 0.1 crate after imazen/zenjpeg#127.
3. **Recalibrated single-config bucket+LUT** — re-fit on a 347-image mixed corpus (CID22 train+val, gb82, gb82-sc, clic2025 train+test). 5–10× richer per-bucket samples vs the original 76-image fit. See `benchmarks/zq_calibration_2026-04-28.log`.
4. **Comprehensive 4-axis Pareto sweep** — harness `examples/zq_pareto_calibrate.rs`, fit `scripts/zq_pareto_fit.py`. Covers size × config × q × content per the global benchmark-discipline rule. **233,184 measurements** in 462 s on 16-thread Ryzen 9 7950X. Summary at `benchmarks/zq_pareto_2026-04-28.summary.md`; raw 35 MB TSV gitignored.

## Headline finding

The current single-config bucket+LUT scaffold ships **35–85 % more bytes than Pareto-optimal at zq target ≥ 85**. Optimal config has clear phase transitions:

- zq ≤ 65: `ycbcr_420_baseline` + `ycbcr_420_progressive` together cover ~80 % of cells.
- zq 70–80: `ycbcr_420_auto_optimize` (hybrid trellis).
- zq 85–90: `xyb_444_baseline` (38–39 %).
- zq ≥ 92: `xyb_420_baseline` (57 % at zq=95). `ycbcr_444_progressive` resurfaces (25 %).

Capturing the gap requires the controller to *choose* the encoder config, not just q within a fixed config — that's a public-API change tracked as a follow-up: **#128** (now also covers caller-constraints API + chroma-quality follow-up sweep).

## Harness-bug correction (recorded)

The first sweep run produced byte-identical output across "baseline" vs "progressive" configs because `EncoderConfig::ycbcr` defaults `scan_mode` to `Progressive`, making `progressive(Progressive)` a no-op. Fixed by explicitly setting `progressive(Baseline)` on non-progressive configs. All numbers above are post-fix.

## Test plan

- [x] `cargo build --release -p zenjpeg --features 'target-zq trellis' --example zq_pareto_calibrate` clean.
- [x] `cargo build --release -p zenjpeg --features target-zq --example zq_calibrate` clean.
- [x] `cargo test --release -p zenjpeg --features target-zq --lib` — **939/939 passing**.
- [ ] CI on combined diff.

## Combines and supersedes

- imazen/zenjpeg#117 (Quality::Zq scaffold + AqController) — closed.
- imazen/zenjpeg#118 (per-content-bucket Zq starting-q calibration) — closed.
- imazen/zenjpeg#119 (this PR — linear-f32 + recalibration + Pareto sweep + harness-bug fix).

## Follow-up

- **imazen/zenjpeg#128** — Pareto-optimal controller + caller-constraints API + chroma-quality / 4:2:2 / trellis-lambda follow-up sweep. Public-API change to `EncoderConfig` / `Quality`; ships in next 0.x.