### PR TITLE
feat(zenanalyze): RGBA8/BGRA8 strip-alpha fast path + CLAUDE.md + README refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,11 +151,11 @@ dependencies = [
 
 [[package]]
 name = "archmage"
-version = "0.9.22"
+version = "0.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4be5852641640dee1a03ac78956c7d9676cd84824a22ca5aa199fa7df730388"
+checksum = "6e6248da30f2b6de70645c7af5b3658cf7d6dde8557a542efab62d21be13567d"
 dependencies = [
- "archmage-macros 0.9.22",
+ "archmage-macros 0.9.23",
  "safe_unaligned_simd",
 ]
 
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "archmage-macros"
-version = "0.9.22"
+version = "0.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22def31d68654cfa9cb2cd3a1384ac9922b68b70cd3e9aa7c80e1cc3cc913c0d"
+checksum = "0990742e24ab2b89d1b3623113cc474903d84151bef52e8b46d1ced2770c9ebb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -371,7 +371,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56839c76313cd315910678355f0cb8ec2390eb1ea91e7d932be62f094a0448cd"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "imgref",
  "magetypes",
  "rayon",
@@ -861,7 +861,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0bbcfa44e1cabf11af96ece5e9273f4dc238f2a557668e70f80cfd662fae25b"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "imgref",
  "magetypes",
  "num-traits",
@@ -878,23 +878,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fd-lock"
@@ -994,7 +980,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96bf7a00ed7fc01dae4e581831996672b2824746af4c0a658ee28ca3cbb823dc"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "bytemuck",
  "paste",
 ]
@@ -1340,7 +1326,7 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0e61c33d85bc56dcaf27cdf48ca32b8e34af7236584eb1d8a47316c49e0be1"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "bytemuck",
  "magetypes",
  "num-traits",
@@ -1369,11 +1355,11 @@ dependencies = [
 
 [[package]]
 name = "magetypes"
-version = "0.9.22"
+version = "0.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0147b9e87be8566c570b5264b45a8ccc84f3bd39158678e39ed9102ae242aef"
+checksum = "98970401ec6a338f1762c7986866ead4ab2257747cb0c247c29c0f0c3718b78e"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
 ]
 
 [[package]]
@@ -2337,7 +2323,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964a038e0f75524ef9bd01ee6bda6d2457a3b6c1ca8df22478b9bb94b3547669"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "bytemuck",
  "enough",
  "half",
@@ -2353,7 +2339,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d65bd22a90785bb7360076b599ffbc201aef2c5817d2e5f37f37357829d476e"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "bytemuck",
  "enough",
  "half",
@@ -3074,7 +3060,7 @@ dependencies = [
 name = "zenanalyze"
 version = "0.1.0"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "image",
  "linear-srgb",
  "magetypes",
@@ -3102,7 +3088,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66daf1f95f9f3a3c7c4529ea1f993069e2691cc89a4f8b0f4002ced96179f68"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "magetypes",
  "safe_unaligned_simd",
 ]
@@ -3126,7 +3112,7 @@ dependencies = [
  "aligned-vec",
  "almost-enough",
  "approx",
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "bincode",
  "butteraugli 0.9.1",
  "bytemuck",
@@ -3223,7 +3209,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d0f4d117f75bb4d2471c7c0b940f27492839d1e23e83dd4ee7a53232c78076e"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "bytemuck",
  "garb",
  "linear-srgb",
@@ -3240,7 +3226,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0703679da7af627f10429532d0633b3d32fa0fd10d2b48ca94b5fcd0dbfd6e5a"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "imgref",
  "libm",
  "linear-srgb",
@@ -3254,11 +3240,11 @@ dependencies = [
 
 [[package]]
 name = "zensim"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3fb9cea779ffee22e2045829cb126df4910f4026ca286f555cf42e9c4c295a"
+checksum = "f46ead96f329b3f706ce66c8f36bf5b5bc1bb1fc5135c467079728379560b93c"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "bytemuck",
  "imgref",
  "linear-srgb",
@@ -3288,7 +3274,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c602cc9010340287fd4ffcb2cd1ae9f6a665d37db59f0b9578352788cf8b304"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "libm",
  "linear-srgb",
  "magetypes",
@@ -3298,7 +3284,7 @@ dependencies = [
 name = "zenyuv"
 version = "0.1.3"
 dependencies = [
- "archmage 0.9.22",
+ "archmage 0.9.23",
  "libm",
  "linear-srgb",
  "magetypes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,6 +3061,7 @@ name = "zenanalyze"
 version = "0.1.0"
 dependencies = [
  "archmage 0.9.23",
+ "garb",
  "image",
  "linear-srgb",
  "magetypes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,9 @@ tinyvec = { version = "1.10", features = ["alloc"] }
 linear-srgb = "0.6.12"
 
 # Token-based safe SIMD intrinsics
-archmage = { version = "0.9.21", features = ["macros", "avx512", "testable_dispatch"] }
+archmage = { version = "0.9.23", features = ["macros", "avx512", "testable_dispatch"] }
 safe_unaligned_simd = { version = "0.2.5", features = ["avx512"] }
-magetypes = { version = "0.9.21", features = ["avx512"] }
+magetypes = { version = "0.9.23", features = ["avx512"] }
 
 # Error tracing with location tracking
 whereat = "0.1.5"
@@ -86,9 +86,9 @@ thiserror = { version = "2.0", default-features = false }
 enough = { version = "0.4", features = ["std"] }
 almost-enough = { version = "0.4", features = ["std"] }
 zencodec = { version = "0.1.20" }
-zenpixels = { version = "0.2.10", default-features = false, features = ["imgref"] }
-zenpixels-convert = { version = "0.2.10", default-features = false }
-garb = { version = "0.2.5", default-features = false }
+zenpixels = { version = "0.2.11", default-features = false, features = ["imgref"] }
+zenpixels-convert = { version = "0.2.11", default-features = false }
+garb = { version = "0.2.6", default-features = false }
 
 # Published crates
 butteraugli = "0.9.0"

--- a/zenanalyze/CLAUDE.md
+++ b/zenanalyze/CLAUDE.md
@@ -1,0 +1,66 @@
+# zenanalyze — Claude project guide
+
+## API stability — non-negotiable
+
+**There will never be a 0.2.x.** The crate ships under 0.1.x forever
+(or until a 1.0). Every change must fit within the additive contract:
+
+- New `pub fn` / `pub struct` / `pub mod`: OK.
+- New variant on a `#[non_exhaustive]` enum (`AnalysisFeature`,
+  `FeatureValue`, `AnalyzeError`, etc.): OK.
+- New field on a struct that's already private or `#[non_exhaustive]`:
+  OK if the existing public constructors stay valid.
+- Renaming, removing, or changing the signature of any existing public
+  item: **NOT OK.** Even small changes ("rename a parameter for
+  clarity", "tighten a return type") are forbidden once the item has
+  shipped. Add a parallel item if you need different shape — see
+  `try_analyze_features_rgb8` next to `analyze_features_rgb8`.
+- Numeric / behavioural drift on existing features in 0.1.x patches is
+  expected (the crate-level threshold contract spells it out) — but the
+  *signatures* don't move.
+
+If a future need can't be solved additively under 0.1.x, pause and
+flag it to the user. Do not propose "ship it in the next major" —
+there is no next major.
+
+## Allocation contract
+
+Today every internal allocation is infallible (`vec!` / `Box::new`).
+The plan to flip to fallible (`Vec::try_reserve`, etc.) does not
+require any signature change — `try_analyze_features_rgb8` and
+`AnalyzeError::OutOfMemory { bytes_requested }` are already in place
+to surface the OOM. When fallible internals land, no caller has to
+recompile.
+
+## Threshold contract
+
+Numeric thresholds and normalisation scales drift during 0.1.x as
+features get refined. Downstream consumers that compile-in fitted
+models pin to a specific patch and re-validate when they bump.
+Documented at the crate-level docstring in `src/lib.rs` and in the
+README.
+
+## Tier architecture quick reference
+
+Five passes, gated by the requested `FeatureSet`:
+
+- **Tier 1** — stripe-sampled RGB8 (variance, edges, chroma, uniformity, grayscale).
+- **Tier 2** — full-image 3-row sliding window over RGB8 (per-axis Cb/Cr sharpness).
+- **Tier 3** — sampled 8×8 DCT blocks on RGB8 (DCT energy, entropy, AQ map, noise floor, line-art, gradient fraction, patch fraction).
+- **Palette** — full-image RGB8 (distinct color bins, indexed-palette signals).
+- **Alpha** — stride-sampled, **reads source bytes directly** (no RowStream).
+- **`tier_depth`** — stride-sampled, **reads source bytes directly** (HDR / wide-gamut / bit-depth signals; HDR signal would not survive RowConverter narrowing).
+
+The Native-vs-Convert decision in `RowStream::new` only applies to
+Tier 1/2/3 + Palette. Alpha and `tier_depth` always read the source.
+
+## Don't
+
+- Don't propose 0.2.x.
+- Don't change a published function signature, even to "improve" it.
+  Add a parallel `try_*` / `with_*` / `_into` variant if needed.
+- Don't add new `expect()` / `unwrap()` to public entries that took
+  untrusted input. The fallible parallels exist for a reason.
+- Don't bake content-class assumptions into the analyzer. The job is
+  to surface signals; the consumer (codec orchestrator) decides what
+  to do with them.

--- a/zenanalyze/Cargo.toml
+++ b/zenanalyze/Cargo.toml
@@ -36,6 +36,11 @@ zenpixels = { workspace = true }
 zenpixels-convert = { workspace = true }
 archmage = { workspace = true }
 magetypes = { workspace = true }
+# `garb` provides SIMD pixel-format conversions (`rgba_to_rgb`,
+# `bgra_to_rgb`, etc.) via `archmage::incant!` — used by the
+# `RowStream::StripAlpha8` fast path. Measured ~7× speedup over the
+# in-tree scalar strip on a 2048-px row (0.13 µs vs 0.94 µs at 4 MP).
+garb = { workspace = true }
 # `transfer` feature exposes scalar PQ / HLG / sRGB / BT.709 EOTFs used by
 # the source-direct HDR / depth tier (`tier_depth`). The tier reads source
 # samples without going through `RowConverter` so it can compute peak
@@ -51,4 +56,13 @@ workspace = true
 
 [[example]]
 name = "corpus_eval"
+required-features = ["experimental"]
+
+[[example]]
+name = "edge_skin_bench"
+required-features = ["experimental"]
+
+
+[[example]]
+name = "tier1_bench"
 required-features = ["experimental"]

--- a/zenanalyze/Cargo.toml
+++ b/zenanalyze/Cargo.toml
@@ -30,6 +30,22 @@ default = []
 # arm, `RawAnalysis` field, `into_results` write, `FeatureSet::
 # SUPPORTED`). Single source of truth.
 experimental = []
+# Opt-in to *classifier-style composite scores* — features whose
+# value is a hand-tuned combination of stable raw signals via
+# weighted sums / mins / thresholds. Examples in 0.1.0:
+# `TextLikelihood`, `ScreenContentLikelihood`, `NaturalLikelihood`,
+# `LineArtScore`. The raw signals these consume (Variance,
+# EdgeDensity, distinct_color_bins, luma_histogram_entropy,
+# flat_color_block_ratio, …) are stable in 0.1.x; the *composite
+# coefficients* are calibration-driven and will drift as the
+# corpus-trained tuning matures. Consumers wanting a single
+# decision number opt in here; consumers building their own
+# classifier on top of the raw signals don't need it.
+#
+# Same single-source-of-truth model as `experimental` —
+# `cfg(feature = "composites")` on a `features_table!` row
+# propagates through to enum / record / SUPPORTED / `into_results`.
+composites = []
 
 [dependencies]
 zenpixels = { workspace = true }
@@ -56,7 +72,7 @@ workspace = true
 
 [[example]]
 name = "corpus_eval"
-required-features = ["experimental"]
+required-features = ["experimental", "composites"]
 
 [[example]]
 name = "edge_skin_bench"
@@ -65,4 +81,4 @@ required-features = ["experimental"]
 
 [[example]]
 name = "tier1_bench"
-required-features = ["experimental"]
+required-features = ["experimental", "composites"]

--- a/zenanalyze/README.md
+++ b/zenanalyze/README.md
@@ -3,17 +3,30 @@
 Streaming image content analyzer for adaptive codec pipelines. One pass over a
 `zenpixels::PixelSlice` extracts the numeric features that decision trees,
 selectors, and per-image encoder configurators consume — variance, edge density,
-chroma sharpness, palette population, DCT energy, alpha statistics, derived
-content-class likelihoods, and (behind `experimental`) source-direct HDR /
-wide-gamut / bit-depth signals that codecs use to **detect when a descriptor
-over-promises and the actual pixel content is encodable in something smaller**.
+chroma sharpness, palette population, DCT energy, alpha statistics, and (behind
+opt-in cargo features) classifier-style content-class likelihoods plus
+source-direct HDR / wide-gamut / bit-depth signals that codecs use to **detect
+when a descriptor over-promises and the actual pixel content is encodable in
+something smaller**.
 
 ```toml
 [dependencies]
 zenanalyze = "0.1"
 # Opt in to source-direct HDR / wide-gamut / descriptor-gap signals:
 # zenanalyze = { version = "0.1", features = ["experimental"] }
+# Opt in to classifier-style composite scores (text / screen / natural /
+# line-art likelihoods). The raw signals these consume are stable; the
+# composite coefficients are calibration-driven and may drift in 0.1.x:
+# zenanalyze = { version = "0.1", features = ["composites"] }
 ```
+
+## Cargo features
+
+| feature | what it gates | stability |
+|---|---|---|
+| _(default)_ | Stable raw signals: variance, edge density, chroma sharpness, DCT energy, alpha, palette, distinct-color bins, etc. | Numeric drift in 0.1.x bounded by the threshold contract; signatures frozen |
+| `experimental` | Research-stage signals: PatchFraction, AqMapMean/Std, NoiseFloorY/UV, GradientFraction, source-direct HDR / wide-gamut / bit-depth | Metric definition or scale may change; opt in only if you re-validate per patch |
+| `composites` | Classifier-style scores: TextLikelihood, ScreenContentLikelihood, NaturalLikelihood, LineArtScore | Hand-tuned weighted combinators; the combination coefficients drift as the corpus calibration matures. The raw signals they consume are stable. |
 
 ## Why
 
@@ -110,7 +123,13 @@ enumerate the surface without hand-listing variants.
 | `HighFreqEnergyRatio` | f32 | DCT AC energy ratio over sampled 8×8 luma blocks. |
 | `LumaHistogramEntropy` | f32 | Shannon entropy of a 32-bin luma histogram (bits). |
 | `AlphaPresent` / `AlphaUsedFraction` / `AlphaBimodalScore` | bool / f32 / f32 | Straight-alpha statistics. |
-| `TextLikelihood` / `ScreenContentLikelihood` / `NaturalLikelihood` | f32 | Soft `[0, 1]` content-class scores. |
+
+**Behind the `composites` cargo feature** (calibration-driven, may drift in 0.1.x):
+
+| Feature | Type | Description |
+|---|---|---|
+| `TextLikelihood` / `ScreenContentLikelihood` / `NaturalLikelihood` | f32 | Soft `[0, 1]` content-class scores. Combine raw signals (variance, edge density, distinct-color bins, etc.) via hand-tuned weights. |
+| `LineArtScore` | f32 | Soft `[0, 1]` rendered-line-art score from luma histogram bimodality + entropy. |
 
 **Behind the `experimental` cargo feature**, organised by what they drive:
 
@@ -121,7 +140,7 @@ enumerate the surface without hand-listing variants.
 | `GrayscaleScore` | zenjpeg `ColorMode::Grayscale`, AVIF `Yuv400`, png/jxl gray paths (~30–40% smaller for B&W) |
 | `AqMapMean` / `AqMapStd` | zenjpeg hybrid trellis λ, webp segments + sns_strength, avif vaq |
 | `NoiseFloorY` / `NoiseFloorUV` | zenjpeg `pre_blur`, jxl `noise/denoise`, webp `sns_strength`, zenrav1e `film_grain` |
-| `LineArtScore` | webp `Preset::Drawing`, jxl `splines` / `patches`, png palette preference |
+| `LineArtScore` _(behind `composites`)_ | webp `Preset::Drawing`, jxl `splines` / `patches`, png palette preference |
 | `GradientFraction` | jxl `with_force_strategy` (DCT16 / DCT32 selection), zenrav1e deblock strength |
 | `SkinToneFraction` | photo-vs-other dispatch (one-direction signal, AUC 0.80) — webp `Preset::Photo`, jxl perceptual presets, jpeg chroma-aware quant |
 | `EdgeSlopeStdev` | screen-vs-photo dispatch (AUC 0.84, second only to `PatchFraction`) — webp `Preset::Drawing` vs `Photo`, jxl modular vs VarDCT |

--- a/zenanalyze/README.md
+++ b/zenanalyze/README.md
@@ -3,21 +3,26 @@
 Streaming image content analyzer for adaptive codec pipelines. One pass over a
 `zenpixels::PixelSlice` extracts the numeric features that decision trees,
 selectors, and per-image encoder configurators consume — variance, edge density,
-chroma sharpness, palette population, DCT energy, alpha statistics, and derived
-text/screen-content/natural likelihoods.
+chroma sharpness, palette population, DCT energy, alpha statistics, derived
+content-class likelihoods, and (behind `experimental`) source-direct HDR /
+wide-gamut / bit-depth signals that codecs use to **detect when a descriptor
+over-promises and the actual pixel content is encodable in something smaller**.
 
 ```toml
 [dependencies]
 zenanalyze = "0.1"
+# Opt in to source-direct HDR / wide-gamut / descriptor-gap signals:
+# zenanalyze = { version = "0.1", features = ["experimental"] }
 ```
 
 ## Why
 
-Modern adaptive codecs (zenjpeg, zenwebp, zenpng, future zen formats) all want
-the same handful of cheap content features to pick a quality knob — *is this a
-photograph or a screenshot? does it have alpha? is it palette-friendly?* —
-before they run their expensive encoder. Re-deriving that from scratch in each
-codec means three copies of the same Tier 1 SIMD scan, three slightly different
+Modern adaptive codecs (zenjpeg, zenwebp, zenpng, zenavif, zenjxl) all want the
+same handful of cheap content features to pick a quality knob — *is this a
+photograph or a screenshot? does it have alpha? is it palette-friendly? is the
+HDR flag stale? does this Rec.2020 file actually use the wider gamut?* — before
+they run their expensive encoder. Re-deriving that from scratch in each codec
+means three copies of the same Tier 1 SIMD scan, three slightly different
 threshold contracts, and three independent oracle retrains every time the math
 moves.
 
@@ -53,20 +58,25 @@ let alpha    = results.get(AnalysisFeature::AlphaPresent)
 ```
 
 `AnalysisFeature` is `#[non_exhaustive]` with stable `u16` discriminants —
-retired ids stay reserved, new ids are sequential. `FeatureSet` has full
-`const fn` set math (`union`, `intersect`, `difference`) so per-codec presets
-compose at compile time. `AnalysisQuery` is intentionally opaque: sampling
-budgets are crate invariants, not per-call knobs.
+retired ids stay reserved, new ids are sequential, the wire format never breaks.
+`FeatureSet` has full `const fn` set math (`union`, `intersect`, `difference`)
+so per-codec presets compose at compile time. `AnalysisQuery` is intentionally
+opaque: sampling budgets are crate invariants, not per-call knobs.
 
 For a packed RGB8 buffer the convenience entry skips the `PixelSlice` ceremony:
 
 ```rust
-let results = zenanalyze::analyze_features_rgb8(&rgb_bytes, width, height, &query);
+// Panicking — for known-good inputs (freshly decoded buffers).
+let r = zenanalyze::analyze_features_rgb8(&rgb_bytes, w, h, &q);
+
+// Fallible — for untrusted input. Returns AnalyzeError::InvalidInput on
+// length / stride mismatch and AnalyzeError::OutOfMemory on (future)
+// fallible-allocation paths.
+let r = zenanalyze::try_analyze_features_rgb8(&rgb_bytes, w, h, &q)?;
 ```
 
-Codecs that need the source's `PixelDescriptor` for encode-side decisions
-(bit depth, primaries, transfer function, color model, alpha mode, signal
-range) read it back without having to retain the original `PixelSlice`:
+Codecs read the source `PixelDescriptor` directly off the result for encode-side
+metadata decisions:
 
 ```rust
 let descriptor = results.source_descriptor();
@@ -79,57 +89,93 @@ match descriptor.primaries {
 }
 ```
 
+`FeatureSet::iter()` walks the contained features in `AnalysisFeature::id()`
+order — convenient for sidecars, harnesses, and Python fitters that need to
+enumerate the surface without hand-listing variants.
+
 ## What it computes
+
+**Default features** (every codec gets these):
 
 | Feature | Type | Description |
 |---|---|---|
 | `Variance` | f32 | Luma variance on the BT.601 [0, 255] scale. |
-| `EdgeDensity` | f32 | Fraction of sampled interior pixels with `|∇L| > 20`. |
+| `EdgeDensity` | f32 | Fraction of sampled interior pixels with `\|∇L\| > 20`. |
 | `ChromaComplexity` | f32 | `√(Var(Cb) + Var(Cr))` over sampled pixels. |
 | `CbSharpness` / `CrSharpness` | f32 | Mean per-axis chroma gradient. |
 | `Uniformity` | f32 | Fraction of 8×8 blocks with luma variance < 25. |
 | `FlatColorBlockRatio` | f32 | Fraction of 8×8 blocks with R/G/B ranges all ≤ 4. |
 | `DistinctColorBins` | u32 | Distinct 5-bit-per-channel RGB bins observed. |
-| `Cb*Sharpness` / `Cr*Sharpness` (×3 each) | f32 | Per-channel per-axis chroma sharpness. |
+| `Cb*Sharpness` / `Cr*Sharpness` (Horiz/Vert/Peak) | f32 | Per-channel per-axis chroma sharpness. |
 | `HighFreqEnergyRatio` | f32 | DCT AC energy ratio over sampled 8×8 luma blocks. |
 | `LumaHistogramEntropy` | f32 | Shannon entropy of a 32-bin luma histogram (bits). |
 | `AlphaPresent` / `AlphaUsedFraction` / `AlphaBimodalScore` | bool / f32 / f32 | Straight-alpha statistics. |
 | `TextLikelihood` / `ScreenContentLikelihood` / `NaturalLikelihood` | f32 | Soft `[0, 1]` content-class scores. |
 
-Behind the `experimental` cargo feature, organized by what they drive:
+**Behind the `experimental` cargo feature**, organised by what they drive:
 
-**Codec-orchestrator gap-fillers** (added 2026-04-27 from the codec-knob inventory; corpus-validated on CID22 / CLIC2025 / gb82):
+### Codec-orchestrator gap-fillers
 
 | Feature | Drives |
 |---|---|
-| `GrayscaleScore` | zenjpeg `ColorMode::Grayscale`, png/avif/jxl gray paths |
+| `GrayscaleScore` | zenjpeg `ColorMode::Grayscale`, AVIF `Yuv400`, png/jxl gray paths (~30–40% smaller for B&W) |
 | `AqMapMean` / `AqMapStd` | zenjpeg hybrid trellis λ, webp segments + sns_strength, avif vaq |
-| `NoiseFloorY` / `NoiseFloorUV` | zenjpeg `pre_blur`, jxl `noise/denoise`, webp `sns_strength` |
-| `LineArtScore` | webp `Preset::Drawing`, jxl modular path, png palette preference |
+| `NoiseFloorY` / `NoiseFloorUV` | zenjpeg `pre_blur`, jxl `noise/denoise`, webp `sns_strength`, zenrav1e `film_grain` |
+| `LineArtScore` | webp `Preset::Drawing`, jxl `splines` / `patches`, png palette preference |
+| `GradientFraction` | jxl `with_force_strategy` (DCT16 / DCT32 selection), zenrav1e deblock strength |
 
-**Source-direct HDR / bit-depth tier** (read source samples without RowConverter, since RowConverter doesn't tonemap):
+### Source-direct HDR / wide-gamut / bit-depth tier
+
+These read source samples without going through `RowConverter`, since
+`RowConverter` doesn't tonemap — a 4000-nit PQ source and a 100-nit-clipped
+SDR source would otherwise produce byte-identical RGB8 streams.
 
 | Feature | Drives |
 |---|---|
-| `PeakLuminanceNits` / `P99LuminanceNits` | HDR encoder peak / target nits |
+| `PeakLuminanceNits` / `P99LuminanceNits` | AVIF `clli`, JXL `intensity_target`, HDR encoder peak |
 | `HdrHeadroomStops` / `HdrPixelFraction` | HDR vs SDR encode-mode selection |
-| `WideGamutPeak` / `WideGamutFraction` | Gamut-clipping decisions before sRGB narrowing |
-| `EffectiveBitDepth` | avif/jxl `bit_depth`, png `near_lossless_bits` |
-| `HdrPresent` | Composite HDR-mode trigger |
+| `WideGamutPeak` / `WideGamutFraction` | "Linear value > 1.0" detection |
+| `GamutCoverageSrgb` / `GamutCoverageP3` | **Descriptor-gap signal** — if a Rec.2020 source's pixels all live in the sRGB sub-gamut, encode at sRGB primaries and save the wide-gamut metadata + encoder modes |
+| `EffectiveBitDepth` | AVIF / JXL `bit_depth`, png `near_lossless_bits` (catches u8-promoted u16) |
+| `HdrPresent` | Composite "transfer claims HDR AND pixels are actually bright" — catches stale HDR flags |
 
-**Research-stage**: `Colourfulness`, `LaplacianVariance`, `VarianceSpread`, `PaletteDensity`, `DctCompressibilityY`, `DctCompressibilityUV`, `PatchFraction`, `IndexedPaletteWidth`, `PaletteFitsIn256`. Their numeric scale or definition may change in 0.1.x patches.
+### Research-stage
+
+`Colourfulness`, `LaplacianVariance`, `VarianceSpread`, `PaletteDensity`,
+`DctCompressibilityY`, `DctCompressibilityUV`, `PatchFraction`,
+`IndexedPaletteWidth`, `PaletteFitsIn256`. Numeric scale or definition may
+change in 0.1.x patches.
+
+## Descriptor-gap detection
+
+The analyzer's job is to spot the gap between what the descriptor *promises*
+and what the data *actually carries*, so encoders don't bloat files paying
+for capacity the source doesn't need.
+
+| Gap | Signal |
+|---|---|
+| RGB declared, content is grayscale | `GrayscaleScore ≥ 0.99` |
+| Wider primaries declared, content fits sRGB | `GamutCoverageSrgb ≥ 0.99` |
+| Rec.2020 declared, content fits Display P3 | `GamutCoverageP3 ≥ 0.99` |
+| HDR transfer declared, content is SDR | `HdrPresent == false` |
+| u16 declared, content is u8-promoted | `EffectiveBitDepth == 8` |
+| RGBA declared, alpha is constant 1.0 | `AlphaUsedFraction == 0` |
+| Standard 8×8 transforms, content is smooth | `GradientFraction ≥ 0.5` (use larger DCTs) |
+| HDR flag set, peak is dim | `PeakLuminanceNits < 200 && HdrPresent` (mis-tagged HDR) |
+
+Each one is a place where a codec orchestrator can downcast metadata + encoder
+modes before encoding, saving real bytes on real corpora.
 
 ## Wide gamut, HDR, and bit depth
 
 `analyze_features` accepts every layout `zenpixels-convert::RowConverter` can
 ingest — RGB8 / RGBA8 / BGRA8, RGB16 / RGBA16, RGB-F32 / RGBA-F32 (linear, sRGB,
 PQ, HLG), grayscale variants, all primaries (sRGB / Display P3 / Rec.2020 /
-AdobeRGB). One entry, no opt-in step.
+AdobeRGB). One entry, no opt-in step. The principle: per-image codec decisions
+don't usually break on a few LSBs of luma drift, they break on the analyzer
+refusing to run.
 
-The principle: per-image codec decisions don't usually break on a few LSBs of
-luma drift, they break on the analyzer refusing to run.
-
-**u8-promotion invariance** is locked by tests. An RGB8 image promoted to
+**u8-promotion invariance is locked by tests.** An RGB8 image promoted to
 RGB16 via the standard `u8 * 257` doubling, or to RGBF32 via `u8 / 255.0`,
 produces *bit-identical* features to the original RGB8 source. Codecs that
 upgrade from u8 to wider formats internally don't see different analyzer
@@ -138,67 +184,120 @@ answers. (Verified by garb's exact-identity narrowing
 
 **Wide gamut adapts the values, not the API.** RGB8 with Display P3 / Rec.2020
 / AdobeRGB primaries passes through the zero-copy `Native` row path. The
-BT.601 luma weights produce slightly different numbers vs sRGB content — and
-that's the principled outcome, since wide-gamut content is more saturated,
-chroma signals legitimately read higher.
+BT.601 luma weights produce slightly different numbers vs sRGB content — that
+is the principled outcome, since wide-gamut content is more saturated, chroma
+signals legitimately read higher.
 
-**HDR f32 inputs** are converted through their declared transfer function to
-display-space RGB8 — a tonemapped SDR rendition, since the analyzer's
-threshold contract is calibrated on display-space bytes. HDR-aware features
-(peak luminance, HDR pixel fraction, wide-gamut peak) live in the future
-`tier_depth` work tracked under issue #120; they read the source samples
-directly, without going through `RowConverter`.
+**HDR f32 / linear inputs** are handled by the dedicated `tier_depth` pass,
+which reads source samples directly via `PixelSlice::row` (bypassing
+`RowConverter` entirely) and decodes through the descriptor's transfer
+function — sRGB / BT.709 / Gamma2.2 / Linear / PQ / HLG — to linear nits. The
+reference convention is stable across 0.1.x:
 
-The only error you can get from a well-formed `PixelSlice` is
-`AnalyzeError::Convert(...)` when a descriptor isn't supported by
-`zenpixels-convert` (e.g. CMYK without a CMS plugin loaded).
+| Transfer | Linear 1.0 maps to | Convention |
+|---|---|---|
+| `Srgb` / `Bt709` / `Gamma22` / `Linear` | 80 nits | sRGB display reference (IEC 61966-2-1) |
+| `Pq` | 10 000 nits | SMPTE ST 2084 absolute |
+| `Hlg` | 1 000 nits | nominal HLG broadcast |
 
-## How it's organized
+The standard tiers' threshold contract is calibrated on display-space RGB8
+bytes; the depth tier surfaces the additional metadata-gap and HDR signals
+that the RGB8 narrowing destroys.
 
-Three tiers, all dispatched through the requested `FeatureSet` at runtime:
+## Errors
 
-- **Tier 1** — staggered-stripe sample (≈500K pixels, ~1 ms at 4K). Variance,
-  edge density, chroma complexity, 8×8 uniformity / flat-block ratio, optional
-  Hasler-Süsstrunk colourfulness and Laplacian variance.
-- **Tier 2** — full-image 3-row sliding window. Per-channel per-axis chroma
-  sharpness; forked from evalchroma 1.0.3.
-- **Tier 3** — sampled 8×8 DCT blocks (1024-block budget). High-frequency energy
-  ratio, 32-bin luma entropy, optional libwebp α compressibility, optional
-  patch-fraction perceptual-hash detector.
+```rust
+#[non_exhaustive]
+pub enum AnalyzeError {
+    Convert(String),                                  // RowConverter setup failed
+    InvalidInput(String),                             // user-supplied bad layout / length
+    OutOfMemory { bytes_requested: Option<usize> },   // future fallible-alloc path
+    Internal(String),                                 // unexpected
+}
+```
 
-A separate **palette pass** runs always-full-scan when any palette feature was
-requested (counts converge slowly under sub-sampling). An **alpha pass** scans
-the source descriptor's straight-alpha channel directly without going through
-RowConverter — no precision loss for u16/f32 alpha.
+Production code handling untrusted images should pattern-match on
+`InvalidInput` / `OutOfMemory` explicitly. Today every internal allocation is
+infallible (so `OutOfMemory` is reserved, never returned by current builds);
+the variant is part of the public surface so a future minor that flips
+internals to `Vec::try_reserve` doesn't break anyone's `match`.
+
+## How it's organised
+
+Five passes, each gated by what the requested `FeatureSet` actually needs:
+
+| Pass | Iterates over | Reads | Cost (4 MP) | Drives |
+|---|---|---|---|---|
+| Tier 1 | Stripe-sampled rows | RGB8 | ~1 ms | luma stats, edges, chroma, uniformity, grayscale |
+| Tier 2 | 3-row sliding window | RGB8 | ~2 ms | per-axis Cb/Cr sharpness |
+| Tier 3 | Sampled 8×8 DCT blocks | RGB8 | ~3 ms | DCT energy, entropy, AQ map, noise floor, line-art, gradient, patch fraction |
+| Palette | Full image | RGB8 | ~1 ms | distinct color bins |
+| Alpha | Stride-sampled rows | **Source bytes** | ~0.3 ms | alpha presence / used / bimodal |
+| `tier_depth` (experimental) | Stride-sampled rows | **Source bytes** | ~0.5 ms HDR, ~0 SDR-fast-path | HDR / wide-gamut / bit-depth / gamut-coverage |
+
+Tier 1/2/3 + Palette read RGB8 via `RowStream`, which has three internal paths:
+
+- **Native** (zero-copy) — RGB8-byte-layout-compatible inputs. Sub-slice straight from the source.
+- **StripAlpha8** (zero RowConverter, scratch-only) — RGBA8 / BGRA8 / Rgbx8 / Bgrx8. Tight strip-and-maybe-swap into the row scratch. Skips the RowConverter alloc + plan + per-row CPU work.
+- **Convert** — everything else (16-bit, f32, grayscale, CMYK, …) goes through `RowConverter` row-by-row.
+
+Alpha and `tier_depth` always read source bytes directly, never through
+`RowStream` — a load-bearing detail for HDR (RowConverter doesn't tonemap;
+its narrowing clips PQ / HLG into sRGB-display).
+
+## Performance
+
+Release build, AVX2, no `target-cpu=native`, full `FeatureSet::SUPPORTED`:
+
+| Image | RGB8 input | RGBA8 input |
+|---|---|---|
+| 1 MP | ~5 ms | — |
+| 4 MP | ~7 ms | — |
+| 16 MP | ~17 ms (~1 ms/MP) | ~41 ms |
+
+The RGBA8 path's higher cost is the per-row strip-alpha pass repeated for
+each tier's row fetch; still ~2× cheaper than the previous full-RowConverter
+path, with zero converter setup allocation.
+
+Per-call working-set memory is ~265 KB across ~7 allocations (largest single
+chunk is the Tier 1 stripe scratch at 9 × width × 3 = 108 KB at 4 K). All
+allocations are infallible today; the `OutOfMemory` variant exists so a
+future minor can flip them without API breakage.
 
 ## Threshold contract
 
-Numeric thresholds and normalization scales are converging during the 0.1.x
-line. Downstream consumers that compile-in fitted models (oracle decision
-trees, content selectors) must pin to a specific zenanalyze patch version and
-re-validate / retrain whenever they bump it. Every breaking numeric change
-ships with a CHANGELOG entry. The contract freezes at 1.0.
+Numeric thresholds and normalisation scales drift during 0.1.x. Downstream
+consumers that compile-in fitted models (oracle decision trees, content
+selectors) must pin to a specific zenanalyze patch version and re-validate
+when they bump it.
+
+**There is no 0.2.x.** Every change in 0.1.x is additive — new variants on
+`#[non_exhaustive]` enums, new parallel functions, never a signature change to
+a shipped item. See `CLAUDE.md`.
 
 ## Test surface
 
-100+ tests covering math invariants on synthetic inputs (solid colours,
-horizontal bands, uniform luma distribution, palette-locked images), the full
-16-arm dispatch matrix, every supported pixel format (RGB8 / RGBA8 / BGRA8 /
-RGB16 / RGBA16 / RGB-F32 / RGBA-F32 / Gray8 / Gray16 / GrayF32 / GrayA8 /
-GrayA16 / GrayAF32), tier sizes from 1×1 to 2048×2048, deterministic-input
-bit-equality (catches accumulator non-determinism), and `AnalyzeError` Display
-/ source coverage. Math locks use absolute tolerances chosen to clear ULP-level
-f32 noise from SIMD tree reductions but catch any genuine architecture
-divergence.
+130+ tests covering math invariants on synthetic inputs (solid colours,
+horizontal bands, uniform luma distribution, palette-locked images, two-tone
+line drawings, smooth gradients, pure noise), the full 16-arm dispatch matrix,
+every supported pixel format (3 channel-types × 6 transfers × 4 primaries × 2
+alpha = 144 sanity-matrix combinations), tier sizes from 1×1 to 4096×4096,
+deterministic-input bit-equality (catches accumulator non-determinism),
+u8-promotion bit-equality across u16 / f32 sources, HDR-survival (PQ ~1000-nit
+content preserved end-to-end where standard tiers would have clipped to SDR),
+gamut-coverage projections (saturated Rec.2020 green correctly fails sRGB
+coverage), and `AnalyzeError` Display / source coverage. Math locks use
+absolute tolerances chosen to clear ULP-level f32 noise from SIMD tree
+reductions but catch any genuine architecture divergence.
 
 > Note on coverage tooling: the SIMD kernels in `tier1.rs`, `palette.rs`,
 > `tier2_chroma.rs`, and `tier3.rs` use `#[magetypes(... v4, v3, neon,
-> wasm128, scalar)]` to generate one source-level monomorphization per
+> wasm128, scalar)]` to generate one source-level monomorphisation per
 > architecture tier. At runtime archmage's `incant!` dispatches to whichever
 > the CPU supports; the other variants stay compiled but unreachable. Line-
 > coverage tools count each variant separately, so the raw percentage on
-> these files looks ≈30% on x86_64. Real coverage of executable code paths
-> (counted on the dispatched variant only) is ≥95% across every module.
+> these files looks ≈30 % on x86_64. Real coverage of executable code paths
+> (counted on the dispatched variant only) is ≥95 % across every module.
 
 ## License
 

--- a/zenanalyze/README.md
+++ b/zenanalyze/README.md
@@ -123,6 +123,8 @@ enumerate the surface without hand-listing variants.
 | `NoiseFloorY` / `NoiseFloorUV` | zenjpeg `pre_blur`, jxl `noise/denoise`, webp `sns_strength`, zenrav1e `film_grain` |
 | `LineArtScore` | webp `Preset::Drawing`, jxl `splines` / `patches`, png palette preference |
 | `GradientFraction` | jxl `with_force_strategy` (DCT16 / DCT32 selection), zenrav1e deblock strength |
+| `SkinToneFraction` | photo-vs-other dispatch (one-direction signal, AUC 0.80) — webp `Preset::Photo`, jxl perceptual presets, jpeg chroma-aware quant |
+| `EdgeSlopeStdev` | screen-vs-photo dispatch (AUC 0.84, second only to `PatchFraction`) — webp `Preset::Drawing` vs `Photo`, jxl modular vs VarDCT |
 
 ### Source-direct HDR / wide-gamut / bit-depth tier
 
@@ -263,20 +265,69 @@ its narrowing clips PQ / HLG into sRGB-display).
 
 Release build, AVX2, no `target-cpu=native`, full `FeatureSet::SUPPORTED`:
 
-| Image | RGB8 input | RGBA8 input |
+| Input | 4 MP | RowStream path |
 |---|---|---|
-| 1 MP | ~5 ms | — |
-| 4 MP | ~7 ms | — |
-| 16 MP | ~17 ms (~1 ms/MP) | ~41 ms |
+| RGB8 / Rgbx8 with sRGB / wide-gamut primaries | 9.5 ms | `Native` (zero-copy slice subindex) |
+| RGBA8 | 10.9 ms | `StripAlpha8` (garb SIMD strip) |
+| BGRA8 | 12.0 ms | `StripAlpha8` (garb SIMD strip + swap) |
+| RGB16 | 24.7 ms | `Convert` (zenpixels-convert RowConverter) |
+| RGBA16 | 28.6 ms | `Convert` (zenpixels-convert handles strip + narrow) |
 
-The RGBA8 path's higher cost is the per-row strip-alpha pass repeated for
-each tier's row fetch; still ~2× cheaper than the previous full-RowConverter
-path, with zero converter setup allocation.
+The RGBA8 strip uses `garb::bytes::rgba_to_rgb` / `bgra_to_rgb`
+(SIMD-dispatched via `archmage::incant!`) — measured 7× faster than
+the previous in-tree scalar strip on a 2048-px row, dropping the
+RGBA8 overhead vs RGB8 baseline from +5.8 ms to +1.4 ms. The 16-bit
+input paths cost more because RowConverter does transfer-function-
+aware narrowing — that's the correct tool for genuinely
+heterogeneous input.
 
 Per-call working-set memory is ~265 KB across ~7 allocations (largest single
 chunk is the Tier 1 stripe scratch at 9 × width × 3 = 108 KB at 4 K). All
 allocations are infallible today; the `OutOfMemory` variant exists so a
 future minor can flip them without API breakage.
+
+## Empirical operating thresholds
+
+Picked on a 219-image labeled corpus from coefficient
+(`benchmarks/classifier-eval/labels.tsv`, spanning cid22-train/val,
+clic2025-1024, gb82, gb82-sc, imageflow, kadid10k, qoi-benchmark). 174
+photo, 36 screen, 9 illustration, 44 marked synthetic. F1 / AUC are
+for binary screen-vs-photo classification.
+
+**For codec-orchestrator dispatch ("is this a screen or a photo?"):**
+
+| signal | threshold | F1 | AUC | notes |
+|---|---|---|---|---|
+| `line_art_score > 0` | any nonzero | 0.978 | 0.750 | near-deterministic — line art ⇒ screen-like |
+| `natural_likelihood >= 0.06` | photo detection | 0.924 | 0.814 | high precision photo classifier |
+| `patch_fraction >= 0.27` | screen detection | **0.769** | **0.880** | **strongest single screen discriminator** |
+| `edge_slope_stdev >= 35` | screen detection | — | **0.844** | **second-strongest screen discriminator** — photos cluster 15–32, screens 32–58 |
+| `screen_content_likelihood >= 0.60` | screen detection | 0.750 | 0.831 | derived from flat blocks + palette + chroma |
+| `flat_color_block_ratio >= 0.53` | screen detection | 0.750 | 0.838 | raw — same F1 as the derived `_likelihood` |
+| `skin_tone_fraction >= 0.05` | photo detection | 0.824 | 0.799 | one-direction (presence ⇒ photo); pigmentation-invariant Chai-Ngan YCbCr |
+| `text_likelihood >= 0.30` | text detection | 0.682 | 0.774 | weaker but real |
+| `grayscale_score >= 0.99` | grayscale dispatch | — | — | encoder gap-filler, near-binary on real grayscale |
+
+**Note:** the three `*_likelihood` features empirically saturate at
+~0.70 (not 1.0) on real content, because each is a weighted sum of
+clamped sub-components that don't simultaneously max on real images.
+**Don't threshold them at `>= 0.8` — nothing will fire.** Operating
+points are in the 0.3–0.6 band. The exact corpus maxes are:
+
+- `text_likelihood` max **0.71**
+- `screen_content_likelihood` max **0.70**
+- `natural_likelihood` max **0.69**
+
+**For descriptor-gap detection** the thresholds are content-physical
+(see the "Descriptor-gap detection" table above): `GrayscaleScore >= 0.99`,
+`GamutCoverageSrgb >= 0.99`, etc. Those are spec-driven, not corpus-fit.
+
+The full per-class distributions, ROC-AUC ranking for every feature,
+Spearman redundancy matrix, and the recalibration findings that were
+considered and rejected are recorded in
+[`docs/calibration-corpus-2026-04-27.md`](docs/calibration-corpus-2026-04-27.md).
+That file is the pre-0.1.0-ship empirical baseline; subsequent 0.1.x
+patches that drift numerics should compare against it.
 
 ## Threshold contract
 

--- a/zenanalyze/README.md
+++ b/zenanalyze/README.md
@@ -183,16 +183,30 @@ answers. (Verified by garb's exact-identity narrowing
 `(u16 * 255 + 32768) >> 16` for `u16 = u8 * 257`.)
 
 **Wide gamut adapts the values, not the API.** RGB8 with Display P3 / Rec.2020
-/ AdobeRGB primaries passes through the zero-copy `Native` row path. The
-BT.601 luma weights produce slightly different numbers vs sRGB content — that
-is the principled outcome, since wide-gamut content is more saturated, chroma
-signals legitimately read higher.
+/ AdobeRGB primaries passes through the zero-copy `Native` row path with its
+bytes intact. The standard tiers pick the **right luma matrix per source
+primaries**: BT.601 weights for sRGB / BT.709 (preserving the trained-threshold
+baseline — coefficient's existing thresholds were calibrated against this
+matrix on sRGB content), BT.2020 weights for Rec.2020 sources, the Y row of
+each primary set's RGB→XYZ matrix for Display P3 / AdobeRGB. Fixed-point
+integer-luma scales are normalised to the same sum-220 libwebp baseline so a
+pure-white pixel hits the same histogram bin regardless of source primaries —
+what differs is the per-channel weight that lands it there. No conversion, no
+clipping, just the right matrix. See `src/luma.rs`.
 
-**HDR f32 / linear inputs** are handled by the dedicated `tier_depth` pass,
-which reads source samples directly via `PixelSlice::row` (bypassing
-`RowConverter` entirely) and decodes through the descriptor's transfer
-function — sRGB / BT.709 / Gamma2.2 / Linear / PQ / HLG — to linear nits. The
-reference convention is stable across 0.1.x:
+**HDR f32 / linear inputs.** Standard tiers see what an SDR display would
+show — `RowConverter` clips out-of-[0, 1] linear values, applies the sRGB
+OETF, and narrows to u8. That's the legitimate input for SDR-calibrated
+thresholds; tonemapping a 4 000-nit highlight into a visible mid-tone
+before measuring "high-frequency-energy ratio" would just lie about what's
+there. The above-clip signal lives in `tier_depth`, which reads the source
+samples directly via `PixelSlice::row` (bypassing `RowConverter` entirely)
+and decodes through the descriptor's transfer function — sRGB / BT.709 /
+Gamma 2.2 / Linear / PQ / HLG — to linear nits. Two views of the same
+source: the SDR-display view for trained thresholds, the source-direct view
+for HDR / wide-gamut signal.
+
+The `tier_depth` reference convention is stable across 0.1.x:
 
 | Transfer | Linear 1.0 maps to | Convention |
 |---|---|---|

--- a/zenanalyze/docs/calibration-corpus-2026-04-27.md
+++ b/zenanalyze/docs/calibration-corpus-2026-04-27.md
@@ -1,0 +1,375 @@
+# Empirical calibration report — 2026-04-27
+
+Class-conditional feature distributions, AUC for screen-vs-photo
+classification, recommended operating thresholds, and Spearman
+redundancy. Source: 219-image labeled corpus from
+`coefficient/benchmarks/classifier-eval/labels.tsv` (gpt-5.4-mini
+labels reviewed for primary category, has-text, palette size,
+chroma dominance, synthetic flag).
+
+The labels span 9 source corpora (cid22-train/val, clic2025-1024,
+gb82, gb82-sc, imageflow, kadid10k, qoi-benchmark, corpus). Class
+counts: photo=174 (natural=97, detailed=39, portrait=32, uniform=6),
+screen=36 (ui=17, document=17, chart=2), illustration=9, marked
+synthetic=44.
+
+## Methodology
+
+`zenanalyze/examples/corpus_eval.rs`, labeled mode
+(`LABELS_TSV=…/labels.tsv ./target/release/examples/corpus_eval`),
+runs `analyze_features` with the experimental-feature set on every
+labeled image and emits a CSV with feature columns concatenated
+to label columns. Analyses run the default sampling budget (no
+`MAX_PER_CORPUS` override) so the numbers reflect what shipped
+0.1.0 will produce in production.
+
+## Per-class distributions
+
+p50/p90 per class. "screen" combines screen_* and illustration
+(`#screen-like`); "synth p90" pools `is_synthetic == true`; "max"
+is the corpus-wide maximum.
+
+| feature                       | photo p50 | photo p90 | screen p50 | screen p90 | synth p90 | corpus max |
+|-------------------------------|----------:|----------:|-----------:|-----------:|----------:|-----------:|
+| variance                      |      2994 |      5110 |       2998 |       7514 |      7514 |      11243 |
+| edge_density                  |    0.1373 |    0.3243 |     0.0696 |     0.3068 |    0.2639 |     0.8910 |
+| chroma_complexity             |    0.1125 |    0.2125 |     0.0797 |     0.2230 |    0.2230 |     0.3142 |
+| cb_sharpness                  |    0.0067 |    0.0164 |     0.0025 |     0.0103 |    0.0098 |     0.0663 |
+| cr_sharpness                  |    0.0043 |    0.0111 |     0.0017 |     0.0088 |    0.0088 |     0.0285 |
+| uniformity                    |    0.4211 |    0.7559 |     0.7865 |     0.8901 |    0.8901 |     0.9822 |
+| flat_color_block_ratio        |    0.0298 |    0.2824 |     0.7087 |     0.8677 |    0.8677 |     0.9821 |
+| colourfulness                 |      44.0 |      88.4 |       27.2 |       89.4 |      89.4 |      146.0 |
+| laplacian_variance            |    0.4842 |      1.93 |       1.75 |       9.16 |      9.16 |       22.0 |
+| variance_spread               |      1.31 |      1.74 |       1.28 |       1.83 |      1.83 |       2.63 |
+| distinct_color_bins           |      2739 |      7740 |       2030 |      12190 |     12190 |      22602 |
+| palette_density               |    0.0836 |    0.2362 |     0.0620 |     0.3720 |    0.3720 |     0.6898 |
+| cb_horiz_sharpness            |    0.0025 |    0.0154 |     0.0029 |     0.0227 |    0.0227 |     0.1297 |
+| cb_vert_sharpness             |    0.0026 |    0.0149 |     0.0036 |     0.0288 |    0.0288 |     0.1470 |
+| cb_peak_sharpness             |       0.0 |       3.0 |        2.0 |       11.0 |      11.0 |       38.0 |
+| cr_horiz_sharpness            |    0.0073 |    0.0579 |     0.0129 |     0.0863 |    0.0863 |     0.6771 |
+| cr_vert_sharpness             |    0.0076 |    0.0474 |     0.0115 |     0.1480 |    0.1480 |     0.6590 |
+| cr_peak_sharpness             |       2.0 |      13.0 |       12.0 |       61.0 |      61.0 |      207.0 |
+| high_freq_energy_ratio        |    0.1518 |    0.3747 |     0.1871 |     0.4449 |    0.4449 |     0.9201 |
+| luma_histogram_entropy        |      4.22 |      4.60 |       2.39 |       4.20 |      4.19 |       4.73 |
+| dct_compressibility_y         |      15.3 |      31.9 |       17.7 |       33.0 |      33.0 |       69.1 |
+| dct_compressibility_uv        |      5.40 |      14.6 |       2.79 |       11.0 |      11.0 |       44.8 |
+| patch_fraction                |    0.0020 |    0.0366 |     0.7260 |     0.9062 |    0.9062 |     0.9961 |
+| text_likelihood               |    0.1879 |    0.3000 |     0.3019 |     0.5351 |    0.5351 |     0.7073 |
+| screen_content_likelihood     |    0.0363 |    0.3784 |     0.6183 |     0.6744 |    0.6744 |     0.7000 |
+| natural_likelihood            |    0.5211 |    0.6556 |     0.0681 |     0.5719 |    0.5687 |     0.6885 |
+| grayscale_score               |    0.0494 |    0.2654 |     0.3493 |     0.9666 |    0.9666 |       1.00 |
+| aq_map_mean                   |      3.26 |      4.05 |       1.29 |       3.97 |      3.85 |       4.97 |
+| aq_map_std                    |      1.00 |      1.41 |       1.62 |       2.19 |      2.19 |       2.50 |
+| noise_floor_y                 |    0.0529 |    0.2431 |     0.0000 |     0.1831 |    0.0974 |       1.00 |
+| noise_floor_uv                |    0.0195 |    0.0569 |     0.0000 |     0.0477 |    0.0221 |     0.5474 |
+| line_art_score                |    0.0000 |    0.0000 |     0.0432 |     0.5870 |    0.5870 |     0.9787 |
+
+Depth-tier features (peak_luminance_nits, hdr_*, wide_gamut_*,
+effective_bit_depth) collapse to the SDR fast-path constants on
+every PNG/JPEG input — sRGB transfer + u8 source + sub-sRGB gamut.
+Validating those signals needs an HDR corpus (PQ/HLG PNGs with
+CICP, 10/12/16-bit PNGs, DNG via rawler). Tracked as task #67.
+
+## Discriminative power: AUC for screen-vs-photo
+
+"screen" = `primary_category` starts with `screen_*` or equals
+`illustration` (45 positives, 174 negatives).
+
+| feature                       | AUC   | direction   |
+|-------------------------------|------:|-------------|
+| **patch_fraction**            | 0.880 | high→screen |
+| flat_color_block_ratio        | 0.838 | high→screen |
+| screen_content_likelihood     | 0.831 | high→screen |
+| natural_likelihood            | 0.814 | high→photo  |
+| grayscale_score               | 0.797 | high→screen |
+| text_likelihood               | 0.774 | high→screen |
+| aq_map_std                    | 0.762 | high→screen |
+| laplacian_variance            | 0.760 | high→screen |
+| line_art_score                | 0.750 | high→screen |
+| uniformity                    | 0.738 | high→screen |
+| cr_peak_sharpness             | 0.699 | high→screen |
+| cb_peak_sharpness             | 0.696 | high→screen |
+| luma_histogram_entropy        | 0.848 | high→photo  |
+| aq_map_mean                   | 0.792 | high→photo  |
+| noise_floor_y                 | 0.794 | high→photo  |
+
+(For "high→photo" features, "AUC" is `1 − raw_AUC` so larger means
+better photo discrimination.)
+
+`patch_fraction` is the single strongest screen-vs-photo
+discriminator on this corpus. Downstream consumers picking content
+class for codec dispatch should weight it accordingly.
+
+## Recommended operating thresholds
+
+Best F1 thresholds for binary screen-content / photo / line-art
+classification on this corpus. F1 is reported at the threshold; P
+and R are precision / recall at that threshold.
+
+| feature                       | threshold | F1    | P     | R     | classifies |
+|-------------------------------|----------:|------:|------:|------:|------------|
+| `line_art_score`     `> 0`    |    0.000  | 0.978 | 0.957 | 1.000 | screen-like |
+| `natural_likelihood` `≥ 0.06` |    0.061  | 0.924 | 0.876 | 0.977 | photo |
+| `patch_fraction`     `≥ 0.27` |    0.274  | 0.769 | 0.909 | 0.667 | screen-like |
+| `screen_content_likelihood` `≥ 0.60` |  0.600  | 0.750 | 0.857 | 0.667 | screen-like |
+| `flat_color_block_ratio`     `≥ 0.53` |  0.525  | 0.750 | 0.857 | 0.667 | screen-like |
+| `text_likelihood`    `≥ 0.30` |    0.300  | 0.682 | 0.698 | 0.667 | screen-like |
+| `grayscale_score`    `≥ 0.23` |    0.231  | 0.617 | 0.592 | 0.644 | screen-like |
+
+The `_likelihood` features empirically saturate well below the
+`[0, 1]` theoretical range:
+
+- `text_likelihood` corpus max **0.71**
+- `screen_content_likelihood` corpus max **0.70**
+- `natural_likelihood` corpus max **0.69**
+
+This is a property of the formula structure (each is a weighted
+sum of clamped sub-components, and the sub-components don't
+simultaneously max on real content). The right operating points
+are around the empirical 90th percentile of the target class, not
+the theoretical 1.0 — see the table above. **Do not threshold at
+0.8 or higher; nothing fires there.**
+
+## Spearman redundancy
+
+Top |ρ| pairs across features. Pairs with |ρ| ≥ 0.85 are
+candidates for consolidation, but several of these reflect
+formula-by-construction relationships (e.g.,
+`screen_content_likelihood` is `0.6·flat_color_block_ratio + …`,
+so ρ=0.989 with `flat_color_block_ratio` is structural, not
+incidental).
+
+| ρ     | A                            | B                          | note |
+|-------|------------------------------|----------------------------|------|
+| +1.000| distinct_color_bins          | palette_density            | derived (`bins / max_bins`) |
+| +0.989| flat_color_block_ratio       | screen_content_likelihood  | structural — primary input |
+| −0.967| uniformity                   | aq_map_mean                | both measure block flatness |
+| +0.965| chroma_complexity            | colourfulness              | both quantify chroma spread |
+| +0.914| noise_floor_y                | aq_map_mean                | high-AQ regions have residual noise |
+| −0.902| flat_color_block_ratio       | noise_floor_y              | flat blocks have no AC residue |
+| −0.892| noise_floor_y                | screen_content_likelihood  | screens have no sensor noise |
+| +0.886| cr_sharpness                 | dct_compressibility_uv     | chroma sharpness drives chroma AC |
+| +0.886| cb_sharpness                 | cr_sharpness               | both planes track each other |
+| +0.875| cb_sharpness                 | dct_compressibility_uv     | same shape on cb |
+| +0.859| luma_histogram_entropy       | natural_likelihood         | structural — primary input |
+| +0.858| aq_map_mean                  | natural_likelihood         | photos have higher AQ |
+| −0.857| uniformity                   | noise_floor_y              | flat regions → no noise |
+| −0.848| edge_density                 | uniformity                 | inverse by definition |
+| +0.846| noise_floor_y                | natural_likelihood         | photos noisy, screens clean |
+| −0.845| noise_floor_uv               | screen_content_likelihood  | same chroma reasoning |
+| +0.841| edge_density                 | dct_compressibility_y      | edges drive AC energy |
+| +0.838| noise_floor_y                | noise_floor_uv             | Y/UV noise correlates |
+| −0.826| screen_content_likelihood    | natural_likelihood         | mutually exclusive classes |
+
+`palette_density` ≡ `distinct_color_bins / 32768` and is purely a
+display convenience; consumers can pick whichever is more
+ergonomic.
+
+## What the data does NOT support
+
+This pass evaluated several plausible recalibrations that the
+empirical data does not back:
+
+1. **Lifting `palette_small` ceiling in `screen_content_likelihood`
+   (4000→16000 distinct color bins).** AUC drops 0.831 → 0.817.
+   Photo p90 rises from 0.578 to 0.651 — same magnitude as the
+   screen median rise, no net discrimination gain.
+2. **Multiplicative rescale of derived likelihoods to fill `[0, 1]`.**
+   Cosmetic only — the optimal threshold moves 0.6 → 0.86 with
+   identical F1. Just shifts the magic number.
+3. **Rescaling `dct_compressibility_y/uv` by /32 to land in `[0, 2.2]`.**
+   Less readable than the current `[0, 70]` raw form on real
+   content; theoretical max is 8064 only on degenerate synthetic
+   inputs.
+4. **Rescaling `luma_histogram_entropy` by /5 to `[0, 1]`.**
+   Loses the Shannon-entropy semantics; the 4.73/5.00 corpus
+   ceiling already uses 95% of the range.
+5. **Rescaling `cr_peak_sharpness` to suppress the synthetic-content
+   tail (max 207).** Real photos cap at 57; the 207 max is the
+   stress-test signal. Renormalisation is reserved for the
+   `infer_bucket` calibration step that consumers will own.
+
+## What the data DID surface
+
+1. **Derived likelihoods empirically saturate at ~0.7, not 1.0.**
+   Documented in this report and in the rustdoc on each variant.
+   Operating thresholds in the 0.3–0.6 band are correct.
+2. **`patch_fraction` is the strongest single screen discriminator.**
+   AUC 0.880, F1 0.769 at t≥0.274. Promote in usage guides and in
+   the consumer-side codec dispatch.
+3. **`line_art_score > 0` is essentially deterministic for
+   screen-like content.** F1 0.978 — `> 0` is a reliable enough
+   signal to skip soft thresholds.
+4. **`natural_likelihood ≥ 0.06` cleanly separates photos from
+   screens.** F1 0.924 for photo classification.
+5. **`noise_floor_y` and `screen_content_likelihood` correlate at
+   ρ=−0.892.** Defensible (screens have no sensor noise) but
+   downstream consumers driving different codec knobs
+   (`pre_blur` vs encoder preset) should prefer the one that
+   matches their physical intent.
+
+## Net 0.1.0 action
+
+**No code changes.** The current calibration is empirically
+appropriate for the labeled corpus. Numeric drift is permitted in
+0.1.x patches per the threshold contract; this report is the
+pre-ship empirical baseline against which patch drift can be
+compared.
+
+The rustdoc on each derived likelihood and on `patch_fraction` is
+updated to surface observed ranges and the recommended operating
+thresholds from this report. The README's "Threshold contract"
+section now references this document.
+
+## Reproducing
+
+```sh
+# Build:
+cargo build --release -p zenanalyze --features experimental --example corpus_eval
+
+# Run labeled mode against the coefficient corpus:
+LABELS_TSV=/path/to/coefficient/benchmarks/classifier-eval/labels.tsv \
+CORPUS_ROOT=/path/to/codec-corpus \
+  ./target/release/examples/corpus_eval > /tmp/zenanalyze_labeled.csv
+
+# Then aggregate per-class p10/p50/p90, AUC, and Spearman ρ in
+# Python from the CSV — the report tables above can be regenerated
+# with any standard percentile + Mann-Whitney U code.
+```
+
+`CORPUS_ROOT` defaults to `~/work/codec-eval/codec-corpus`. The
+labeled-mode resolver expects the standard sub-layout
+`<corpus>/<sub>/<image>` (e.g. `CID22/CID22-512/training/<image>`,
+`clic2025-1024/<image>`, `gb82-sc/<image>`). The per-corpus search
+list is in `resolve_dirs` near the top of `run_labeled` in
+`examples/corpus_eval.rs` — extend it for new corpora.
+
+## Addendum 2026-04-27 — `SkinToneFraction` and `EdgeSlopeStdev`
+
+After the original calibration pass landed, two new experimental
+features were added to address issue #123 (artwork-vs-natural-photo
+discriminator). Both validated on the same 219-image labeled corpus
+before shipping.
+
+### Per-class distribution
+
+| feature              | photo_natural p50 | photo_portrait p50 | screen_doc p50 | screen_ui p50 | illustration p50 |
+|----------------------|------------------:|-------------------:|---------------:|--------------:|-----------------:|
+| `skin_tone_fraction` |             0.130 |              0.241 |          0.006 |         0.027 |            0.081 |
+| `edge_slope_stdev`   |              24.2 |               20.7 |           55.3 |          42.1 |             20.9 |
+
+### Discriminative power (photo-vs-other AUC)
+
+| feature              | AUC    | rank | notes |
+|----------------------|-------:|-----:|-------|
+| `skin_tone_fraction` |  0.799 |  3rd | comparable to `natural_likelihood` (0.814), `noise_floor_y` (0.794) |
+| `edge_slope_stdev`   |  0.844* | 2nd  | only `patch_fraction` (0.880) discriminates better |
+
+*`edge_slope_stdev` AUC is high → screen content (i.e., 1 − raw_AUC)
+since the natural direction of the signal is "high stddev ⇒ artwork
+or stylized content".
+
+### Operating thresholds
+
+`skin_tone_fraction`: one-direction signal. `>= 0.05` gives `P = 0.89,
+R = 0.76, F1 = 0.82` for photo classification. Lower thresholds
+maximize recall (`> 0` ⇒ `F1 = 0.882`). Zero fraction is **not**
+evidence against a photograph.
+
+`edge_slope_stdev`: bidirectional. Photos cluster at 15–32, screens
+at 32–58. `>= 35` is a strong screen-detection signal but
+illustration overlaps photo (13–27) — does not solve the issue #123
+illustration-vs-photo subproblem.
+
+### Pigmentation invariance — `SkinToneFraction`
+
+The Chai-Ngan (1999) YCbCr ranges (`Cb ∈ [77, 127], Cr ∈ [133, 173],
+Y ∈ [40, 240]`) are **pigmentation-invariant by design** — chroma
+quantifies hue, not lightness, so the same gates work across light,
+medium, and dark skin tones. Verified against the
+`photo_portrait` subset (n=32, diverse subjects): 93.8% have
+`skin_tone_fraction > 0.01`, with p50=0.241 and p90=0.541. No skew
+toward any specific pigmentation in the misses.
+
+The unit test
+`skin_tone_fraction_fires_on_skin_colored_pixels_zero_on_neutral`
+locks invariance across three representative tones (light pinkish
+RGB(236,188,180), medium tan RGB(198,134,105), deep brown RGB(90,
+56,37)) — all score > 0.95 on uniform-skin-tone test images.
+
+### Performance (4 MP, AVX2, no `-C target-cpu=native`)
+
+#### New-feature incremental cost (RGB8 input, single-feature query)
+
+| feature              | mean    | incremental vs `EdgeDensity` |
+|----------------------|--------:|-----------------------------:|
+| `EdgeDensity`        | 4.31 ms | baseline                     |
+| `GrayscaleScore`     | 4.24 ms | -0.07 ms (noise)             |
+| `SkinToneFraction`   | 4.24 ms | **-0.07 ms** — free          |
+| `EdgeSlopeStdev`     | 4.32 ms | **+0.01 ms** — free          |
+
+Multi-feature: all four together run in 4.25 ms — confirms the
+piggyback design (each new feature shares the same Tier 1 stripe
+sweep, no second pass).
+
+Both new kernels use `#[archmage::autoversion(v4x, v4, v3, neon,
+scalar)]` over `chunks_exact(3)` paired iterators. The chunk size
+proves the inner triplet of u8 loads to LLVM, which then emits
+per-arch SIMD shuffles + integer multiplies for the BT.601 fixed-
+point YCbCr path.
+
+#### `RowStream` row-fetch path comparison
+
+`FeatureSet::SUPPORTED` cost by input format:
+
+| input  | RowStream path                       | mean     |
+|--------|--------------------------------------|---------:|
+| RGB8   | `Native` (zero-copy slice subindex)  |  9.50 ms |
+| RGBA8  | `StripAlpha8` (garb SIMD)            | 10.94 ms |
+| BGRA8  | `StripAlpha8` (garb SIMD)            | 12.00 ms |
+| RGB16  | `Convert` (zenpixels-convert)        | 24.67 ms |
+| RGBA16 | `Convert` (zenpixels-convert)        | 28.64 ms |
+
+Row-level microbench, 2048-px row, RGBA8 → RGB8:
+
+| implementation                                        | µs / row | speedup |
+|-------------------------------------------------------|---------:|--------:|
+| zenanalyze in-tree scalar strip (pre-2026-04-28)      |     0.96 | 1.0×    |
+| `garb::bytes::rgba_to_rgb` (`incant!` SIMD dispatch)  |     0.13 | **7.4×** |
+| `garb::bytes::bgra_to_rgb` (`incant!` SIMD dispatch)  |     0.13 | 7.3×    |
+
+The previous in-tree strip was a plain `chunks_exact(4)` scalar loop
+that LLVM didn't autovectorize cleanly. Switching `strip_alpha_row`
+to `garb::bytes::{rgba,bgra}_to_rgb` (which dispatches to AVX2 /
+NEON / WASM128 via `archmage::incant!`) cut the RGBA8 analyzer
+overhead vs RGB8 baseline from +5.8 ms to +1.4 ms — strip-alpha is
+no longer the bottleneck on RGBA8 input.
+
+**vs zenpixels-convert.** The `Convert` path on 16-bit input is
+already SIMD-aware (zenpixels-convert routes through garb-style
+primitives) and runs at ~6 ms / MP for the full transfer-function-
+aware narrowing. That path is the right tool for genuinely heterogeneous
+input (16-bit, f32, gray, CMYK, …). For the trivial RGBA8 / BGRA8
+strip-alpha case, the dedicated bypass is ~3× faster than going
+through the full converter.
+
+**vs garb directly for the new analyzer features.** Neither garb nor
+zenpixels-convert exposes a skin-tone classifier or edge-slope
+statistic. The closest alternative would allocate a YCbCr8 row scratch
+and walk it for the gate test — doubling memory traffic vs our inline
+register-resident YCbCr classification with zero arithmetic savings.
+
+Reproduce: `cargo run --release -p zenanalyze --features
+experimental --example edge_skin_bench`.
+
+### What didn't work
+
+A third feature, `flat_block_chroma_luma_noise_ratio`, was prototyped
+in tier3 (sensor-noise discriminator from issue #123) and reverted.
+Empirical AUC = 0.625 — worse than the existing `noise_floor_y`
+(0.794). Root cause documented in
+[issue #123 comment](https://github.com/imazen/zenjpeg/issues/123#issuecomment-4331156178):
+BT.601 chroma matrix cancels the RGB-domain ratio the issue assumed,
+and JPEG 4:2:0 chroma subsampling further suppresses within-block
+chroma stddev. The cheap chroma/luma stddev ratio doesn't recover the
+sensor-noise signal in the corpus we have.

--- a/zenanalyze/examples/corpus_eval.rs
+++ b/zenanalyze/examples/corpus_eval.rs
@@ -1,8 +1,40 @@
-//! Corpus evaluation harness — runs analyze_features over multiple
-//! corpora with FeatureSet::SUPPORTED and dumps every feature to CSV.
+//! Corpus evaluation harness — runs `analyze_features` over one or
+//! more corpora with `FeatureSet::SUPPORTED` and dumps every feature
+//! to CSV on stdout. Used to reproduce the empirical calibration
+//! baseline in `docs/calibration-corpus-2026-04-27.md`.
 //!
-//! NOT FOR COMMIT. Temporary tool used to evaluate just-landed
-//! HDR/depth + Tier1/Tier3 piggyback features.
+//! Two modes, picked via env vars:
+//!
+//! * **Labeled mode** (preferred for calibration). Set
+//!   `LABELS_TSV=/path/to/labels.tsv` to a TSV with at least the
+//!   columns `corpus`, `image`, `primary_category`, `is_synthetic`,
+//!   `palette_size`, `dominant_chroma`, `has_text` (the
+//!   coefficient `benchmarks/classifier-eval/labels.tsv` schema).
+//!   Each row's image is resolved against `CORPUS_ROOT` (defaults
+//!   to `~/work/codec-eval/codec-corpus`) and the per-corpus
+//!   sub-directories listed in `RESOLVE_DIRS` below. Output CSV
+//!   has the label columns inserted before the feature columns.
+//!
+//! * **Unlabeled walk mode** (default if `LABELS_TSV` is unset).
+//!   Walks each corpus root in `CORPORA` and runs the analyzer on
+//!   every PNG / JPEG up to `MAX_PER_CORPUS` images
+//!   (default 120, override via env). Override the corpus list at
+//!   the top of `main()` for one-off runs.
+//!
+//! Build:
+//!
+//! ```sh
+//! cargo build --release -p zenanalyze --features experimental \
+//!   --example corpus_eval
+//! ```
+//!
+//! Run (labeled mode):
+//!
+//! ```sh
+//! LABELS_TSV=path/to/labels.tsv \
+//! CORPUS_ROOT=/path/to/codec-corpus \
+//!   ./target/release/examples/corpus_eval > /tmp/zenanalyze_labeled.csv
+//! ```
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -63,6 +95,8 @@ fn all_features() -> Vec<AnalysisFeature> {
         NoiseFloorY,
         NoiseFloorUV,
         LineArtScore,
+        SkinToneFraction,
+        EdgeSlopeStdev,
     ]
 }
 
@@ -152,30 +186,29 @@ fn main() {
     }
     let query = AnalysisQuery::new(set);
 
+    // Labeled mode: LABELS_TSV=/path/to/labels.tsv emits CSV with label
+    // columns appended. Used for empirical class-conditional recalibration.
+    if let Ok(tsv) = std::env::var("LABELS_TSV") {
+        run_labeled(&tsv, &query, &features);
+        return;
+    }
+
     let mut all_rows: Vec<Row> = Vec::new();
     let max_per_corpus: usize = std::env::var("MAX_PER_CORPUS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(120);
 
-    let corpora: &[(&str, &str)] = &[
-        (
-            "CID22-512",
-            "/home/lilith/work/codec-eval/codec-corpus/CID22/CID22-512",
-        ),
-        (
-            "clic2025-final-test",
-            "/home/lilith/work/codec-eval/codec-corpus/clic2025/final-test",
-        ),
-        ("gb82", "/home/lilith/work/codec-eval/codec-corpus/gb82"),
-        (
-            "gb82-sc",
-            "/home/lilith/work/codec-eval/codec-corpus/gb82-sc",
-        ),
+    let cc = corpus_root();
+    let corpora: Vec<(String, PathBuf)> = vec![
+        ("CID22-512".into(), cc.join("CID22/CID22-512")),
+        ("clic2025-final-test".into(), cc.join("clic2025/final-test")),
+        ("gb82".into(), cc.join("gb82")),
+        ("gb82-sc".into(), cc.join("gb82-sc")),
     ];
 
-    for (name, root) in corpora {
-        let files = list_pngs(Path::new(root), max_per_corpus);
+    for (name, root) in &corpora {
+        let files = list_pngs(root, max_per_corpus);
         eprintln!("{}: {} files", name, files.len());
         for (i, f) in files.iter().enumerate() {
             if let Some(row) = analyze_path(f, name, &query, &features) {
@@ -211,4 +244,115 @@ fn main() {
     }
 
     eprintln!("done — {} rows", all_rows.len());
+}
+
+// ---- labeled mode -----------------------------------------------------
+
+/// Resolve the codec-corpus root from `CORPUS_ROOT` or fall back to
+/// the standard layout under `~/work/codec-eval/codec-corpus`.
+fn corpus_root() -> PathBuf {
+    if let Ok(p) = std::env::var("CORPUS_ROOT") {
+        return PathBuf::from(p);
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/".into());
+    PathBuf::from(home).join("work/codec-eval/codec-corpus")
+}
+
+fn run_labeled(tsv: &str, query: &AnalysisQuery, features: &[AnalysisFeature]) {
+    let cc = corpus_root();
+    // (corpus -> [search dirs relative to corpus_root])
+    let resolve_dirs: &[(&str, &[&str])] = &[
+        ("cid22-train", &["CID22/CID22-512/training", "CID22/CID22-512"]),
+        ("cid22-val", &["CID22/CID22-512/validation", "CID22/CID22-512"]),
+        ("clic2025-1024", &["clic2025-1024", "clic2025/final-test", "clic2025/training"]),
+        ("gb82", &["gb82"]),
+        ("gb82-sc", &["gb82-sc"]),
+        ("imageflow", &["imageflow/test_inputs", "imageflow"]),
+        ("kadid10k", &["kadid10k"]),
+        ("qoi-benchmark", &["qoi-benchmark/screenshot_web", "qoi-benchmark"]),
+        ("corpus", &[""]),
+    ];
+
+    let labels = fs::read_to_string(tsv).expect("read labels");
+    let mut lines = labels.lines();
+    let header = lines.next().expect("header");
+    let cols: Vec<&str> = header.split('\t').collect();
+    let idx_corpus = cols.iter().position(|s| *s == "corpus").unwrap();
+    let idx_image = cols.iter().position(|s| *s == "image").unwrap();
+    let idx_cat = cols.iter().position(|s| *s == "primary_category").unwrap();
+    let idx_synth = cols.iter().position(|s| *s == "is_synthetic").unwrap();
+    let idx_palette = cols.iter().position(|s| *s == "palette_size").unwrap();
+    let idx_chroma = cols.iter().position(|s| *s == "dominant_chroma").unwrap();
+    let idx_text = cols.iter().position(|s| *s == "has_text").unwrap();
+
+    // emit header
+    let mut out_h = String::from("corpus,file,width,height,elapsed_us,primary_category,is_synthetic,palette_size,dominant_chroma,has_text");
+    for &f in features {
+        out_h.push(',');
+        out_h.push_str(f.name());
+    }
+    println!("{}", out_h);
+
+    let mut found = 0usize;
+    let mut missing = 0usize;
+    for line in lines {
+        let f: Vec<&str> = line.split('\t').collect();
+        if f.len() <= idx_text { continue; }
+        let corpus = f[idx_corpus];
+        let img = f[idx_image];
+        let cat = f[idx_cat];
+        let synth = f[idx_synth];
+        let palette = f[idx_palette];
+        let chroma = f[idx_chroma];
+        let text = f[idx_text];
+
+        // resolve path
+        let dirs = resolve_dirs.iter().find(|(c, _)| *c == corpus).map(|(_, d)| *d).unwrap_or(&[]);
+        let mut path: Option<PathBuf> = None;
+        for sub in dirs {
+            let dir = if sub.is_empty() {
+                cc.clone()
+            } else {
+                cc.join(sub)
+            };
+            if !dir.is_dir() { continue; }
+            let mut found_path: Option<PathBuf> = None;
+            walk_find(&dir, img, &mut found_path);
+            if let Some(p) = found_path { path = Some(p); break; }
+        }
+        let Some(p) = path else { missing += 1; eprintln!("MISSING: {}/{}", corpus, img); continue };
+
+        let Some(row) = analyze_path(&p, corpus, query, features) else {
+            eprintln!("ANALYZE_FAIL: {}", p.display());
+            continue;
+        };
+        found += 1;
+        let mut line = format!(
+            "{},{},{},{},{},{},{},{},{},{}",
+            row.corpus, row.file, row.width, row.height, row.elapsed_us,
+            cat, synth, palette, chroma, text,
+        );
+        for v in &row.values {
+            line.push(',');
+            if v.is_nan() { line.push_str("NA"); } else { line.push_str(&format!("{}", v)); }
+        }
+        println!("{}", line);
+        if found % 25 == 0 { eprintln!("  {} rows", found); }
+    }
+    eprintln!("done — {} found, {} missing", found, missing);
+}
+
+fn walk_find(dir: &Path, name: &str, out: &mut Option<PathBuf>) {
+    if out.is_some() { return; }
+    let Ok(rd) = fs::read_dir(dir) else { return };
+    for e in rd.flatten() {
+        if out.is_some() { return; }
+        let p = e.path();
+        if p.is_dir() {
+            walk_find(&p, name, out);
+        } else if p.file_name().and_then(|s| s.to_str()) == Some(name) {
+            *out = Some(p);
+            return;
+        }
+    }
 }

--- a/zenanalyze/examples/edge_skin_bench.rs
+++ b/zenanalyze/examples/edge_skin_bench.rs
@@ -1,0 +1,149 @@
+//! Microbench: comparing zenanalyze's `RowStream` row-fetch paths
+//! (`Native`, `StripAlpha8`, `Convert`) against direct
+//! `zenpixels-convert::RowConverter` use, on the same Tier-1
+//! analyzer workload.
+//!
+//! Run: `cargo run --release -p zenanalyze --features experimental
+//! --example edge_skin_bench`.
+
+use std::time::Instant;
+use zenanalyze::feature::{AnalysisQuery, FeatureSet};
+use zenpixels::{PixelDescriptor, PixelSlice};
+
+fn make_random(n: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; n];
+    let mut state: u32 = 0xdeadbeef;
+    for b in buf.iter_mut() {
+        state = state.wrapping_mul(1103515245).wrapping_add(12345);
+        *b = (state >> 16) as u8;
+    }
+    buf
+}
+
+fn bench(label: &str, mut f: impl FnMut()) {
+    for _ in 0..3 {
+        f();
+    }
+    let n = 30;
+    let t0 = Instant::now();
+    for _ in 0..n {
+        f();
+    }
+    let dt = t0.elapsed();
+    let per = dt.as_secs_f64() * 1e3 / n as f64;
+    println!("  {:50} mean = {:7.3} ms / iter", label, per);
+}
+
+fn main() {
+    println!(
+        "RowStream path microbench, 4 MP image, AVX2 dispatch, no target-cpu=native\n\
+         Workload: `analyze_features` with `FeatureSet::SUPPORTED`\n"
+    );
+    let (w, h) = (2048u32, 2048u32);
+
+    println!("## RGB8 input (RowStream::Native — zero-copy slice subindex)\n");
+    {
+        let buf = make_random((w as usize) * (h as usize) * 3);
+        let stride = (w as usize) * 3;
+        let mk =
+            || PixelSlice::new(&buf, w, h, stride, PixelDescriptor::RGB8_SRGB).unwrap();
+        let q = AnalysisQuery::new(FeatureSet::SUPPORTED);
+        bench("RGB8_SRGB → Native row fetch", || {
+            let _ = zenanalyze::analyze_features(mk(), &q).unwrap();
+        });
+    }
+
+    println!("\n## RGBA8 input (RowStream::StripAlpha8 — tight scalar strip)\n");
+    {
+        let buf = make_random((w as usize) * (h as usize) * 4);
+        let stride = (w as usize) * 4;
+        let mk =
+            || PixelSlice::new(&buf, w, h, stride, PixelDescriptor::RGBA8_SRGB).unwrap();
+        let q = AnalysisQuery::new(FeatureSet::SUPPORTED);
+        bench("RGBA8_SRGB → StripAlpha8", || {
+            let _ = zenanalyze::analyze_features(mk(), &q).unwrap();
+        });
+    }
+
+    println!("\n## BGRA8 input (RowStream::StripAlpha8 — strip + channel swap)\n");
+    {
+        let buf = make_random((w as usize) * (h as usize) * 4);
+        let stride = (w as usize) * 4;
+        let mk =
+            || PixelSlice::new(&buf, w, h, stride, PixelDescriptor::BGRA8_SRGB).unwrap();
+        let q = AnalysisQuery::new(FeatureSet::SUPPORTED);
+        bench("BGRA8_SRGB → StripAlpha8", || {
+            let _ = zenanalyze::analyze_features(mk(), &q).unwrap();
+        });
+    }
+
+    println!(
+        "\n## RGB16 input (RowStream::Convert — zenpixels-convert RowConverter)\n"
+    );
+    {
+        let buf = make_random((w as usize) * (h as usize) * 6);
+        let stride = (w as usize) * 6;
+        let mk =
+            || PixelSlice::new(&buf, w, h, stride, PixelDescriptor::RGB16_SRGB).unwrap();
+        let q = AnalysisQuery::new(FeatureSet::SUPPORTED);
+        bench("RGB16_SRGB → Convert (zenpixels-convert)", || {
+            let _ = zenanalyze::analyze_features(mk(), &q).unwrap();
+        });
+    }
+
+    println!(
+        "\n## RGBA16 input (RowStream::Convert — zenpixels-convert handles strip + narrowing)\n"
+    );
+    {
+        let buf = make_random((w as usize) * (h as usize) * 8);
+        let stride = (w as usize) * 8;
+        let mk =
+            || PixelSlice::new(&buf, w, h, stride, PixelDescriptor::RGBA16_SRGB).unwrap();
+        let q = AnalysisQuery::new(FeatureSet::SUPPORTED);
+        bench("RGBA16_SRGB → Convert", || {
+            let _ = zenanalyze::analyze_features(mk(), &q).unwrap();
+        });
+    }
+
+    println!(
+        "\n## Row-level microbench: zenanalyze scalar strip vs garb SIMD strip\n\
+         (One row, 2048 px wide, RGBA8 → RGB8.)\n"
+    );
+    {
+        let row_bytes_in = (w as usize) * 4;
+        let row_bytes_out = (w as usize) * 3;
+        let src = make_random(row_bytes_in);
+        let mut dst = vec![0u8; row_bytes_out];
+        bench_row("zenanalyze strip_alpha_row (scalar, plain loop)", || {
+            // mirror the strip_alpha_row scalar pattern
+            let r = 0usize;
+            let g = 1usize;
+            let b = 2usize;
+            for (s, d) in src.chunks_exact(4).zip(dst.chunks_exact_mut(3)) {
+                d[0] = s[r];
+                d[1] = s[g];
+                d[2] = s[b];
+            }
+        });
+        bench_row("garb::bytes::rgba_to_rgb (incant! SIMD dispatch)", || {
+            garb::bytes::rgba_to_rgb(&src, &mut dst).unwrap();
+        });
+        bench_row("garb::bytes::bgra_to_rgb (incant! SIMD dispatch)", || {
+            garb::bytes::bgra_to_rgb(&src, &mut dst).unwrap();
+        });
+    }
+}
+
+fn bench_row(label: &str, mut f: impl FnMut()) {
+    for _ in 0..1000 {
+        f();
+    }
+    let n = 100_000usize;
+    let t0 = Instant::now();
+    for _ in 0..n {
+        f();
+    }
+    let dt = t0.elapsed();
+    let per_us = dt.as_secs_f64() * 1e6 / n as f64;
+    println!("  {:55} mean = {:7.3} µs / row", label, per_us);
+}

--- a/zenanalyze/examples/tier1_bench.rs
+++ b/zenanalyze/examples/tier1_bench.rs
@@ -24,10 +24,22 @@ fn bench(label: &str, iters: usize, mut f: impl FnMut()) {
 }
 
 fn main() {
-    // Tier 1 only: just request one Tier 1 feature so other tiers
-    // skip themselves.
     let q_t1 = AnalysisQuery::new(FeatureSet::just(AnalysisFeature::Variance));
     let q_all = AnalysisQuery::new(FeatureSet::SUPPORTED);
+    // zenjpeg's actual ADAPTIVE_FEATURES — the realistic orchestrator
+    // hot path that drives Bucket-dispatch design choices.
+    let mut zj = FeatureSet::new();
+    zj = zj.with(AnalysisFeature::ChromaComplexity);
+    zj = zj.with(AnalysisFeature::CbPeakSharpness);
+    zj = zj.with(AnalysisFeature::CrPeakSharpness);
+    zj = zj.with(AnalysisFeature::Uniformity);
+    zj = zj.with(AnalysisFeature::FlatColorBlockRatio);
+    zj = zj.with(AnalysisFeature::EdgeDensity);
+    zj = zj.with(AnalysisFeature::HighFreqEnergyRatio);
+    zj = zj.with(AnalysisFeature::TextLikelihood);
+    zj = zj.with(AnalysisFeature::ScreenContentLikelihood);
+    zj = zj.with(AnalysisFeature::NaturalLikelihood);
+    let q_zj = AnalysisQuery::new(zj);
 
     for (label, w, h) in [
         ("1 MP   1024x1024", 1024u32, 1024u32),
@@ -41,12 +53,12 @@ fn main() {
 
         let iters = if w >= 4096 { 10 } else { 30 };
 
-        // Tier 1 only
         bench("Tier 1 only (Variance)", iters, || {
             let _ = zenanalyze::analyze_features(mk(), &q_t1).unwrap();
         });
-
-        // Full pipeline
+        bench("zenjpeg ADAPTIVE_FEATURES", iters, || {
+            let _ = zenanalyze::analyze_features(mk(), &q_zj).unwrap();
+        });
         bench("FeatureSet::SUPPORTED", iters, || {
             let _ = zenanalyze::analyze_features(mk(), &q_all).unwrap();
         });

--- a/zenanalyze/examples/tier1_bench.rs
+++ b/zenanalyze/examples/tier1_bench.rs
@@ -1,0 +1,54 @@
+//! Tier 1 hot-path microbench. Measures Tier-1-only cost at 1/4/16 MP
+//! to identify where the mass lives.
+use std::time::Instant;
+use zenanalyze::feature::{AnalysisFeature, AnalysisQuery, FeatureSet};
+use zenpixels::{PixelDescriptor, PixelSlice};
+
+fn make_random(n: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; n];
+    let mut s: u32 = 0xdeadbeef;
+    for b in buf.iter_mut() {
+        s = s.wrapping_mul(1103515245).wrapping_add(12345);
+        *b = (s >> 16) as u8;
+    }
+    buf
+}
+
+fn bench(label: &str, iters: usize, mut f: impl FnMut()) {
+    for _ in 0..3 { f(); }
+    let t0 = Instant::now();
+    for _ in 0..iters { f(); }
+    let dt = t0.elapsed();
+    let per = dt.as_secs_f64() * 1e3 / iters as f64;
+    println!("  {:55} mean = {:7.3} ms / iter", label, per);
+}
+
+fn main() {
+    // Tier 1 only: just request one Tier 1 feature so other tiers
+    // skip themselves.
+    let q_t1 = AnalysisQuery::new(FeatureSet::just(AnalysisFeature::Variance));
+    let q_all = AnalysisQuery::new(FeatureSet::SUPPORTED);
+
+    for (label, w, h) in [
+        ("1 MP   1024x1024", 1024u32, 1024u32),
+        ("4 MP   2048x2048", 2048u32, 2048u32),
+        ("16 MP  4096x4096", 4096u32, 4096u32),
+    ] {
+        println!("\n=== {} ===", label);
+        let buf = make_random((w as usize) * (h as usize) * 3);
+        let stride = (w as usize) * 3;
+        let mk = || PixelSlice::new(&buf, w, h, stride, PixelDescriptor::RGB8_SRGB).unwrap();
+
+        let iters = if w >= 4096 { 10 } else { 30 };
+
+        // Tier 1 only
+        bench("Tier 1 only (Variance)", iters, || {
+            let _ = zenanalyze::analyze_features(mk(), &q_t1).unwrap();
+        });
+
+        // Full pipeline
+        bench("FeatureSet::SUPPORTED", iters, || {
+            let _ = zenanalyze::analyze_features(mk(), &q_all).unwrap();
+        });
+    }
+}

--- a/zenanalyze/src/feature.rs
+++ b/zenanalyze/src/feature.rs
@@ -400,6 +400,7 @@ features_table! {
     /// for screen-like classification). Do not threshold at `>= 0.8`
     /// — nothing fires there. See
     /// `docs/calibration-corpus-2026-04-27.md`.
+    #[cfg(feature = "composites")]
     TextLikelihood = 27 : f32 => text_likelihood,
     /// `f32`. Soft score: UI / chart / synthetic content.
     ///
@@ -414,6 +415,7 @@ features_table! {
     /// discriminator, see [`Self::PatchFraction`] (AUC = 0.88) which
     /// outperforms this derived likelihood (AUC = 0.83). See
     /// `docs/calibration-corpus-2026-04-27.md`.
+    #[cfg(feature = "composites")]
     ScreenContentLikelihood = 28 : f32 => screen_content_likelihood,
     /// `f32`. Soft score: natural photographic content.
     ///
@@ -424,6 +426,7 @@ features_table! {
     /// classification. Equivalent to a probability — high values
     /// reliably mean photo. See
     /// `docs/calibration-corpus-2026-04-27.md`.
+    #[cfg(feature = "composites")]
     NaturalLikelihood = 29 : f32 => natural_likelihood,
 
     // ---------------- Quick-path palette signals --------------------
@@ -582,7 +585,10 @@ features_table! {
     /// `Preset::Drawing`, jxl modular path selection, png palette
     /// preference. Distinct from `ScreenContentLikelihood` (which is
     /// driven by palette and high-frequency energy).
-    #[cfg(feature = "experimental")]
+    ///
+    /// Behind the `composites` cargo feature: the combinator
+    /// coefficients are calibration-driven and may drift in 0.1.x.
+    #[cfg(feature = "composites")]
     LineArtScore = 45 : f32 => line_art_score,
 
     /// `f32`. Fraction `[0, 1]` of sampled pixels in the canonical
@@ -1000,6 +1006,70 @@ pub(crate) const PALETTE_QUICK_FEATURES: FeatureSet = {
 /// (which produces both signal classes).
 pub(crate) const PALETTE_FEATURES: FeatureSet = PALETTE_FULL_FEATURES.union(PALETTE_QUICK_FEATURES);
 
+/// Tier 1 "extras" — the optional accumulators that elevate the
+/// SIMD kernel from `Minimal` to `Full`. When the requested
+/// `FeatureSet` doesn't intersect this set, `accumulate_row_simd`
+/// is dispatched as `<FULL = false>` and skips the per-chunk
+/// luma_sum / Hasler-Süsstrunk M3 (rg/yb) / skin-tone / edge-slope
+/// accumulators — and `extract_tier1_into` skips the separate
+/// Laplacian SIMD row pass entirely. Drops ~10 lane-wise f32x8
+/// accumulators on AVX2, freeing register pressure on the Tier 1
+/// hot path.
+///
+/// Driven by zenjpeg's actual `ADAPTIVE_FEATURES` query — neither
+/// `Variance`, `Colourfulness`, `LaplacianVariance`,
+/// `SkinToneFraction`, nor `EdgeSlopeStdev` is in that set, so
+/// every zenjpeg analyze call lands in the `Minimal` bucket.
+#[allow(unused_mut, unused_assignments)]
+pub(crate) const TIER1_EXTRAS_FEATURES: FeatureSet = {
+    let mut s = FeatureSet::new();
+    s = s.with(AnalysisFeature::Variance);
+    #[cfg(feature = "experimental")]
+    {
+        s = s.with(AnalysisFeature::Colourfulness);
+        s = s.with(AnalysisFeature::LaplacianVariance);
+        s = s.with(AnalysisFeature::SkinToneFraction);
+        s = s.with(AnalysisFeature::EdgeSlopeStdev);
+    }
+    s
+};
+
+/// Subset of [`TIER1_EXTRAS_FEATURES`] gated by the
+/// `accumulate_row_simd` `FULL` const-bool: luma stats (Variance) +
+/// Hasler M3 (Colourfulness) + edge-slope batching
+/// (EdgeSlopeStdev) + the separate Laplacian SIMD pass
+/// (LaplacianVariance). `SkinToneFraction` is peeled off into
+/// [`TIER1_SKIN_FEATURES`] so the two halves share register
+/// pressure on AVX2 only when both are requested.
+#[allow(unused_mut, unused_assignments)]
+pub(crate) const TIER1_FULL_FEATURES: FeatureSet = {
+    let mut s = FeatureSet::new();
+    s = s.with(AnalysisFeature::Variance);
+    #[cfg(feature = "experimental")]
+    {
+        s = s.with(AnalysisFeature::Colourfulness);
+        s = s.with(AnalysisFeature::LaplacianVariance);
+        s = s.with(AnalysisFeature::EdgeSlopeStdev);
+    }
+    s
+};
+
+/// Subset of [`TIER1_EXTRAS_FEATURES`] gated by the
+/// `accumulate_row_simd` `SKIN` const-bool: BT.601 chroma matrix
+/// (2 fma chains) + 6 Chai-Ngan threshold compares + 5 mask
+/// AND-chain + masked counter. Independent of `FULL` — a caller
+/// that only wants `SkinToneFraction` dispatches with
+/// `<*, false, true>` and skips luma stats / Hasler M3 entirely.
+#[allow(unused_mut, unused_assignments)]
+pub(crate) const TIER1_SKIN_FEATURES: FeatureSet = {
+    let mut s = FeatureSet::new();
+    #[cfg(feature = "experimental")]
+    {
+        s = s.with(AnalysisFeature::SkinToneFraction);
+    }
+    s
+};
+
 pub(crate) const TIER2_FEATURES: FeatureSet = FeatureSet::new()
     .with(AnalysisFeature::CbHorizSharpness)
     .with(AnalysisFeature::CbVertSharpness)
@@ -1008,6 +1078,7 @@ pub(crate) const TIER2_FEATURES: FeatureSet = FeatureSet::new()
     .with(AnalysisFeature::CrVertSharpness)
     .with(AnalysisFeature::CrPeakSharpness);
 
+#[allow(unused_mut, unused_assignments)]
 pub(crate) const TIER3_FEATURES: FeatureSet = {
     let mut s = FeatureSet::new();
     s = s.with(AnalysisFeature::HighFreqEnergyRatio);
@@ -1021,8 +1092,11 @@ pub(crate) const TIER3_FEATURES: FeatureSet = {
         s = s.with(AnalysisFeature::AqMapStd);
         s = s.with(AnalysisFeature::NoiseFloorY);
         s = s.with(AnalysisFeature::NoiseFloorUV);
-        s = s.with(AnalysisFeature::LineArtScore);
         s = s.with(AnalysisFeature::GradientFraction);
+    }
+    #[cfg(feature = "composites")]
+    {
+        s = s.with(AnalysisFeature::LineArtScore);
     }
     s
 };
@@ -1056,10 +1130,17 @@ pub(crate) const DEPTH_FEATURES: FeatureSet = {
     s
 };
 
-pub(crate) const DERIVED_FEATURES: FeatureSet = FeatureSet::new()
-    .with(AnalysisFeature::TextLikelihood)
-    .with(AnalysisFeature::ScreenContentLikelihood)
-    .with(AnalysisFeature::NaturalLikelihood);
+#[allow(unused_mut, unused_assignments)]
+pub(crate) const DERIVED_FEATURES: FeatureSet = {
+    let mut s = FeatureSet::new();
+    #[cfg(feature = "composites")]
+    {
+        s = s.with(AnalysisFeature::TextLikelihood);
+        s = s.with(AnalysisFeature::ScreenContentLikelihood);
+        s = s.with(AnalysisFeature::NaturalLikelihood);
+    }
+    s
+};
 
 // --- Derived-feature dependency closures ----------------------------
 //
@@ -1080,9 +1161,16 @@ pub(crate) const DERIVED_FEATURES: FeatureSet = FeatureSet::new()
 /// - [`AnalysisFeature::NaturalLikelihood`] (uses `luma_histogram_entropy`).
 ///
 /// `ScreenContentLikelihood` is **not** here — it's palette + T1 only.
-pub(crate) const T3_NEEDED_BY: FeatureSet = TIER3_FEATURES
-    .with(AnalysisFeature::TextLikelihood)
-    .with(AnalysisFeature::NaturalLikelihood);
+#[allow(unused_mut, unused_assignments)]
+pub(crate) const T3_NEEDED_BY: FeatureSet = {
+    let mut s = TIER3_FEATURES;
+    #[cfg(feature = "composites")]
+    {
+        s = s.with(AnalysisFeature::TextLikelihood);
+        s = s.with(AnalysisFeature::NaturalLikelihood);
+    }
+    s
+};
 
 /// Features whose computation reads from palette outputs
 /// (`distinct_color_bins`). Includes:
@@ -1091,9 +1179,16 @@ pub(crate) const T3_NEEDED_BY: FeatureSet = TIER3_FEATURES
 /// - [`AnalysisFeature::NaturalLikelihood`] (uses `distinct_color_bins`).
 ///
 /// `TextLikelihood` is **not** here — it's T3-entropy + T1 only.
-pub(crate) const PAL_NEEDED_BY: FeatureSet = PALETTE_FEATURES
-    .with(AnalysisFeature::ScreenContentLikelihood)
-    .with(AnalysisFeature::NaturalLikelihood);
+#[allow(unused_mut, unused_assignments)]
+pub(crate) const PAL_NEEDED_BY: FeatureSet = {
+    let mut s = PALETTE_FEATURES;
+    #[cfg(feature = "composites")]
+    {
+        s = s.with(AnalysisFeature::ScreenContentLikelihood);
+        s = s.with(AnalysisFeature::NaturalLikelihood);
+    }
+    s
+};
 
 // `RawAnalysis` and `into_results` are generated by the
 // `features_table!` invocation at the top of this file.

--- a/zenanalyze/src/feature.rs
+++ b/zenanalyze/src/feature.rs
@@ -349,21 +349,32 @@ features_table! {
     #[cfg(feature = "experimental")]
     DctCompressibilityUV = 22 : f32 => dct_compressibility_uv,
     /// `f32`. Fraction `[0, 1]` of sampled blocks matching another.
-    /// Strong photo-vs-screen-content discriminator.
+    /// Strongest single photo-vs-screen-content discriminator on
+    /// real corpora.
     ///
-    /// Empirically validated on a 50-photo / 10-screen corpus
-    /// (CID22-512 + CLIC2025-final + gb82-sc): default-budget
-    /// classifier ROC-AUC = 0.978 (vs 0.980 at dense scan), and
-    /// Spearman ρ between default and dense = 0.887 — rank order is
-    /// preserved across the full image set. Photos cluster below
-    /// 0.05; screen content sits above 0.7. The earlier "57 % p50
-    /// error" measurement was relative error blowing up on photos
-    /// near zero; absolute error is p50=0.010 / p90=0.039, well
-    /// below any sensible classification threshold.
+    /// **Empirical AUC = 0.880** for screen-vs-photo on a 219-image
+    /// labeled corpus (cid22 + clic2025 + gb82 + gb82-sc + imageflow
+    /// + kadid10k + qoi-benchmark) — higher than every other shipped
+    /// feature, including the derived [`Self::ScreenContentLikelihood`]
+    /// (AUC 0.83). Photos: p50 = 0.002, p90 = 0.037. Screens: p50 =
+    /// 0.726, p90 = 0.906. **Recommended operating threshold:
+    /// `patch_fraction >= 0.27`** (F1 = 0.769, P = 0.91, R = 0.67)
+    /// for screen-like classification.
     ///
-    /// Bumping `hf_max_blocks` to 4096+ tightens the absolute error
-    /// further but doesn't materially improve the classifier — the
-    /// 1024-block default is fit for codec dispatch as shipped.
+    /// Originally validated on a smaller 50-photo / 10-screen pilot
+    /// corpus where the default-budget classifier scored ROC-AUC =
+    /// 0.978 (vs 0.980 at dense scan) and Spearman ρ between
+    /// default and dense = 0.887. The 219-image labeled-corpus AUC
+    /// is lower because that corpus includes screen-like
+    /// illustrations and edge-case "uniform photos" that genuinely
+    /// sit closer to the boundary; the rank order remains correct
+    /// and the 1024-block default budget is fit for codec dispatch
+    /// as shipped.
+    ///
+    /// Bumping `hf_max_blocks` to 4096+ tightens absolute error
+    /// further but doesn't materially improve the classifier — see
+    /// `docs/calibration-corpus-2026-04-27.md` for the full
+    /// per-class distribution and AUC ranking.
     ///
     /// Gated behind `experimental` for 0.1.0 because no in-tree
     /// codec consumes it yet; promote when a consumer wires up.
@@ -379,11 +390,40 @@ features_table! {
     AlphaBimodalScore = 26 : f32 => alpha_bimodal_score,
 
     // ---------------- Derived likelihoods ----------------------------
-    /// `f32`. Soft `[0, 1]` score: rendered text / document content.
+    /// `f32`. Soft score: rendered text / document content.
+    ///
+    /// Theoretical range `[0, 1]`. **Empirical max on a 219-image
+    /// labeled corpus: 0.71** — the formula's three sub-components
+    /// (low entropy + high edge density + low chroma) don't all max
+    /// simultaneously on real content. Recommended operating
+    /// threshold: `text_likelihood >= 0.30` (F1 = 0.682, AUC = 0.774
+    /// for screen-like classification). Do not threshold at `>= 0.8`
+    /// — nothing fires there. See
+    /// `docs/calibration-corpus-2026-04-27.md`.
     TextLikelihood = 27 : f32 => text_likelihood,
-    /// `f32`. Soft `[0, 1]` score: UI / chart / synthetic content.
+    /// `f32`. Soft score: UI / chart / synthetic content.
+    ///
+    /// Theoretical range `[0, 1]`. **Empirical max on a 219-image
+    /// labeled corpus: 0.70** — typical screen content has flat
+    /// blocks and low chroma (which drive the formula's 0.6 + 0.1
+    /// weights to 1) but a moderate distinct-color count (>= 4000
+    /// bins) which forces the `palette_small` term to 0, capping the
+    /// total at ~0.70. Recommended operating threshold:
+    /// `screen_content_likelihood >= 0.60` (F1 = 0.750, P = 0.86,
+    /// R = 0.67). For the strongest single screen-vs-photo
+    /// discriminator, see [`Self::PatchFraction`] (AUC = 0.88) which
+    /// outperforms this derived likelihood (AUC = 0.83). See
+    /// `docs/calibration-corpus-2026-04-27.md`.
     ScreenContentLikelihood = 28 : f32 => screen_content_likelihood,
-    /// `f32`. Soft `[0, 1]` score: natural photographic content.
+    /// `f32`. Soft score: natural photographic content.
+    ///
+    /// Theoretical range `[0, 1]`. **Empirical max on a 219-image
+    /// labeled corpus: 0.69**, and photos cleanly separate from
+    /// screens at a low threshold: `natural_likelihood >= 0.06`
+    /// gives F1 = 0.924, P = 0.876, R = 0.977 for photo
+    /// classification. Equivalent to a probability — high values
+    /// reliably mean photo. See
+    /// `docs/calibration-corpus-2026-04-27.md`.
     NaturalLikelihood = 29 : f32 => natural_likelihood,
 
     // ---------------- Quick-path palette signals --------------------
@@ -544,6 +584,105 @@ features_table! {
     /// driven by palette and high-frequency energy).
     #[cfg(feature = "experimental")]
     LineArtScore = 45 : f32 => line_art_score,
+
+    /// `f32`. Fraction `[0, 1]` of sampled pixels in the canonical
+    /// chrominance-only skin-tone region. The chroma gates are
+    /// **invariant to skin pigmentation** (Cb / Cr quantify hue, not
+    /// brightness), so the same thresholds work across light, medium,
+    /// and dark skin. Luma covers a wide range to span every tone:
+    ///
+    /// - `Y  ∈ [40,  240]` — spans deep shadow on dark skin to bright
+    ///   highlight on light skin without rejecting either end
+    /// - `Cb ∈ [77,  127]` — Chai & Ngan (1999) chrominance bound
+    /// - `Cr ∈ [133, 173]` — Chai & Ngan (1999) chrominance bound
+    ///
+    /// Computed per-pixel in Tier 1 alongside the existing grayscale
+    /// counter, reusing the BT.601 fixed-point YCbCr conversion. Zero
+    /// added allocations; ~2 ns/pixel on a 7950X.
+    ///
+    /// **One-direction signal.** Non-zero fraction is strong evidence
+    /// of a natural photograph (humans, animals, food). Zero fraction
+    /// is **not** evidence against a photograph — landscapes,
+    /// architecture, and macro shots without skin tones all score
+    /// zero. Use as a positive-only confirmation, never as a negative
+    /// classifier.
+    ///
+    /// **Why YCbCr instead of CIELAB.** CIELAB skin classifiers
+    /// (Garcia & Tziritas 1999) outperform YCbCr by ~2 percentage
+    /// points on standard skin-detection benchmarks but cost a
+    /// non-linear sRGB → XYZ → LAB conversion per pixel. The Chai-Ngan
+    /// YCbCr classifier is within ~5 % of LAB at zero extra
+    /// arithmetic — already paid for by `chroma_complexity`,
+    /// `cb_sharpness`, and the BT.601 luma the analyzer needs anyway.
+    ///
+    /// **Empirical ranges** (from a 219-image labeled corpus —
+    /// `docs/calibration-corpus-2026-04-27.md`):
+    ///
+    /// - `photo_natural`:   p10 = 0.009, p50 = 0.130, p90 = 0.543
+    /// - `photo_portrait`:  p10 = 0.047, p50 = 0.241, p90 = 0.541 — 94 % > 1 %
+    /// - `photo_detailed`:  p10 = 0.021, p50 = 0.300, p90 = 0.470
+    /// - `screen_document`: p10 = 0.000, p50 = 0.006, p90 = 0.077
+    /// - `screen_ui`:       p10 = 0.000, p50 = 0.027, p90 = 0.127
+    /// - `illustration`:    p10 = 0.001, p50 = 0.081, p90 = 0.323
+    ///
+    /// AUC = `0.799` for photo-vs-other classification — comparable
+    /// to [`Self::NaturalLikelihood`] (0.814).
+    ///
+    /// **Operating threshold:** `skin_tone_fraction >= 0.05` gives
+    /// `P = 0.89, R = 0.76, F1 = 0.82` for photo classification.
+    /// Lower thresholds (`> 0`) maximize recall (`F1 = 0.882`).
+    ///
+    /// References: Chai & Ngan, "Face segmentation using skin-color
+    /// map in videophone applications", IEEE TCSVT 1999;
+    /// Vezhnevets et al., "A Survey on Pixel-Based Skin Color
+    /// Detection Techniques", Graphicon 2003.
+    #[cfg(feature = "experimental")]
+    SkinToneFraction = 49 : f32 => skin_tone_fraction,
+
+    /// `f32`. Standard deviation of luma gradient magnitudes across
+    /// pixels that crossed the [`Self::EdgeDensity`] threshold
+    /// (`|∇L|² > 400`, i.e. `|∇L| > 20`). Range `[0, ~150]` on the
+    /// 0–255 luma scale.
+    ///
+    /// Tier 1 piggyback: the same SIMD edge sweep that produces
+    /// `edge_density` accumulates `Σ g` and `Σ g²` over the threshold-
+    /// crossing subset. Stddev is computed at row close from those
+    /// running sums. Returns `0.0` if zero edges crossed (smooth
+    /// image or below-threshold-only gradients).
+    ///
+    /// **Physical signal.** Natural photographs have edges anti-
+    /// aliased by lens MTF + sensor pixel pitch — gradient magnitudes
+    /// cluster tightly around the optical cutoff (typical stddev
+    /// ~`8–18` on 0–255 luma). Digital artwork has either no edges
+    /// (smooth gradients), single-pixel edges (line art — already
+    /// caught by [`Self::LineArtScore`]), or **bimodal** gradients
+    /// from variable-pressure brushwork or stylization (typical
+    /// stddev `> 25`). JPEG-roundtripped artwork's blocking artifacts
+    /// also widen this stddev relative to a pristine PNG photograph.
+    ///
+    /// **Empirical ranges** (from a 219-image labeled corpus —
+    /// `docs/calibration-corpus-2026-04-27.md`):
+    ///
+    /// - `photo_natural`:   p10 = 15.9, p50 = 24.2, p90 = 31.8
+    /// - `photo_portrait`:  p10 = 15.3, p50 = 20.7, p90 = 27.0
+    /// - `photo_detailed`:  p10 = 18.2, p50 = 23.1, p90 = 32.0
+    /// - `illustration`:    p10 = 12.9, p50 = 20.9, p90 = 26.7
+    /// - `screen_document`: p10 = 42.0, p50 = 55.3, p90 = 57.5
+    /// - `screen_ui`:       p10 = 31.6, p50 = 42.1, p90 = 54.4
+    ///
+    /// AUC = `0.843` for screen-vs-photo classification (high values →
+    /// screen content). The strongest single screen-content signal
+    /// after [`Self::PatchFraction`].
+    ///
+    /// **Operating thresholds:**
+    /// - `edge_slope_stdev > 35` ⇒ very likely screen / chart / UI
+    /// - `15 ≤ edge_slope_stdev ≤ 32` ⇒ photographic-edge distribution
+    /// - `< 15` with low [`Self::EdgeDensity`] ⇒ smooth content
+    ///   (illustrations or low-detail photos overlap here, ~13–27)
+    ///
+    /// Tracks the issue #123 proposal `EdgeSlopeStdev`.
+    #[cfg(feature = "experimental")]
+    EdgeSlopeStdev = 50 : f32 => edge_slope_stdev,
 }
 
 /// A scalar feature value — discriminated by the value type, not by
@@ -829,6 +968,12 @@ pub(crate) const PALETTE_FULL_FEATURES: FeatureSet = {
     #[cfg(feature = "experimental")]
     {
         s = s.with(AnalysisFeature::PaletteDensity);
+        // GrayscaleScore is computed on the same full-scan walk that
+        // builds the palette histogram. It needs 100 % coverage —
+        // stripe-sampling at ~5 % budget would let a single colour
+        // pixel slip past the gate ~95 % of the time and produce a
+        // false-positive grayscale classification.
+        s = s.with(AnalysisFeature::GrayscaleScore);
     }
     s
 };

--- a/zenanalyze/src/feature.rs
+++ b/zenanalyze/src/feature.rs
@@ -312,13 +312,21 @@ features_table! {
     CbHorizSharpness = 13 : f32 => cb_horiz_sharpness,
     /// `f32`. Cb vertical gradient energy / 1e5.
     CbVertSharpness = 14 : f32 => cb_vert_sharpness,
-    /// `f32`. Cb peak gradient magnitude on `[0, 100]`.
+    /// `f32`. Cb peak gradient magnitude. Calibrated so natural
+    /// photographic content lands `< 100`; saturated synthetic
+    /// inputs (alternating-channel chroma stripes) can reach
+    /// `~666`. Renormalising onto a stable `[0, 100]` ceiling is a
+    /// follow-up calibration task — until then, code that wants
+    /// "is this peak unusually high?" should compare against a
+    /// content-class-appropriate threshold rather than clamping.
     CbPeakSharpness = 15 : f32 => cb_peak_sharpness,
     /// `f32`. Cr horizontal gradient energy / 1e5.
     CrHorizSharpness = 16 : f32 => cr_horiz_sharpness,
     /// `f32`. Cr vertical gradient energy / 1e5.
     CrVertSharpness = 17 : f32 => cr_vert_sharpness,
-    /// `f32`. Cr peak gradient magnitude on `[0, 100]`.
+    /// `f32`. Cr peak gradient magnitude. Same calibration story as
+    /// [`Self::CbPeakSharpness`] — natural photographs `< 100`,
+    /// saturated synthetic content up to `~666`.
     CrPeakSharpness = 18 : f32 => cr_peak_sharpness,
 
     // ---------------- Tier 3: DCT energy + entropy -------------------
@@ -326,10 +334,18 @@ features_table! {
     HighFreqEnergyRatio = 19 : f32 => high_freq_energy_ratio,
     /// `f32`. Shannon entropy of a 32-bin luma histogram, in bits.
     LumaHistogramEntropy = 20 : f32 => luma_histogram_entropy,
-    /// `f32`. libwebp α on luma DCT blocks. `[0, 255]`.
+    /// `f32`. Mean libwebp α on sampled luma 8×8 DCT blocks. Higher
+    /// = harder to compress (more spread AC, fewer near-zero coefs).
+    /// **Range:** theoretical `[0, ~8064]` from `256 * last_non_zero
+    /// / max_count`; on real photo corpora the median sits at ~16,
+    /// p90 at ~30. Downstream calibration must NOT clamp / normalise
+    /// against 255 (earlier docs were wrong about that).
     #[cfg(feature = "experimental")]
     DctCompressibilityY = 21 : f32 => dct_compressibility_y,
-    /// `f32`. libwebp α on chroma DCT blocks (max of Cb/Cr).
+    /// `f32`. Same shape on chroma DCT blocks, `max(α_cb, α_cr)` per
+    /// block. Same `[0, ~8064]` theoretical range; chroma values run
+    /// lower in practice (median ~5 on photos). Scale matches
+    /// [`Self::DctCompressibilityY`].
     #[cfg(feature = "experimental")]
     DctCompressibilityUV = 22 : f32 => dct_compressibility_uv,
     /// `f32`. Fraction `[0, 1]` of sampled blocks matching another.

--- a/zenanalyze/src/feature.rs
+++ b/zenanalyze/src/feature.rs
@@ -1,7 +1,10 @@
-//! **DRAFT — not yet wired into the crate.** Public-API surface for
-//! the next major (0.x → 0.y) of zenanalyze: a stable, opaque,
-//! set-composable feature interface that lets multiple codecs share
-//! one analysis pass.
+//! Public API surface: a stable, opaque, set-composable feature
+//! interface that lets multiple codecs share one analysis pass.
+//!
+//! **Stability contract: there is no 0.2.x.** Every change in 0.1.x
+//! is additive — new variants on `#[non_exhaustive]` enums, new
+//! parallel functions, never a signature change to a shipped item.
+//! See `CLAUDE.md`.
 //!
 //! Stability contract:
 //! - [`AnalysisFeature`] discriminants are **immutable once shipped**.

--- a/zenanalyze/src/lib.rs
+++ b/zenanalyze/src/lib.rs
@@ -130,6 +130,7 @@
 
 mod alpha;
 pub mod feature;
+pub(crate) mod luma;
 mod palette;
 pub(crate) mod row_stream;
 pub(crate) mod tier1;

--- a/zenanalyze/src/lib.rs
+++ b/zenanalyze/src/lib.rs
@@ -372,6 +372,28 @@ pub fn analyze_features(
     #[cfg(not(feature = "experimental"))]
     let palette_wants_grayscale = false;
 
+    // Tier 1 dispatch: skip the separate Laplacian SIMD row pass
+    // when LaplacianVariance isn't requested. Load-bearing for
+    // orchestrator-style callers like zenjpeg's ADAPTIVE_FEATURES,
+    // which doesn't ask for LaplacianVariance and currently pays
+    // the full cost of the separate SIMD row walk anyway.
+    #[cfg(feature = "experimental")]
+    let tier1_wants_laplacian = features.contains(feature::AnalysisFeature::LaplacianVariance);
+    #[cfg(not(feature = "experimental"))]
+    let tier1_wants_laplacian = false;
+
+    // Tier 1 full-kernel gate: flip on for `Variance` /
+    // `Colourfulness` / `EdgeSlopeStdev` / `LaplacianVariance` — the
+    // accumulators inside `accumulate_row_simd`'s `if FULL` block.
+    // See `feature::TIER1_FULL_FEATURES`.
+    let tier1_full_kernel = features.intersects(feature::TIER1_FULL_FEATURES);
+    // Tier 1 skin-gate: peeled off `wants_full_kernel` so callers
+    // that only want `SkinToneFraction` don't pay for Variance /
+    // Colourfulness / edge-slope, and vice versa. The BT.601 chroma
+    // matrix + Chai-Ngan thresholds spent 12 vmovups + 13 broadcasts
+    // of register-spill traffic when bundled — see `cargo asm` audit.
+    let tier1_wants_skin = features.intersects(feature::TIER1_SKIN_FEATURES);
+
     // Depth tier is a runtime axis (not const-bool) — adding it to
     // the 16-arm dispatch would double to 32 arms for one extra
     // pass with negligible LLVM monomorphization wins. The depth
@@ -391,6 +413,9 @@ pub fn analyze_features(
                 feature::DEFAULT_HF_MAX_BLOCKS,
                 palette_full_required,
                 palette_wants_grayscale,
+                tier1_wants_laplacian,
+                tier1_full_kernel,
+                tier1_wants_skin,
                 run_depth,
             )?;
             Ok(raw.into_results(features, geometry, source_descriptor))
@@ -440,6 +465,9 @@ fn analyze_specialized_raw<const PAL: bool, const T2: bool, const T3: bool, cons
     hf_max_blocks: usize,
     palette_full_required: bool,
     palette_wants_grayscale: bool,
+    tier1_wants_laplacian: bool,
+    tier1_full_kernel: bool,
+    tier1_wants_skin: bool,
     run_depth: bool,
 ) -> Result<(feature::RawAnalysis, feature::ImageGeometry), AnalyzeError> {
     let width = slice.width();
@@ -488,7 +516,22 @@ fn analyze_specialized_raw<const PAL: bool, const T2: bool, const T3: bool, cons
     let mut raw = feature::RawAnalysis::default();
 
     if width >= 2 && height >= 2 {
-        tier1::extract_tier1_into(&mut raw, &mut stream, pixel_budget);
+        // Tier 1 dispatch knobs — currently just `wants_laplacian`,
+        // which lets orchestrator-style callers (e.g. zenjpeg's
+        // `ADAPTIVE_FEATURES`) skip the separate Laplacian SIMD row
+        // pass when `LaplacianVariance` isn't requested.
+        // `TIER1_EXTRAS_FEATURES` is the union of all features whose
+        // accumulators add cost beyond the Tier 1 baseline; for now
+        // only LaplacianVariance gates a runtime branch, but the
+        // dispatch struct is laid out to grow more knobs (skin /
+        // edge-slope / colourfulness const-fold) without churning
+        // call sites.
+        let t1_dispatch = tier1::Tier1Dispatch {
+            wants_laplacian: tier1_wants_laplacian,
+            wants_full_kernel: tier1_full_kernel,
+            wants_skin: tier1_wants_skin,
+        };
+        tier1::extract_tier1_into_dispatch(&mut raw, &mut stream, pixel_budget, t1_dispatch);
         if T2 && width >= 3 && height >= 3 {
             tier2_chroma::populate_tier2(&mut raw, &mut stream, pixel_budget);
         }
@@ -583,6 +626,9 @@ pub fn __analyze_internal(
         query.hf_max_blocks,
         true, // override path always uses full palette scan
         true, // and includes the grayscale gate (test path wants every signal)
+        true, // and the Laplacian SIMD pass
+        true, // and the Tier 1 full kernel (luma stats / Hasler M3 / edge slope)
+        true, // and the Tier 1 skin gate
         run_depth,
     )?;
     Ok(raw.into_results(query.features, geometry, source_descriptor))
@@ -609,7 +655,9 @@ pub(crate) fn analyze_full_raw_for_test(
     // Tests want every signal — always run the full palette path,
     // and the depth tier when it's compiled in.
     let run_depth = cfg!(feature = "experimental");
-    analyze_specialized_raw::<true, true, true, true>(slice, pb, hf, true, true, run_depth)
+    analyze_specialized_raw::<true, true, true, true>(
+        slice, pb, hf, true, true, true, true, true, run_depth,
+    )
 }
 
 /// Convenience entry for callers holding a packed RGB8 buffer plus a

--- a/zenanalyze/src/lib.rs
+++ b/zenanalyze/src/lib.rs
@@ -105,24 +105,57 @@
 //! rows, and shares no inner loop with T1/T2/T3 to specialize. So
 //! it's wired as a runtime branch outside the const-bool dispatch.
 //!
-//! ## Feature-overlap notes (corpus-eval 2026-04-27)
+//! ## Empirical calibration (corpus-eval 2026-04-27)
 //!
-//! Empirical Spearman ρ across CID22 / CLIC2025 / gb82 / gb82-sc:
+//! Pre-0.1.0-ship calibration baseline measured on a 219-image
+//! labeled corpus from `coefficient/benchmarks/classifier-eval/labels.tsv`
+//! (174 photo, 36 screen, 9 illustration, 44 marked synthetic;
+//! pooled from cid22-train/val, clic2025-1024, gb82, gb82-sc,
+//! imageflow, kadid10k, qoi-benchmark). Full per-class
+//! distributions, ROC-AUC ranking for every feature, recommended
+//! operating thresholds, and the recalibration candidates that
+//! were considered and rejected are recorded in
+//! `docs/calibration-corpus-2026-04-27.md`.
 //!
-//! - `aq_map_mean` ↔ `noise_floor_y`: ρ ≈ +0.91. Both fall when
-//!   blocks are flat (low AC energy). They drive different
-//!   downstream knobs (zenjpeg trellis-λ vs `pre_blur` strength), so
-//!   keep both — but if a future consumer reads only one of them,
-//!   delete the other.
-//! - `noise_floor_y` ↔ `screen_content_likelihood`: ρ ≈ −0.88.
+//! Top-line empirical findings:
+//!
+//! - **Strongest single screen-vs-photo discriminator**:
+//!   [`feature::AnalysisFeature::PatchFraction`] (AUC = 0.880,
+//!   F1 = 0.769 at `>= 0.27`).
+//! - **Strongest photo classifier**:
+//!   [`feature::AnalysisFeature::NaturalLikelihood`] (F1 = 0.924
+//!   at `>= 0.06`).
+//! - **Near-deterministic line-art signal**:
+//!   [`feature::AnalysisFeature::LineArtScore`] `> 0`
+//!   (F1 = 0.978).
+//! - **Derived likelihoods empirically saturate at ~0.70**, not
+//!   1.0 — operating thresholds live in the 0.3–0.6 band, not 0.8+.
+//!
+//! Spearman ρ |≥ 0.85| pairs (mostly structural, all kept):
+//!
+//! - `distinct_color_bins` ↔ `palette_density`: ρ = +1.00 — derived.
+//! - `flat_color_block_ratio` ↔ `screen_content_likelihood`: ρ =
+//!   +0.99 — structural, the former is the latter's primary input.
+//! - `uniformity` ↔ `aq_map_mean`: ρ = −0.97. Both measure block
+//!   flatness; drive different knobs (T1 fast-path vs T3 AQ-driven
+//!   trellis-λ).
+//! - `chroma_complexity` ↔ `colourfulness`: ρ = +0.97. Both
+//!   quantify chroma spread; one is normalised, the other is the
+//!   raw Hasler-Süsstrunk M3 published scale — keep both for
+//!   ergonomics.
+//! - `aq_map_mean` ↔ `noise_floor_y`: ρ = +0.91. Both fall when
+//!   blocks are flat. Different downstream knobs (zenjpeg trellis-λ
+//!   vs `pre_blur`), keep both.
+//! - `noise_floor_y` ↔ `screen_content_likelihood`: ρ = −0.89.
 //!   Screen content is clean-by-construction; photos carry sensor
-//!   noise. The signals come from different passes (T3 noise floor
-//!   vs derived likelihood) and feed different knobs (`pre_blur` vs
-//!   `Preset`), so the redundancy is descriptive, not load-bearing.
-//! - `aq_map_mean` ↔ `edge_density`: ρ ≈ +0.85. Expected — both
-//!   measure busyness. Keep both.
+//!   noise. Different passes, different knobs.
+//! - `cb_sharpness` ↔ `cr_sharpness`: ρ = +0.89. Co-vary by
+//!   construction in natural content.
 //!
-//! All other feature pairs are at |ρ| < 0.85. No deletion candidates.
+//! No deletion candidates were found. Numeric drift in 0.1.x
+//! patches is permitted by the threshold contract above; the
+//! committed `docs/calibration-corpus-2026-04-27.md` is the
+//! pre-ship baseline against which patch drift can be compared.
 
 // `#[archmage::autoversion]` generates dispatch trampolines that
 // don't always reference the unversioned base function.
@@ -331,6 +364,13 @@ pub fn analyze_features(
     // (much faster on photographic content). Computed once per call;
     // analyze_specialized_raw const-folds nothing on this axis.
     let palette_full_required = features.intersects(feature::PALETTE_FULL_FEATURES);
+    // GrayscaleScore lives on the palette tier (full-scan, 100 %
+    // coverage) but its per-pixel max/min gate isn't free — only run
+    // the gate when the caller actually requested it.
+    #[cfg(feature = "experimental")]
+    let palette_wants_grayscale = features.contains(feature::AnalysisFeature::GrayscaleScore);
+    #[cfg(not(feature = "experimental"))]
+    let palette_wants_grayscale = false;
 
     // Depth tier is a runtime axis (not const-bool) — adding it to
     // the 16-arm dispatch would double to 32 arms for one extra
@@ -350,6 +390,7 @@ pub fn analyze_features(
                 feature::DEFAULT_PIXEL_BUDGET,
                 feature::DEFAULT_HF_MAX_BLOCKS,
                 palette_full_required,
+                palette_wants_grayscale,
                 run_depth,
             )?;
             Ok(raw.into_results(features, geometry, source_descriptor))
@@ -398,6 +439,7 @@ fn analyze_specialized_raw<const PAL: bool, const T2: bool, const T3: bool, cons
     pixel_budget: usize,
     hf_max_blocks: usize,
     palette_full_required: bool,
+    palette_wants_grayscale: bool,
     run_depth: bool,
 ) -> Result<(feature::RawAnalysis, feature::ImageGeometry), AnalyzeError> {
     let width = slice.width();
@@ -435,7 +477,7 @@ fn analyze_specialized_raw<const PAL: bool, const T2: bool, const T3: bool, cons
     // image rows.
     let palette_stats = if PAL {
         if palette_full_required {
-            palette::scan_palette(&mut stream)
+            palette::scan_palette(&mut stream, palette_wants_grayscale)
         } else {
             palette::scan_palette_quick(&mut stream)
         }
@@ -487,6 +529,20 @@ fn analyze_specialized_raw<const PAL: bool, const T2: bool, const T3: bool, cons
                 let denom = pixel_count.clamp(1.0, 32_768.0);
                 raw.palette_density =
                     (raw.distinct_color_bins as f64 / denom).clamp(0.0, 1.0) as f32;
+                // GrayscaleScore is computed on the same full-scan walk
+                // as the distinct-bin histogram. 100 % coverage is
+                // load-bearing — the score is used downstream as a
+                // binary classifier (`>= 0.99` ⇒ encode as grayscale),
+                // and stripe-sampling at ~5 % budget would let one
+                // colour pixel slip past the gate ~95 % of the time.
+                raw.grayscale_score = if palette_stats.total_pixels > 0 {
+                    let gray = palette_stats
+                        .total_pixels
+                        .saturating_sub(palette_stats.non_grayscale);
+                    (gray as f64 / palette_stats.total_pixels as f64) as f32
+                } else {
+                    0.0
+                };
             }
         }
         let _ = palette_stats; // silence unused on the all-experimental-off path
@@ -526,6 +582,7 @@ pub fn __analyze_internal(
         query.pixel_budget,
         query.hf_max_blocks,
         true, // override path always uses full palette scan
+        true, // and includes the grayscale gate (test path wants every signal)
         run_depth,
     )?;
     Ok(raw.into_results(query.features, geometry, source_descriptor))
@@ -552,7 +609,7 @@ pub(crate) fn analyze_full_raw_for_test(
     // Tests want every signal — always run the full palette path,
     // and the depth tier when it's compiled in.
     let run_depth = cfg!(feature = "experimental");
-    analyze_specialized_raw::<true, true, true, true>(slice, pb, hf, true, run_depth)
+    analyze_specialized_raw::<true, true, true, true>(slice, pb, hf, true, true, run_depth)
 }
 
 /// Convenience entry for callers holding a packed RGB8 buffer plus a

--- a/zenanalyze/src/luma.rs
+++ b/zenanalyze/src/luma.rs
@@ -1,0 +1,207 @@
+//! Per-primaries luma weights for the tier kernels.
+//!
+//! The standard tiers (Tier 1 / Tier 2 / Tier 3) compute luma /
+//! chroma stats on display-space u8 RGB bytes. For sRGB-primary
+//! content that's a well-defined operation: pick a fixed
+//! `(KR, KG, KB)` triplet, accumulate. For wide-gamut u8 inputs
+//! (Display P3 / Rec.2020 / AdobeRGB) the *bytes* are still
+//! display-space u8, but the green primary in particular sits at a
+//! different chromaticity — so the weights `(0.299, 0.587, 0.114)`
+//! that turn sRGB-primary RGB into BT.601 luma are wrong.
+//!
+//! This module returns the right `(KR, KG, KB)` triplet for each
+//! `ColorPrimaries`, derived from each primary set's RGB→XYZ matrix
+//! (Y row, normalised so KR + KG + KB ≈ 1.0).
+//!
+//! ## Why sRGB / BT.709 keeps BT.601 weights
+//!
+//! Strictly, sRGB-primary content should use the BT.709 weights
+//! `(0.2126, 0.7152, 0.0722)` — sRGB and BT.709 share primaries, and
+//! BT.709 is the matching YCbCr matrix. The analyzer's threshold
+//! contract is calibrated against BT.601 weights on sRGB bytes (a
+//! historical accident — `coefficient` and the trees it ships used
+//! `(0.299, 0.587, 0.114)` against sRGB content from day one). To
+//! preserve those trained thresholds, we keep BT.601 weights for the
+//! sRGB / BT.709 path. Wide-gamut sources are new territory and get
+//! the mathematically-correct weights for their primaries.
+//!
+//! See `CLAUDE.md` for the no-0.2.x stability contract — this is a
+//! one-time, additive numeric drift on wide-gamut inputs only.
+
+use zenpixels::ColorPrimaries;
+
+/// `(KR, KG, KB)` luma weight triplet, plus precomputed 8-bit fixed-
+/// point versions for the integer luma paths (Tier 3 histogram +
+/// block luma).
+///
+/// The f32 weights `kr / kg / kb` sum to ≈ 1.0 (mathematical luma
+/// matrix from each primary set's RGB→XYZ Y row). The fixed-point
+/// weights `qr / qg / qb` sum to **220**, matching the libwebp /
+/// coefficient BT.601 baseline `66 + 129 + 25 = 220`. That sum is
+/// the integer-luma scale Tier 3's histogram and DCT-block paths
+/// were calibrated against (white maps to 219, not 255). Wide-
+/// gamut weight sets are scaled to the same 220 sum so a pure-
+/// white pixel hits the same histogram bin regardless of source
+/// primaries — keeping the trained-threshold contract intact for
+/// every analyzer feature whose output depends on absolute luma
+/// magnitude.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LumaWeights {
+    pub kr: f32,
+    pub kg: f32,
+    pub kb: f32,
+    /// Fixed-point luma scaled to sum ≈ 220 (libwebp baseline).
+    /// Used by Tier 3 in `((qr * R + qg * G + qb * B + 128) >> 8)`.
+    pub qr: i32,
+    pub qg: i32,
+    pub qb: i32,
+}
+
+/// Sum of the libwebp-style fixed-point luma matrix. White maps to
+/// `(LUMA_SUM_220 * 255 + 128) >> 8 = 219`. All primaries use this
+/// scale so the histogram thresholds keep their meaning.
+const LUMA_SUM_220: i32 = 220;
+
+impl LumaWeights {
+    /// Pick weights for a source's declared [`ColorPrimaries`].
+    ///
+    /// - `Bt709` (sRGB / BT.709): BT.601 weights — preserves the
+    ///   trained-threshold baseline.
+    /// - `Bt2020`: BT.2020 luma weights from Rec. ITU-R BT.2020.
+    /// - `DisplayP3`, `AdobeRgb`: derived from each primary set's
+    ///   RGB→XYZ Y row.
+    /// - Anything else (`Unknown`, future variants): falls back to
+    ///   BT.601, matching the historical default.
+    pub fn for_primaries(p: ColorPrimaries) -> Self {
+        match p {
+            ColorPrimaries::Bt709 => bt601(),
+            ColorPrimaries::Bt2020 => bt2020(),
+            ColorPrimaries::DisplayP3 => display_p3(),
+            ColorPrimaries::AdobeRgb => adobe_rgb(),
+            _ => bt601(),
+        }
+    }
+}
+
+/// BT.601 weights — the analyzer's historical baseline; preserved
+/// for sRGB / BT.709 inputs to keep the trained threshold contract.
+#[inline]
+const fn bt601() -> LumaWeights {
+    LumaWeights {
+        kr: 0.299,
+        kg: 0.587,
+        kb: 0.114,
+        // round(0.299 * 256) = 77; 0.587 * 256 ≈ 150; 0.114 * 256 ≈ 29
+        // — but tier 3's existing integer math uses 66/129/25 which
+        // is BT.601-derived-from-BT.709-with-different-rounding (the
+        // libwebp / coefficient lineage). Match that.
+        qr: 66,
+        qg: 129,
+        qb: 25,
+    }
+}
+
+/// BT.2020 luma weights — Rec. ITU-R BT.2020-2 §3.4. Fixed-point
+/// weights scaled to the sum-220 libwebp baseline so wide-gamut
+/// integer luma lands on the same 0-219 scale as sRGB content.
+#[inline]
+const fn bt2020() -> LumaWeights {
+    LumaWeights {
+        kr: 0.2627,
+        kg: 0.6780,
+        kb: 0.0593,
+        // round(0.2627 * 220) = 58, round(0.6780 * 220) = 149,
+        // round(0.0593 * 220) = 13. Sum = 220.
+        qr: 58,
+        qg: 149,
+        qb: 13,
+    }
+}
+
+/// Display P3 (D65, P3 primaries) — derived from the RGB→XYZ matrix
+/// in SMPTE EG 432-1. Sum-220 fixed-point.
+#[inline]
+const fn display_p3() -> LumaWeights {
+    LumaWeights {
+        kr: 0.2289,
+        kg: 0.6917,
+        kb: 0.0793,
+        // round(0.2289 * 220) = 50, round(0.6917 * 220) = 152,
+        // round(0.0793 * 220) = 17. Sum = 219, off by -1 (negligible).
+        qr: 50,
+        qg: 152,
+        qb: 17,
+    }
+}
+
+/// AdobeRGB (1998), D65. Primaries differ from sRGB on green;
+/// red and blue are close. Sum-220 fixed-point.
+#[inline]
+const fn adobe_rgb() -> LumaWeights {
+    LumaWeights {
+        kr: 0.2974,
+        kg: 0.6273,
+        kb: 0.0753,
+        // round(0.2974 * 220) = 65, round(0.6273 * 220) = 138,
+        // round(0.0753 * 220) = 17. Sum = 220.
+        qr: 65,
+        qg: 138,
+        qb: 17,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// fp + integer weights both sum close to unity / 256.
+    #[test]
+    fn weights_sum_to_unity_for_every_primary_set() {
+        for &p in &[
+            ColorPrimaries::Bt709,
+            ColorPrimaries::Bt2020,
+            ColorPrimaries::DisplayP3,
+            ColorPrimaries::AdobeRgb,
+        ] {
+            let w = LumaWeights::for_primaries(p);
+            let f_sum = w.kr + w.kg + w.kb;
+            assert!(
+                (f_sum - 1.0).abs() < 1e-2,
+                "{p:?}: f32 weights sum {f_sum}, expected ≈ 1.0"
+            );
+            let q_sum = w.qr + w.qg + w.qb;
+            assert!(
+                (q_sum - LUMA_SUM_220).abs() <= 1,
+                "{p:?}: fixed-point weights sum {q_sum}, expected ≈ 220 (libwebp baseline)"
+            );
+        }
+    }
+
+    #[test]
+    fn bt709_path_returns_bt601_baseline() {
+        // Trained-threshold preservation: sRGB / BT.709 inputs MUST
+        // continue to use BT.601 weights so the existing thresholds
+        // keep their meaning.
+        let w = LumaWeights::for_primaries(ColorPrimaries::Bt709);
+        assert_eq!(w.kr, 0.299);
+        assert_eq!(w.kg, 0.587);
+        assert_eq!(w.kb, 0.114);
+        assert_eq!((w.qr, w.qg, w.qb), (66, 129, 25));
+    }
+
+    #[test]
+    fn wide_gamut_paths_diverge_from_bt601() {
+        for &p in &[
+            ColorPrimaries::Bt2020,
+            ColorPrimaries::DisplayP3,
+            ColorPrimaries::AdobeRgb,
+        ] {
+            let w = LumaWeights::for_primaries(p);
+            assert_ne!(
+                (w.kr, w.kg, w.kb),
+                (0.299_f32, 0.587_f32, 0.114_f32),
+                "{p:?} should NOT use BT.601 weights"
+            );
+        }
+    }
+}

--- a/zenanalyze/src/luma.rs
+++ b/zenanalyze/src/luma.rs
@@ -63,6 +63,18 @@ pub(crate) struct LumaWeights {
 const LUMA_SUM_220: i32 = 220;
 
 impl LumaWeights {
+    /// True iff this weight set is the BT.601 baseline shared by
+    /// sRGB / BT.709 / Unknown sources. Used by the Tier 1 SIMD
+    /// dispatcher to pick the const-folded `accumulate_row_simd::<true>`
+    /// specialisation, which lets LLVM emit `vfmadd*` immediates for
+    /// `kr / kg / kb` instead of register-loaded splats.
+    #[inline]
+    pub(crate) fn is_bt601_baseline(&self) -> bool {
+        // The constants are chosen so equality holds bit-exact against
+        // the `bt601()` constructor below — no tolerance needed.
+        self.kr == 0.299 && self.kg == 0.587 && self.kb == 0.114
+    }
+
     /// Pick weights for a source's declared [`ColorPrimaries`].
     ///
     /// - `Bt709` (sRGB / BT.709): BT.601 weights — preserves the

--- a/zenanalyze/src/palette.rs
+++ b/zenanalyze/src/palette.rs
@@ -57,6 +57,21 @@ pub(crate) struct PaletteStats {
     pub indexed_width: u32,
     /// Convenience: `indexed_width != 0`.
     pub fits_in_256: bool,
+    /// Total pixels walked by the scan (`width × height`). Used to
+    /// compute fractions like `GrayscaleScore` from `non_grayscale`.
+    /// Set by `scan_palette` only; `scan_palette_quick` may have
+    /// early-exited before walking every pixel and leaves this at 0.
+    pub total_pixels: u64,
+    /// Pixels that failed the grayscale gate (`max(R, G, B) − min ≤ 4`).
+    /// Computed on the same full walk that builds the bin histogram.
+    /// **100 % coverage** — at stripe-sampled budgets a single colour
+    /// pixel in a sea of gray would have ~95 % chance of being missed,
+    /// breaking the binary "is this image grayscale?" classifier.
+    /// Hosting it on the always-full-scan palette tier gives the
+    /// right answer at no extra cost (the row walk is bandwidth-bound
+    /// on the flag-array store; the 4-instruction max−min gate fits
+    /// in the same target_feature loop).
+    pub non_grayscale: u64,
 }
 
 /// Map a distinct-colour count to the smallest power-of-2 palette
@@ -81,7 +96,7 @@ fn width_for_count(count: u32) -> u32 {
 /// store (no read-modify-write); the final count is a linear pop over
 /// the array, which LLVM autovectorizes. At full scan the raw count is
 /// the population truth — no extrapolation needed.
-pub(crate) fn scan_palette(stream: &mut RowStream<'_>) -> PaletteStats {
+pub(crate) fn scan_palette(stream: &mut RowStream<'_>, want_grayscale: bool) -> PaletteStats {
     let width = stream.width() as usize;
     let height = stream.height();
     if width == 0 || height == 0 {
@@ -102,11 +117,17 @@ pub(crate) fn scan_palette(stream: &mut RowStream<'_>) -> PaletteStats {
     // ~10 ns lookup `height` times and the wins from chunks-of-24
     // never amortized. Pulling the row loop in lets v3/v4 autovec the
     // index batch *and* the final reduction in the same code generation.
-    let distinct = scan_and_count(stream, &mut flags);
+    let (distinct, non_grayscale) = scan_and_count(stream, &mut flags, want_grayscale);
     PaletteStats {
         distinct,
         indexed_width: width_for_count(distinct),
         fits_in_256: distinct <= 256,
+        total_pixels: if want_grayscale {
+            (width as u64) * (height as u64)
+        } else {
+            0
+        },
+        non_grayscale,
     }
 }
 
@@ -144,10 +165,18 @@ pub(crate) fn scan_palette_quick(stream: &mut RowStream<'_>) -> PaletteStats {
         .try_into()
         .expect("32 KB heap alloc for palette flag array");
     let (count, exceeded) = scan_quick_inner(stream, &mut flags);
+    // The quick path doesn't compute grayscale (the early-exit
+    // structure can bail before walking all pixels, and the
+    // grayscale gate has no analogous early-exit at this
+    // granularity). Callers that request `GrayscaleScore` route
+    // through the full `scan_palette` path because `GrayscaleScore`
+    // is in `PALETTE_FULL_FEATURES`.
     PaletteStats {
-        distinct: 0, // not computed in the quick path
+        distinct: 0,
         indexed_width: if exceeded { 0 } else { width_for_count(count) },
         fits_in_256: !exceeded,
+        total_pixels: 0,
+        non_grayscale: 0,
     }
 }
 
@@ -166,8 +195,26 @@ pub(crate) fn scan_palette_quick(stream: &mut RowStream<'_>) -> PaletteStats {
 /// inside this fn since `borrow_row` is `#[inline]` and itself a tiny
 /// pointer indirection. The hot work — chunked index compute + 32 KB
 /// reduction — is what we wanted in the v4x context anyway.
+/// Two-mode scan: with-grayscale or without. The runtime `want_gray`
+/// flag dispatches to one of two `#[autoversion]`-tier inner kernels
+/// so the without-grayscale path keeps its tight original codegen
+/// (no per-pixel max/min/compare in the inner loop) while the
+/// with-grayscale path adds the gate inside the same target_feature
+/// region.
+fn scan_and_count(
+    stream: &mut RowStream<'_>,
+    flags: &mut [u8; 32_768],
+    want_gray: bool,
+) -> (u32, u64) {
+    if want_gray {
+        scan_and_count_gray(stream, flags)
+    } else {
+        (scan_and_count_no_gray(stream, flags), 0)
+    }
+}
+
 #[autoversion(v4x, v4, v3, neon, scalar)]
-fn scan_and_count(stream: &mut RowStream<'_>, flags: &mut [u8; 32_768]) -> u32 {
+fn scan_and_count_no_gray(stream: &mut RowStream<'_>, flags: &mut [u8; 32_768]) -> u32 {
     let width = stream.width() as usize;
     let height = stream.height();
     let row_bytes = width * 3;
@@ -179,9 +226,6 @@ fn scan_and_count(stream: &mut RowStream<'_>, flags: &mut [u8; 32_768]) -> u32 {
         for c in 0..full_chunks {
             let base = c * chunk_bytes;
             let chunk: &[u8; 24] = (&row[base..base + chunk_bytes]).try_into().unwrap();
-            // Eight independent index computes — no inter-iteration
-            // dependencies, so the autovectorizer can issue them as a
-            // SIMD shift+or sequence at v3/v4 and emit eight stores.
             let mut i = 0;
             while i < 8 {
                 let r = (chunk[i * 3] >> 3) as usize;
@@ -192,7 +236,6 @@ fn scan_and_count(stream: &mut RowStream<'_>, flags: &mut [u8; 32_768]) -> u32 {
                 i += 1;
             }
         }
-        // Tail: the < 8-pixel remainder.
         let tail_start = full_chunks * chunk_bytes;
         for px in row[tail_start..].chunks_exact(3) {
             let idx = (((px[0] >> 3) as usize) << 10)
@@ -202,6 +245,53 @@ fn scan_and_count(stream: &mut RowStream<'_>, flags: &mut [u8; 32_768]) -> u32 {
         }
     }
     flags.iter().map(|&f| f as u32).sum()
+}
+
+#[autoversion(v4x, v4, v3, neon, scalar)]
+fn scan_and_count_gray(stream: &mut RowStream<'_>, flags: &mut [u8; 32_768]) -> (u32, u64) {
+    let width = stream.width() as usize;
+    let height = stream.height();
+    let row_bytes = width * 3;
+    let chunk_bytes = 24usize;
+    let mut non_gray: u64 = 0;
+    for y in 0..height {
+        let row = stream.borrow_row(y);
+        let row = &row[..row_bytes.min(row.len())];
+        let full_chunks = row.len() / chunk_bytes;
+        for c in 0..full_chunks {
+            let base = c * chunk_bytes;
+            let chunk: &[u8; 24] = (&row[base..base + chunk_bytes]).try_into().unwrap();
+            let mut i = 0;
+            while i < 8 {
+                let r = chunk[i * 3];
+                let g = chunk[i * 3 + 1];
+                let b = chunk[i * 3 + 2];
+                let idx = (((r >> 3) as usize) << 10)
+                    | (((g >> 3) as usize) << 5)
+                    | ((b >> 3) as usize);
+                flags[idx] = 1;
+                let mx = r.max(g).max(b);
+                let mn = r.min(g).min(b);
+                non_gray += (mx - mn > 4) as u64;
+                i += 1;
+            }
+        }
+        let tail_start = full_chunks * chunk_bytes;
+        for px in row[tail_start..].chunks_exact(3) {
+            let r = px[0];
+            let g = px[1];
+            let b = px[2];
+            let idx = (((r >> 3) as usize) << 10)
+                | (((g >> 3) as usize) << 5)
+                | ((b >> 3) as usize);
+            flags[idx] = 1;
+            let mx = r.max(g).max(b);
+            let mn = r.min(g).min(b);
+            non_gray += (mx - mn > 4) as u64;
+        }
+    }
+    let distinct: u32 = flags.iter().map(|&f| f as u32).sum();
+    (distinct, non_gray)
 }
 
 /// Same row+chunks(24) skeleton as `scan_and_count`, but with a

--- a/zenanalyze/src/row_stream.rs
+++ b/zenanalyze/src/row_stream.rs
@@ -40,6 +40,20 @@ pub struct RowStream<'a> {
 
 enum Inner<'a> {
     Native(PixelSlice<'a>),
+    /// 32-bpp RGBA-family layout (RGBA8 / BGRA8 / Rgbx8 / Bgrx8).
+    /// Skips `RowConverter` entirely — populates the row scratch
+    /// with a tight strip-alpha-and-maybe-swap pass that's an order
+    /// of magnitude cheaper than the converter's full
+    /// transfer + matrix + narrow path. The converter alloc + setup
+    /// cost is also gone. Saves ~1 ms / 4 K row in profiles.
+    StripAlpha8 {
+        slice: PixelSlice<'a>,
+        /// Byte indices within each 4-byte source pixel that map to
+        /// `[R, G, B]` in the output. RGBA8 / Rgbx8 ⇒ `[0, 1, 2]`,
+        /// BGRA8 / Bgrx8 ⇒ `[2, 1, 0]`. Resolved at construction so
+        /// the inner loop is branch-free.
+        rgb_idx: [u8; 3],
+    },
     Convert {
         slice: PixelSlice<'a>,
         converter: RowConverter,
@@ -69,8 +83,21 @@ impl<'a> RowStream<'a> {
         // semantics.
         let rgb8_compat = desc.layout_compatible(PixelDescriptor::RGB8);
 
+        // Strip-alpha fast path: 32-bpp RGBA-class layouts. The RGB
+        // tiers want display-space RGB samples; for opaque or
+        // straight-alpha sources, that's just the colour bytes with
+        // alpha dropped (channel-order re-mapped for BGRA). The full
+        // RowConverter machinery is overkill for that case — building
+        // the converter alone allocates and bakes a multi-stage plan,
+        // and `convert_row` does work that's wasted when the
+        // destination is the same channel type, same transfer, just
+        // 4 → 3 bytes per pixel.
+        let strip_idx = strip_alpha_indices(desc.format);
+
         let inner = if rgb8_compat {
             Inner::Native(slice)
+        } else if let Some(rgb_idx) = strip_idx {
+            Inner::StripAlpha8 { slice, rgb_idx }
         } else {
             // Convert to plain RGB8_SRGB on the way in. The transfer
             // function difference vs the native input has at most
@@ -123,6 +150,9 @@ impl<'a> RowStream<'a> {
                 let row = slice.row(y);
                 dst[..len].copy_from_slice(&row[..len]);
             }
+            Inner::StripAlpha8 { slice, rgb_idx } => {
+                strip_alpha_row(slice.row(y), self.width as usize, *rgb_idx, &mut dst[..len]);
+            }
             Inner::Convert { slice, converter } => {
                 let src = slice.row(y);
                 converter.convert_row(src, &mut dst[..len], self.width);
@@ -142,6 +172,10 @@ impl<'a> RowStream<'a> {
         let len = self.width as usize * 3;
         match &mut self.inner {
             Inner::Native(slice) => &slice.row(y)[..len],
+            Inner::StripAlpha8 { slice, rgb_idx } => {
+                strip_alpha_row(slice.row(y), self.width as usize, *rgb_idx, &mut self.scratch[..len]);
+                &self.scratch[..len]
+            }
             Inner::Convert { slice, converter } => {
                 let src = slice.row(y);
                 converter.convert_row(src, &mut self.scratch[..len], self.width);
@@ -166,5 +200,90 @@ impl<'a> RowStream<'a> {
         for (i, y) in range.enumerate() {
             self.fetch_into(y, &mut dst[i * row_bytes..(i + 1) * row_bytes]);
         }
+    }
+}
+
+/// Decide whether a 32-bpp RGBA-class format is the strip-alpha
+/// fast path, and what `[R, G, B]` byte indices within each
+/// 4-byte source pixel map to. Returns `None` for layouts that
+/// genuinely need `RowConverter` (different channel type, gray,
+/// CMYK, Oklab, …) or for non-32-bpp inputs.
+fn strip_alpha_indices(format: zenpixels::PixelFormat) -> Option<[u8; 3]> {
+    use zenpixels::PixelFormat;
+    match format {
+        PixelFormat::Rgba8 | PixelFormat::Rgbx8 => Some([0, 1, 2]),
+        PixelFormat::Bgra8 | PixelFormat::Bgrx8 => Some([2, 1, 0]),
+        // RGBA16 / RGBAF32 / Gray* / CMYK / etc. all need the full
+        // converter — channel type doesn't match RGB8.
+        _ => None,
+    }
+}
+
+/// Strip alpha from a 32-bpp RGBA-class row into a tightly packed
+/// 24-bpp RGB8 row. The compiler autovectorizes the `chunks_exact(4) →
+/// chunks_exact_mut(3)` loop for the common in-order case
+/// (`rgb_idx == [0, 1, 2]`); the BGRA case generates a tiny shuffle.
+/// No allocation, no transfer-function math, no f32.
+#[inline]
+fn strip_alpha_row(src: &[u8], width: usize, rgb_idx: [u8; 3], dst: &mut [u8]) {
+    let need_src = width * 4;
+    let need_dst = width * 3;
+    debug_assert!(src.len() >= need_src);
+    debug_assert!(dst.len() >= need_dst);
+    let src_pixels = src[..need_src].chunks_exact(4);
+    let dst_pixels = dst[..need_dst].chunks_exact_mut(3);
+    let r = rgb_idx[0] as usize;
+    let g = rgb_idx[1] as usize;
+    let b = rgb_idx[2] as usize;
+    for (s, d) in src_pixels.zip(dst_pixels) {
+        d[0] = s[r];
+        d[1] = s[g];
+        d[2] = s[b];
+    }
+}
+
+#[cfg(test)]
+mod strip_tests {
+    use super::*;
+    use zenpixels::{PixelDescriptor, PixelSlice};
+
+    #[test]
+    fn strip_alpha_path_fires_for_rgba8() {
+        // RGBA8 source ⇒ should pick the StripAlpha8 path (not Convert).
+        // Verify by checking that no allocation-heavy converter setup
+        // happens — observable through the strip helper producing
+        // bit-exact output and the rows being identical to a manual
+        // strip.
+        let w: u32 = 8;
+        let h: u32 = 4;
+        let mut rgba = Vec::with_capacity((w * h * 4) as usize);
+        for i in 0..(w * h) {
+            let v = (i & 0xFF) as u8;
+            rgba.extend_from_slice(&[v, v.wrapping_add(1), v.wrapping_add(2), 0xFF]);
+        }
+        let s = PixelSlice::new(&rgba, w, h, (w * 4) as usize, PixelDescriptor::RGBA8_SRGB)
+            .unwrap();
+        let mut stream = RowStream::new(s).unwrap();
+        let row = stream.borrow_row(0);
+        assert_eq!(row.len(), (w * 3) as usize);
+        for px in 0..(w as usize) {
+            assert_eq!(row[px * 3], (px & 0xFF) as u8);
+            assert_eq!(row[px * 3 + 1], (px as u8).wrapping_add(1));
+            assert_eq!(row[px * 3 + 2], (px as u8).wrapping_add(2));
+        }
+    }
+
+    #[test]
+    fn strip_alpha_path_swaps_channels_for_bgra8() {
+        // BGRA8 ⇒ index map [2, 1, 0]: source bytes [B, G, R, A]
+        // become RGB8 [R, G, B] in the output.
+        let w: u32 = 4;
+        let h: u32 = 1;
+        let bgra: Vec<u8> = vec![10, 20, 30, 0xFF, 11, 21, 31, 0xFF, 12, 22, 32, 0xFF, 13, 23, 33, 0xFF];
+        let s = PixelSlice::new(&bgra, w, h, (w * 4) as usize, PixelDescriptor::BGRA8_SRGB)
+            .unwrap();
+        let mut stream = RowStream::new(s).unwrap();
+        let row = stream.borrow_row(0);
+        assert_eq!(row, &[30, 20, 10, 31, 21, 11, 32, 22, 12, 33, 23, 13]);
     }
 }

--- a/zenanalyze/src/row_stream.rs
+++ b/zenanalyze/src/row_stream.rs
@@ -34,6 +34,10 @@ pub struct RowStream<'a> {
     inner: Inner<'a>,
     width: u32,
     height: u32,
+    /// Source primaries — captured at construction so per-primaries
+    /// luma weights / chroma matrices can be looked up by tier code
+    /// without holding a back-reference to the slice.
+    primaries: zenpixels::ColorPrimaries,
     /// Row-of-RGB8 scratch reused across `fetch_into` and `borrow_row`.
     scratch: Vec<u8>,
 }
@@ -115,8 +119,18 @@ impl<'a> RowStream<'a> {
             inner,
             width,
             height,
+            primaries: desc.primaries,
             scratch: vec![0u8; scratch_len],
         })
+    }
+
+    /// Source primaries — the analyzer tiers look this up to pick the
+    /// right luma weights for a u8 RGB byte stream that's still in
+    /// the source's primaries (Native zero-copy path) without
+    /// converting. See [`crate::luma::LumaWeights::for_primaries`].
+    #[inline]
+    pub fn primaries(&self) -> zenpixels::ColorPrimaries {
+        self.primaries
     }
 
     #[inline]

--- a/zenanalyze/src/row_stream.rs
+++ b/zenanalyze/src/row_stream.rs
@@ -234,9 +234,17 @@ fn strip_alpha_indices(format: zenpixels::PixelFormat) -> Option<[u8; 3]> {
 }
 
 /// Strip alpha from a 32-bpp RGBA-class row into a tightly packed
-/// 24-bpp RGB8 row. The compiler autovectorizes the `chunks_exact(4) →
-/// chunks_exact_mut(3)` loop for the common in-order case
-/// (`rgb_idx == [0, 1, 2]`); the BGRA case generates a tiny shuffle.
+/// 24-bpp RGB8 row, dispatching to garb's SIMD primitives:
+/// `rgba_to_rgb` for the in-order case (`rgb_idx == [0, 1, 2]`,
+/// RGBA / Rgbx sources) and `bgra_to_rgb` for the swapped case
+/// (`rgb_idx == [2, 1, 0]`, BGRA / Bgrx). Both use
+/// `archmage::incant!` to dispatch to AVX2 / NEON / WASM128 / scalar.
+///
+/// Measured ~7× speedup over the previous in-tree scalar strip on a
+/// 2048-px row (0.13 µs vs 0.94 µs). On full-feature analyzer
+/// runs (`FeatureSet::SUPPORTED`, 4 MP RGBA8) the strip cost
+/// dropped from ~5.7 ms total to under 1 ms.
+///
 /// No allocation, no transfer-function math, no f32.
 #[inline]
 fn strip_alpha_row(src: &[u8], width: usize, rgb_idx: [u8; 3], dst: &mut [u8]) {
@@ -244,15 +252,32 @@ fn strip_alpha_row(src: &[u8], width: usize, rgb_idx: [u8; 3], dst: &mut [u8]) {
     let need_dst = width * 3;
     debug_assert!(src.len() >= need_src);
     debug_assert!(dst.len() >= need_dst);
-    let src_pixels = src[..need_src].chunks_exact(4);
-    let dst_pixels = dst[..need_dst].chunks_exact_mut(3);
-    let r = rgb_idx[0] as usize;
-    let g = rgb_idx[1] as usize;
-    let b = rgb_idx[2] as usize;
-    for (s, d) in src_pixels.zip(dst_pixels) {
-        d[0] = s[r];
-        d[1] = s[g];
-        d[2] = s[b];
+    let src_row = &src[..need_src];
+    let dst_row = &mut dst[..need_dst];
+    match rgb_idx {
+        [0, 1, 2] => {
+            // RGBA / Rgbx → drop byte 3, keep 0..3 in order.
+            // garb returns `Result<(), SizeError>`; we already
+            // sized the slices to match, so unwrap is infallible.
+            garb::bytes::rgba_to_rgb(src_row, dst_row).unwrap();
+        }
+        [2, 1, 0] => {
+            // BGRA / Bgrx → drop byte 3, swap 0↔2.
+            garb::bytes::bgra_to_rgb(src_row, dst_row).unwrap();
+        }
+        _ => {
+            // Defensive fallback for any new layout that
+            // `strip_alpha_indices` might map to in the future.
+            // Today only the two cases above reach here.
+            let r = rgb_idx[0] as usize;
+            let g = rgb_idx[1] as usize;
+            let b = rgb_idx[2] as usize;
+            for (s, d) in src_row.chunks_exact(4).zip(dst_row.chunks_exact_mut(3)) {
+                d[0] = s[r];
+                d[1] = s[g];
+                d[2] = s[b];
+            }
+        }
     }
 }
 

--- a/zenanalyze/src/tests.rs
+++ b/zenanalyze/src/tests.rs
@@ -3046,6 +3046,120 @@ fn aq_map_std_low_for_uniform_high_for_heterogeneous() {
 
 #[cfg(feature = "experimental")]
 #[test]
+fn skin_tone_fraction_fires_on_skin_colored_pixels_zero_on_neutral() {
+    // The Chai-Ngan YCbCr classifier (Cb [77,127], Cr [133,173], Y [40,240])
+    // is invariant to skin pigmentation by design — chroma quantifies hue
+    // not lightness. Verify that a representative tone in each common
+    // pigmentation lands inside the gate.
+    use crate::feature::{AnalysisFeature, AnalysisQuery, FeatureSet};
+
+    let q = AnalysisQuery::new(FeatureSet::just(AnalysisFeature::SkinToneFraction));
+
+    // Three sRGB skin tones spanning a wide range of pigmentations:
+    //   light  : (236, 188, 180)  — light pinkish
+    //   medium : (198, 134, 105)  — medium tan
+    //   dark   : (90,  56,  37)   — deep brown
+    // Each YCbCr-conversion lands inside the Chai-Ngan rectangle.
+    for (label, rgb) in [
+        ("light", [236u8, 188, 180]),
+        ("medium", [198u8, 134, 105]),
+        ("dark", [90u8, 56, 37]),
+    ] {
+        let mut buf = vec![0u8; 64 * 64 * 3];
+        for px in buf.chunks_exact_mut(3) {
+            px[0] = rgb[0];
+            px[1] = rgb[1];
+            px[2] = rgb[2];
+        }
+        let s = PixelSlice::new(&buf, 64, 64, 64 * 3, PixelDescriptor::RGB8_SRGB).unwrap();
+        let r = crate::analyze_features(s, &q).unwrap();
+        let f = r.get_f32(AnalysisFeature::SkinToneFraction).unwrap();
+        assert!(
+            f > 0.95,
+            "{label} skin tone {:?} should fire near 1.0, got {f}",
+            rgb
+        );
+    }
+
+    // Pure neutral grey: Cb = Cr = 128 — outside Cr [133, 173], so 0.
+    let neutral = vec![128u8; 64 * 64 * 3];
+    let s = PixelSlice::new(&neutral, 64, 64, 64 * 3, PixelDescriptor::RGB8_SRGB).unwrap();
+    let r = crate::analyze_features(s, &q).unwrap();
+    let f = r.get_f32(AnalysisFeature::SkinToneFraction).unwrap();
+    assert!(f < 0.01, "neutral grey ⇒ ~0.0, got {f}");
+
+    // Saturated blue: Cb high (≈240), outside the Cb [77, 127] gate.
+    let mut blue = vec![0u8; 64 * 64 * 3];
+    for px in blue.chunks_exact_mut(3) {
+        px[0] = 0;
+        px[1] = 0;
+        px[2] = 255;
+    }
+    let s = PixelSlice::new(&blue, 64, 64, 64 * 3, PixelDescriptor::RGB8_SRGB).unwrap();
+    let r = crate::analyze_features(s, &q).unwrap();
+    let f = r.get_f32(AnalysisFeature::SkinToneFraction).unwrap();
+    assert!(f < 0.01, "saturated blue ⇒ ~0.0, got {f}");
+}
+
+#[cfg(feature = "experimental")]
+#[test]
+fn edge_slope_stdev_low_for_uniform_high_for_varied_edges() {
+    // Synthetic two-tone bands at one luma step (all crossings have the
+    // same gradient magnitude) ⇒ very low stddev. Mixed-amplitude edges
+    // (alternating step heights) ⇒ higher stddev.
+    use crate::feature::{AnalysisFeature, AnalysisQuery, FeatureSet};
+
+    let q = AnalysisQuery::new(FeatureSet::just(AnalysisFeature::EdgeSlopeStdev));
+
+    // Uniform-amplitude vertical bands: every transition is the same
+    // magnitude. stddev should be ~0 (mean grad = single value).
+    let mut uniform = vec![0u8; 64 * 64 * 3];
+    for y in 0..64 {
+        for x in 0..64 {
+            let v = if (x / 4) % 2 == 0 { 50 } else { 200 };
+            let off = (y * 64 + x) * 3;
+            uniform[off] = v;
+            uniform[off + 1] = v;
+            uniform[off + 2] = v;
+        }
+    }
+    let s = PixelSlice::new(&uniform, 64, 64, 64 * 3, PixelDescriptor::RGB8_SRGB).unwrap();
+    let r = crate::analyze_features(s, &q).unwrap();
+    let e = r.get_f32(AnalysisFeature::EdgeSlopeStdev).unwrap();
+    assert!(
+        e < 5.0,
+        "uniform bands should have low stddev, got {e}"
+    );
+
+    // Mixed-amplitude vertical bands: alternating step heights produce
+    // a bimodal gradient distribution ⇒ higher stddev.
+    let mut mixed = vec![0u8; 64 * 64 * 3];
+    for y in 0..64 {
+        for x in 0..64 {
+            // 4-period: 0, 100, 50, 250 ⇒ steps of 100, 50, 200
+            let v = match (x / 4) % 4 {
+                0 => 0,
+                1 => 100,
+                2 => 50,
+                _ => 250,
+            };
+            let off = (y * 64 + x) * 3;
+            mixed[off] = v;
+            mixed[off + 1] = v;
+            mixed[off + 2] = v;
+        }
+    }
+    let s = PixelSlice::new(&mixed, 64, 64, 64 * 3, PixelDescriptor::RGB8_SRGB).unwrap();
+    let r = crate::analyze_features(s, &q).unwrap();
+    let e = r.get_f32(AnalysisFeature::EdgeSlopeStdev).unwrap();
+    assert!(
+        e > 30.0,
+        "mixed-amplitude bands should have high stddev, got {e}"
+    );
+}
+
+#[cfg(feature = "experimental")]
+#[test]
 fn grayscale_score_one_for_neutral_image_zero_for_saturated() {
     // Neutral (R=G=B) ⇒ score = 1.0; saturated colour ⇒ score ≈ 0.
     use crate::feature::{AnalysisFeature, AnalysisQuery, FeatureSet};

--- a/zenanalyze/src/tests.rs
+++ b/zenanalyze/src/tests.rs
@@ -2715,6 +2715,57 @@ fn sdr_srgb_does_not_trip_hdr_present() {
 
 #[cfg(feature = "experimental")]
 #[test]
+#[ignore] // run with `cargo test --release --features experimental -- perf_strip_alpha_vs_convert --ignored --nocapture`
+fn perf_strip_alpha_vs_convert() {
+    // RGBA8 used to route through RowConverter; now takes the
+    // native StripAlpha8 path. Compare the per-call cost to RGB8.
+    use crate::feature::{AnalysisQuery, FeatureSet};
+    use std::time::Instant;
+
+    let q = AnalysisQuery::new(FeatureSet::SUPPORTED);
+    let w: u32 = 4096;
+    let h: u32 = 4096;
+    let rgb = synth_rgb(w, h, 0xCAFE_F00D);
+    let mut rgba = vec![0u8; (w * h * 4) as usize];
+    for (i, px) in rgba.chunks_exact_mut(4).enumerate() {
+        px[0] = rgb[i * 3];
+        px[1] = rgb[i * 3 + 1];
+        px[2] = rgb[i * 3 + 2];
+        px[3] = 0xFF;
+    }
+
+    let s_rgb = PixelSlice::new(&rgb, w, h, (w * 3) as usize, PixelDescriptor::RGB8_SRGB).unwrap();
+    let _ = crate::analyze_features(s_rgb, &q).unwrap(); // warmup
+
+    let mut rgb8_us = Vec::with_capacity(5);
+    for _ in 0..5 {
+        let s = PixelSlice::new(&rgb, w, h, (w * 3) as usize, PixelDescriptor::RGB8_SRGB).unwrap();
+        let t0 = Instant::now();
+        let _ = crate::analyze_features(s, &q).unwrap();
+        rgb8_us.push(t0.elapsed().as_micros() as u64);
+    }
+    rgb8_us.sort_unstable();
+
+    let mut rgba8_us = Vec::with_capacity(5);
+    for _ in 0..5 {
+        let s = PixelSlice::new(&rgba, w, h, (w * 4) as usize, PixelDescriptor::RGBA8_SRGB)
+            .unwrap();
+        let t0 = Instant::now();
+        let _ = crate::analyze_features(s, &q).unwrap();
+        rgba8_us.push(t0.elapsed().as_micros() as u64);
+    }
+    rgba8_us.sort_unstable();
+
+    eprintln!(
+        "4K full-feature-set: RGB8 {} µs, RGBA8 {} µs (Δ = {} µs)",
+        rgb8_us[2],
+        rgba8_us[2],
+        rgba8_us[2] as i64 - rgb8_us[2] as i64
+    );
+}
+
+#[cfg(feature = "experimental")]
+#[test]
 #[ignore] // run with `cargo test --release --features experimental -- perf_full_feature_set --ignored --nocapture`
 fn perf_full_feature_set() {
     // Ad-hoc timing check: full feature surface on synthetic images

--- a/zenanalyze/src/tests.rs
+++ b/zenanalyze/src/tests.rs
@@ -3115,6 +3115,141 @@ fn effective_bit_depth_distinguishes_u8_promoted_from_genuine_u16() {
 }
 
 // --------------------------------------------------------------------
+// Regression: PR #116 review surfaced two real bugs.
+//
+// Bug 1 — `gradient_diff_ycbcr` (tier2_chroma.rs) used a
+//   `(cr_d.pow(2) as u32).saturating_mul(boost)` chain that silently
+//   clamped the per-group `max_diff_cr` to ~33.5M instead of the
+//   true ~62.9M on saturated synthetic content (alternating pure-red
+//   / pure-green columns). 1.87× undercount on `cr_peak_sharpness`.
+//   Fix: u64 intermediates.
+//
+// Bug 2 — `accumulate_row_simd` scalar tail (tier1.rs) only
+//   accumulated `edge_count`, dropping `cb_grad_sum` / `cr_grad_sum`
+//   / `chroma_grad_count` for the rightmost 1–7 columns when
+//   `(width − 1) % 8 ≠ 0`. Tiny on 4 K, 20 % on `width = 11`.
+//   Fix: same chroma-gradient accumulation as the SIMD edge loop.
+// --------------------------------------------------------------------
+
+#[test]
+fn pr116_review_cr_diff_no_overflow_on_saturated_chroma_columns() {
+    // Worst-case Cr second-difference: alternating saturated red /
+    // green columns. Pre-fix `cr_diff` saturated at u32::MAX / 128 ≈
+    // 33.5M; post-fix the u64 intermediates produce the correct
+    // ~62.9M. We don't lock the exact peak value (calibration is
+    // documented as drifting in 0.1.x), but we lock that the SIMD
+    // and scalar paths agree on the same image — saturating_mul
+    // would have made the scalar-tail-fed even-width image diverge
+    // from the all-SIMD odd-multiple-of-8 width.
+    use crate::feature::{AnalysisFeature, AnalysisQuery, FeatureSet};
+    let q = AnalysisQuery::new(FeatureSet::just(AnalysisFeature::CrPeakSharpness));
+
+    // 16-wide → all triplets handled by Tier 2 SIMD; no scalar tail.
+    let mut buf16 = vec![0u8; 16 * 8 * 3];
+    for y in 0..8 {
+        for x in 0..16 {
+            let i = ((y * 16 + x) * 3) as usize;
+            // Alternating saturated red / green columns.
+            if x % 2 == 0 {
+                buf16[i] = 255;
+                buf16[i + 1] = 0;
+                buf16[i + 2] = 0;
+            } else {
+                buf16[i] = 0;
+                buf16[i + 1] = 255;
+                buf16[i + 2] = 0;
+            }
+        }
+    }
+    let s = PixelSlice::new(&buf16, 16, 8, 16 * 3, PixelDescriptor::RGB8_SRGB).unwrap();
+    let r16 = crate::analyze_features(s, &q).unwrap();
+    let p16 = r16.get_f32(AnalysisFeature::CrPeakSharpness).unwrap();
+
+    // Same content at 11-wide forces the scalar gradient_diff_ycbcr
+    // path on the rightmost triplets. The peak should be in the
+    // same ballpark — pre-fix it would have been clamped to ~half
+    // the SIMD value because saturating_mul kicked in.
+    let mut buf11 = vec![0u8; 11 * 8 * 3];
+    for y in 0..8 {
+        for x in 0..11 {
+            let i = ((y * 11 + x) * 3) as usize;
+            if x % 2 == 0 {
+                buf11[i] = 255;
+                buf11[i + 1] = 0;
+                buf11[i + 2] = 0;
+            } else {
+                buf11[i] = 0;
+                buf11[i + 1] = 255;
+                buf11[i + 2] = 0;
+            }
+        }
+    }
+    let s = PixelSlice::new(&buf11, 11, 8, 11 * 3, PixelDescriptor::RGB8_SRGB).unwrap();
+    let r11 = crate::analyze_features(s, &q).unwrap();
+    let p11 = r11.get_f32(AnalysisFeature::CrPeakSharpness).unwrap();
+
+    // Both paths must report a peak ≥ 100. Pre-fix the scalar path
+    // would have clamped to ≈ 355 (33.5M / peak_div) while the SIMD
+    // path produces ≈ 666; here we just want both well above the
+    // pre-fix ceiling, proving overflow is gone.
+    assert!(
+        p16 > 100.0,
+        "16-wide saturated-chroma cr peak too low: {p16}"
+    );
+    assert!(
+        p11 > 100.0,
+        "11-wide saturated-chroma cr peak too low: {p11}"
+    );
+    // And they should be in the same ballpark (within 2× of each
+    // other) — pre-fix the difference was 1.87× for content that
+    // exercised the scalar path heavily.
+    let ratio = if p11 > p16 { p11 / p16 } else { p16 / p11 };
+    assert!(
+        ratio < 2.0,
+        "scalar (11) vs SIMD (16) cr_peak diverge: 11→{p11} 16→{p16} ratio={ratio}"
+    );
+}
+
+#[test]
+fn pr116_review_chroma_gradients_counted_in_scalar_tail() {
+    // `accumulate_row_simd` scalar tail used to drop cb/cr gradient
+    // accumulation. On `width = 11` (one SIMD chunk + 2 tail edge
+    // pixels), the tail represents 20 % of edge positions per row.
+    // Saturated-chroma horizontal stripes give a non-trivial
+    // `cb_sharpness` / `cr_sharpness` that pre-fix would have
+    // under-reported.
+    use crate::feature::{AnalysisFeature, AnalysisQuery, FeatureSet};
+
+    // Vertical stripes — each row has the same per-pixel chroma
+    // gradient at every column transition. Making `width = 11` puts
+    // 8 transitions in the SIMD loop and 2 in the scalar tail.
+    let mut buf = vec![0u8; 11 * 8 * 3];
+    for y in 0..8 {
+        for x in 0..11 {
+            let i = ((y * 11 + x) * 3) as usize;
+            if x % 2 == 0 {
+                buf[i] = 255; // red
+            } else {
+                buf[i + 2] = 255; // blue
+            }
+        }
+    }
+    let q = AnalysisQuery::new(
+        FeatureSet::just(AnalysisFeature::CbSharpness).with(AnalysisFeature::CrSharpness),
+    );
+    let s = PixelSlice::new(&buf, 11, 8, 11 * 3, PixelDescriptor::RGB8_SRGB).unwrap();
+    let r = crate::analyze_features(s, &q).unwrap();
+    let cb = r.get_f32(AnalysisFeature::CbSharpness).unwrap();
+    let cr = r.get_f32(AnalysisFeature::CrSharpness).unwrap();
+    // Both signals must be substantial — saturated red↔blue stripes
+    // produce massive Cb gradients (B − Y flips full-scale every
+    // column). Pre-fix the scalar tail's 2 columns wouldn't have
+    // contributed at all, biasing the average down by ~20 %.
+    assert!(cb > 0.3, "cb_sharpness on red↔blue stripes too low: {cb}");
+    assert!(cr > 0.1, "cr_sharpness on red↔blue stripes too low: {cr}");
+}
+
+// --------------------------------------------------------------------
 // Per-primaries luma weights: wide-gamut u8 sources go through the
 // Native zero-copy path with their bytes intact; the analyzer must
 // use per-primaries weights so the luma stats reflect the source's

--- a/zenanalyze/src/tests.rs
+++ b/zenanalyze/src/tests.rs
@@ -3115,6 +3115,55 @@ fn effective_bit_depth_distinguishes_u8_promoted_from_genuine_u16() {
 }
 
 // --------------------------------------------------------------------
+// Per-primaries luma weights: wide-gamut u8 sources go through the
+// Native zero-copy path with their bytes intact; the analyzer must
+// use per-primaries weights so the luma stats reflect the source's
+// actual chromaticity matrix, not the sRGB / BT.601 baseline.
+// --------------------------------------------------------------------
+
+#[test]
+fn wide_gamut_luma_histogram_lands_in_different_bin_than_srgb() {
+    // The same pure-green RGB bytes, declared under different
+    // primaries, must produce different luma values — because
+    // each primary set's RGB→XYZ Y-row scales green differently
+    // (BT.601 ≈ 0.587, BT.2020 ≈ 0.678, DisplayP3 ≈ 0.692,
+    // AdobeRgb ≈ 0.627). The histogram bin lands somewhere in
+    // [4, 5] for sRGB and [4, 5] for AdobeRgb but at a noticeably
+    // higher bin for BT.2020 / DisplayP3. Easiest to lock: capture
+    // the LumaHistogramEntropy as 0 (solid image, single bin)
+    // for every primaries — but verify the analyzer ACCEPTS
+    // every primaries set unchanged, and that variance stays
+    // ~0 (proves the per-primaries weights produce internally-
+    // consistent luma).
+    use crate::feature::{AnalysisFeature, AnalysisQuery, FeatureSet};
+
+    let q = AnalysisQuery::new(
+        FeatureSet::just(AnalysisFeature::Variance)
+            .with(AnalysisFeature::LumaHistogramEntropy),
+    );
+    let mut buf = vec![0u8; 64 * 64 * 3];
+    for px in buf.chunks_exact_mut(3) {
+        px[0] = 0;
+        px[1] = 255;
+        px[2] = 0;
+    }
+    for &p in &[
+        zenpixels::ColorPrimaries::Bt709,
+        zenpixels::ColorPrimaries::Bt2020,
+        zenpixels::ColorPrimaries::DisplayP3,
+        zenpixels::ColorPrimaries::AdobeRgb,
+    ] {
+        let desc = PixelDescriptor::RGB8_SRGB.with_primaries(p);
+        let s = PixelSlice::new(&buf, 64, 64, 64 * 3, desc).unwrap();
+        let r = crate::analyze_features(s, &q).unwrap();
+        let v = r.get_f32(AnalysisFeature::Variance).unwrap();
+        assert!(v < 0.5, "{p:?}: solid green variance = {v}");
+        let h = r.get_f32(AnalysisFeature::LumaHistogramEntropy).unwrap();
+        assert!(h.abs() < 1e-3, "{p:?}: solid green entropy = {h}");
+    }
+}
+
+// --------------------------------------------------------------------
 // Sanity matrix: every channel-type × transfer × primaries combination
 // the analyzer is expected to handle. Verifies (1) no error is returned
 // across the cross-product, (2) the source_descriptor accessor returns

--- a/zenanalyze/src/tests.rs
+++ b/zenanalyze/src/tests.rs
@@ -167,6 +167,7 @@ fn vstripes_have_high_horiz_chroma_zero_vert() {
     assert_eq!(out.cr_vert_sharpness, 0.0);
 }
 
+#[cfg(feature = "composites")]
 #[test]
 fn synthetic_image_likelihoods_in_unit_interval() {
     let out = analyze_rgb8(&synth_rgb(128, 128, 42), 128, 128);
@@ -470,9 +471,12 @@ fn assert_well_formed(out: &TestOutput, w: u32, h: u32) {
         "aspect_ratio: expected {expected_ar}, got {}",
         out.aspect_ratio
     );
-    assert!((0.0..=1.0).contains(&out.text_likelihood));
-    assert!((0.0..=1.0).contains(&out.screen_content_likelihood));
-    assert!((0.0..=1.0).contains(&out.natural_likelihood));
+    #[cfg(feature = "composites")]
+    {
+        assert!((0.0..=1.0).contains(&out.text_likelihood));
+        assert!((0.0..=1.0).contains(&out.screen_content_likelihood));
+        assert!((0.0..=1.0).contains(&out.natural_likelihood));
+    }
     assert!(
         (0.0..=5.0).contains(&out.luma_histogram_entropy),
         "entropy: {}",
@@ -634,15 +638,18 @@ fn medium_image_is_deterministic() {
         a.luma_histogram_entropy.to_bits(),
         b.luma_histogram_entropy.to_bits()
     );
-    assert_eq!(a.text_likelihood.to_bits(), b.text_likelihood.to_bits());
-    assert_eq!(
-        a.screen_content_likelihood.to_bits(),
-        b.screen_content_likelihood.to_bits()
-    );
-    assert_eq!(
-        a.natural_likelihood.to_bits(),
-        b.natural_likelihood.to_bits()
-    );
+    #[cfg(feature = "composites")]
+    {
+        assert_eq!(a.text_likelihood.to_bits(), b.text_likelihood.to_bits());
+        assert_eq!(
+            a.screen_content_likelihood.to_bits(),
+            b.screen_content_likelihood.to_bits()
+        );
+        assert_eq!(
+            a.natural_likelihood.to_bits(),
+            b.natural_likelihood.to_bits()
+        );
+    }
     assert_eq!(a.distinct_color_bins, b.distinct_color_bins);
 }
 
@@ -1595,8 +1602,15 @@ fn requesting_more_features_does_not_change_existing_values() {
         v.push(DctCompressibilityY);
         v
     };
-    let probes_b: &[AnalysisFeature] =
-        &[HighFreqEnergyRatio, AlphaPresent, ScreenContentLikelihood];
+    // Always include a stable T3 + Alpha probe; ScreenContentLikelihood
+    // (composite) only joins the matrix when the cargo feature is on.
+    let probes_b: &[AnalysisFeature] = &[HighFreqEnergyRatio, AlphaPresent];
+    #[cfg(feature = "composites")]
+    let probes_b = {
+        let mut v = probes_b.to_vec();
+        v.push(ScreenContentLikelihood);
+        v
+    };
     #[cfg(feature = "experimental")]
     let probes_b = {
         let mut v = probes_b.to_vec();
@@ -1823,6 +1837,7 @@ fn math_lock_geometry_exact() {
     assert_eq!(big.pixels(), u32::MAX as u64 * u32::MAX as u64);
 }
 
+#[cfg(feature = "composites")]
 #[test]
 fn math_lock_likelihoods_in_unit_interval_for_random_input() {
     // Locks the contract: TextLikelihood / ScreenContentLikelihood /
@@ -1879,15 +1894,18 @@ fn math_lock_deterministic_input_is_reproducible() {
         a.luma_histogram_entropy.to_bits(),
         b.luma_histogram_entropy.to_bits()
     );
-    assert_eq!(a.text_likelihood.to_bits(), b.text_likelihood.to_bits());
-    assert_eq!(
-        a.screen_content_likelihood.to_bits(),
-        b.screen_content_likelihood.to_bits()
-    );
-    assert_eq!(
-        a.natural_likelihood.to_bits(),
-        b.natural_likelihood.to_bits()
-    );
+    #[cfg(feature = "composites")]
+    {
+        assert_eq!(a.text_likelihood.to_bits(), b.text_likelihood.to_bits());
+        assert_eq!(
+            a.screen_content_likelihood.to_bits(),
+            b.screen_content_likelihood.to_bits()
+        );
+        assert_eq!(
+            a.natural_likelihood.to_bits(),
+            b.natural_likelihood.to_bits()
+        );
+    }
 }
 
 #[test]
@@ -2104,6 +2122,7 @@ fn analysis_feature_name_returns_field_name_string() {
         "distinct_color_bins"
     );
     assert_eq!(AnalysisFeature::AlphaPresent.name(), "alpha_present");
+    #[cfg(feature = "composites")]
     assert_eq!(
         AnalysisFeature::ScreenContentLikelihood.name(),
         "screen_content_likelihood"
@@ -2921,7 +2940,7 @@ fn gamut_coverage_zero_for_saturated_rec2020_green() {
     );
 }
 
-#[cfg(feature = "experimental")]
+#[cfg(feature = "composites")]
 #[test]
 fn line_art_score_high_for_two_tone_low_for_natural() {
     // A black-on-white line drawing-shaped image should score high.

--- a/zenanalyze/src/tier1.rs
+++ b/zenanalyze/src/tier1.rs
@@ -18,9 +18,9 @@ use super::feature::RawAnalysis;
 use super::row_stream::RowStream;
 use archmage::{incant, magetypes};
 
-const KR: f32 = 0.299;
-const KG: f32 = 0.587;
-const KB: f32 = 0.114;
+// Luma weights are no longer constants — they're picked per-source-
+// primaries by `crate::luma::LumaWeights::for_primaries(...)` and
+// threaded into the SIMD kernels as `kr / kg / kb` parameters.
 const EDGE_THRESH_SQ: f32 = 400.0; // (|∇L| > 20)²
 
 /// Stripe height. Matches the 8×8 block size used for uniformity so
@@ -95,6 +95,13 @@ pub fn extract_tier1_into(out: &mut RawAnalysis, stream: &mut RowStream<'_>, pix
         return;
     }
 
+    // Per-primaries luma weights — wide-gamut u8 sources go through
+    // RowStream's Native zero-copy path with their bytes intact, so
+    // the analyzer must use the right matrix for those bytes (BT.2020
+    // for Rec.2020 sources, etc.) rather than the BT.601 sRGB
+    // baseline. See `crate::luma::LumaWeights::for_primaries`.
+    let weights = crate::luma::LumaWeights::for_primaries(stream.primaries());
+
     let stripe_step = compute_stripe_step(w, h, pixel_budget);
     let row_bytes = w * 3;
     let blocks_x = w / STRIPE_H;
@@ -120,7 +127,7 @@ pub fn extract_tier1_into(out: &mut RawAnalysis, stream: &mut RowStream<'_>, pix
     // Stripe scratch holds 9 rows (the 8-row stripe + the lookahead
     // row for vertical gradient at the last interior row of the
     // stripe). Allocated once, reused across every active stripe.
-    // 9 × max_width × 3 = ~108 KB at 4K width.
+    // 9 × max_width × 3 = ~108 kb at 4K width.
     let stripe_rows = STRIPE_H + 1;
     let mut stripe_buf = vec![0u8; stripe_rows * row_bytes];
 
@@ -171,7 +178,7 @@ pub fn extract_tier1_into(out: &mut RawAnalysis, stream: &mut RowStream<'_>, pix
                 None
             };
 
-            accumulate_row_dispatch(&stripe_buf, row_off, next_row_off, w, &mut stats);
+            accumulate_row_dispatch(&stripe_buf, row_off, next_row_off, w, &weights, &mut stats);
 
             // Laplacian: 3-row window. Skip the topmost row of the
             // image (no `prev_row` available) and the bottom row of
@@ -191,7 +198,7 @@ pub fn extract_tier1_into(out: &mut RawAnalysis, stream: &mut RowStream<'_>, pix
                     let prev_row = &stripe_buf[prev_off..prev_off + row_bytes];
                     let cur_row = &stripe_buf[cur_off..cur_off + row_bytes];
                     let nxt_row = &stripe_buf[nxt_off..nxt_off + row_bytes];
-                    accumulate_laplacian_dispatch(prev_row, cur_row, nxt_row, w, &mut stats);
+                    accumulate_laplacian_dispatch(prev_row, cur_row, nxt_row, w, &weights, &mut stats);
                 }
             }
 
@@ -471,9 +478,21 @@ fn accumulate_row_dispatch(
     row_off: usize,
     next_row_off: Option<usize>,
     width: usize,
+    weights: &crate::luma::LumaWeights,
     stats: &mut PixelStats,
 ) {
-    let row_stats = incant!(accumulate_row_simd(rgb, row_off, next_row_off, width));
+    let kr = weights.kr;
+    let kg = weights.kg;
+    let kb = weights.kb;
+    let row_stats = incant!(accumulate_row_simd(
+        rgb,
+        row_off,
+        next_row_off,
+        width,
+        kr,
+        kg,
+        kb
+    ));
     stats.merge(&row_stats);
 }
 
@@ -637,6 +656,9 @@ fn accumulate_row_simd(
     row_off: usize,
     next_row_off: Option<usize>,
     width: usize,
+    kr: f32,
+    kg: f32,
+    kb: f32,
 ) -> PixelStats {
     // Outer f64 accumulators — only touched during the periodic flush.
     let mut luma_sum: f64 = 0.0;
@@ -655,9 +677,9 @@ fn accumulate_row_simd(
     let next_row = next_row_off.map(|nr| &rgb[nr..nr + width * 3]);
 
     // ---- f32x8 stats pass: 8 pixels (24 bytes) per chunk ----
-    let kr_v = f32x8::splat(token, KR);
-    let kg_v = f32x8::splat(token, KG);
-    let kb_v = f32x8::splat(token, KB);
+    let kr_v = f32x8::splat(token, kr);
+    let kg_v = f32x8::splat(token, kg);
+    let kb_v = f32x8::splat(token, kb);
     let inv_255_v = f32x8::splat(token, 1.0 / 255.0);
     let half_v = f32x8::splat(token, 0.5);
 
@@ -754,7 +776,7 @@ fn accumulate_row_simd(
         let r = px[0] as f32;
         let g = px[1] as f32;
         let b = px[2] as f32;
-        let l = KR * r + KG * g + KB * b;
+        let l = kr * r + kg * g + kb * b;
         luma_sum += l as f64;
         luma_sq_sum += (l * l) as f64;
         let cb = (b - l) * (1.0 / 255.0);
@@ -796,11 +818,11 @@ fn accumulate_row_simd(
                 let cr_ = c[i * 3] as f32;
                 let cg_ = c[i * 3 + 1] as f32;
                 let cb_ = c[i * 3 + 2] as f32;
-                let l = KR * cr_ + KG * cg_ + KB * cb_;
+                let l = kr * cr_ + kg * cg_ + kb * cb_;
                 let rr_ = r_chunk[i * 3] as f32;
                 let rg_ = r_chunk[i * 3 + 1] as f32;
                 let rb_ = r_chunk[i * 3 + 2] as f32;
-                let lr = KR * rr_ + KG * rg_ + KB * rb_;
+                let lr = kr * rr_ + kg * rg_ + kb * rb_;
                 let gx = lr - l;
                 let mut grad_sq = gx * gx;
 
@@ -813,9 +835,9 @@ fn accumulate_row_simd(
                 chroma_grad_count += 1;
 
                 if has_next {
-                    let ld = KR * d_chunk[i * 3] as f32
-                        + KG * d_chunk[i * 3 + 1] as f32
-                        + KB * d_chunk[i * 3 + 2] as f32;
+                    let ld = kr * d_chunk[i * 3] as f32
+                        + kg * d_chunk[i * 3 + 1] as f32
+                        + kb * d_chunk[i * 3 + 2] as f32;
                     grad_sq += (ld - l) * (ld - l);
                 }
                 if grad_sq > EDGE_THRESH_SQ {
@@ -828,15 +850,15 @@ fn accumulate_row_simd(
         let processed = (width - 1) / 8 * 8;
         for x in processed..width - 1 {
             let off = row_off + x * 3;
-            let l = KR * rgb[off] as f32 + KG * rgb[off + 1] as f32 + KB * rgb[off + 2] as f32;
+            let l = kr * rgb[off] as f32 + kg * rgb[off + 1] as f32 + kb * rgb[off + 2] as f32;
             let roff = row_off + (x + 1) * 3;
-            let lr = KR * rgb[roff] as f32 + KG * rgb[roff + 1] as f32 + KB * rgb[roff + 2] as f32;
+            let lr = kr * rgb[roff] as f32 + kg * rgb[roff + 1] as f32 + kb * rgb[roff + 2] as f32;
             let gx = lr - l;
             let mut grad_sq = gx * gx;
             if has_next {
                 let doff = next_row_off.unwrap() + x * 3;
                 let ld =
-                    KR * rgb[doff] as f32 + KG * rgb[doff + 1] as f32 + KB * rgb[doff + 2] as f32;
+                    kr * rgb[doff] as f32 + kg * rgb[doff + 1] as f32 + kb * rgb[doff + 2] as f32;
                 grad_sq += (ld - l) * (ld - l);
             }
             if grad_sq > EDGE_THRESH_SQ {
@@ -883,6 +905,9 @@ fn accumulate_laplacian_simd(
     cur_row: &[u8],
     next_row: &[u8],
     width: usize,
+    kr: f32,
+    kg: f32,
+    kb: f32,
 ) -> (f64, f64, u64) {
     if width < 3 {
         return (0.0, 0.0, 0);
@@ -892,14 +917,14 @@ fn accumulate_laplacian_simd(
     let mut next_l = vec![0.0f32; width];
     for x in 0..width {
         let off = x * 3;
-        prev_l[x] = KR * prev_row[off] as f32
-            + KG * prev_row[off + 1] as f32
-            + KB * prev_row[off + 2] as f32;
+        prev_l[x] = kr * prev_row[off] as f32
+            + kg * prev_row[off + 1] as f32
+            + kb * prev_row[off + 2] as f32;
         cur_l[x] =
-            KR * cur_row[off] as f32 + KG * cur_row[off + 1] as f32 + KB * cur_row[off + 2] as f32;
-        next_l[x] = KR * next_row[off] as f32
-            + KG * next_row[off + 1] as f32
-            + KB * next_row[off + 2] as f32;
+            kr * cur_row[off] as f32 + kg * cur_row[off + 1] as f32 + kb * cur_row[off + 2] as f32;
+        next_l[x] = kr * next_row[off] as f32
+            + kg * next_row[off + 1] as f32
+            + kb * next_row[off + 2] as f32;
     }
 
     // Stencil over interior columns 1..width-1. Process 8 pixels per
@@ -962,10 +987,14 @@ fn accumulate_laplacian_dispatch(
     cur_row: &[u8],
     next_row: &[u8],
     width: usize,
+    weights: &crate::luma::LumaWeights,
     stats: &mut PixelStats,
 ) {
+    let kr = weights.kr;
+    let kg = weights.kg;
+    let kb = weights.kb;
     let (s, sq, n) = incant!(accumulate_laplacian_simd(
-        prev_row, cur_row, next_row, width
+        prev_row, cur_row, next_row, width, kr, kg, kb
     ));
     stats.laplacian_sum += s;
     stats.laplacian_sq_sum += sq;

--- a/zenanalyze/src/tier1.rs
+++ b/zenanalyze/src/tier1.rs
@@ -103,7 +103,52 @@ impl PixelStats {
 /// Pass [`DEFAULT_PIXEL_BUDGET`] to match the oracle-trained reference
 /// behavior; pass a smaller value for proxy-server speed (with reduced
 /// feature precision on multi-megapixel inputs).
+/// Per-call dispatch knobs for the Tier 1 stripe sweep. Lets the
+/// caller skip optional accumulators / passes that the requested
+/// `FeatureSet` doesn't need, recovering register pressure on the
+/// AVX2 hot path. Computed once per `analyze_features` call from
+/// `feature::TIER1_EXTRAS_FEATURES`.
+#[derive(Clone, Copy)]
+pub(crate) struct Tier1Dispatch {
+    /// Skip the separate Laplacian SIMD row pass when
+    /// `LaplacianVariance` isn't requested.
+    pub(crate) wants_laplacian: bool,
+    /// Run the full SIMD kernel's optional accumulators
+    /// (luma_sum/sq for Variance, rg/yb for Colourfulness, edge_grad
+    /// sums for EdgeSlopeStdev). Gated on the Skin axis below — on
+    /// AVX2's 16-register file the kernel runs out of YMM regs when
+    /// FULL + SKIN are both live, so peel them apart.
+    pub(crate) wants_full_kernel: bool,
+    /// Run the BT.601 chroma matrix + Chai-Ngan skin-tone gate.
+    /// Independent of `wants_full_kernel` — `SkinToneFraction` can
+    /// be queried on its own without paying for Variance /
+    /// Colourfulness / EdgeSlope, and likewise `Variance` doesn't
+    /// pay for the skin gate's 6 mask compares + 5 ANDs + 2 chroma
+    /// FMAs per chunk. Splitting this out off `wants_full_kernel`
+    /// is the AVX2-register-pressure relief flagged by `cargo asm`.
+    pub(crate) wants_skin: bool,
+}
+
+impl Tier1Dispatch {
+    pub(crate) fn full() -> Self {
+        Self {
+            wants_laplacian: true,
+            wants_full_kernel: true,
+            wants_skin: true,
+        }
+    }
+}
+
 pub fn extract_tier1_into(out: &mut RawAnalysis, stream: &mut RowStream<'_>, pixel_budget: usize) {
+    extract_tier1_into_dispatch(out, stream, pixel_budget, Tier1Dispatch::full());
+}
+
+pub(crate) fn extract_tier1_into_dispatch(
+    out: &mut RawAnalysis,
+    stream: &mut RowStream<'_>,
+    pixel_budget: usize,
+    dispatch: Tier1Dispatch,
+) {
     let w = stream.width() as usize;
     let h = stream.height() as usize;
     if w < 2 || h < 2 {
@@ -206,28 +251,40 @@ pub fn extract_tier1_into(out: &mut RawAnalysis, stream: &mut RowStream<'_>, pix
                 None
             };
 
-            accumulate_row_dispatch(&stripe_buf, row_off, next_row_off, w, &weights, &mut stats);
+            accumulate_row_dispatch(
+                &stripe_buf,
+                row_off,
+                next_row_off,
+                w,
+                &weights,
+                dispatch.wants_full_kernel,
+                dispatch.wants_skin,
+                &mut stats,
+            );
 
             // Laplacian: 3-row window. Skip the topmost row of the
             // image (no `prev_row` available) and the bottom row of
             // the stripe (will be picked up by the lookahead row of
             // *this* stripe — see the prev_row index below).
-            if y_start + y_local >= 1 && y_start + y_local + 1 < h {
-                // `prev_row` is one row above the current row in the
-                // image. Inside the stripe buffer that's `y_local - 1`
-                // when `y_local >= 1`; when `y_local == 0` and we have
-                // an `y_start >= 1`, we'd need the row from the prior
-                // stripe — skip those rows for simplicity (cost: drop
-                // ~1 row per stripe, which is <1.5% of sampled pixels).
-                if y_local >= 1 {
-                    let prev_off = (y_local - 1) * row_bytes;
-                    let cur_off = row_off;
-                    let nxt_off = (y_local + 1) * row_bytes;
-                    let prev_row = &stripe_buf[prev_off..prev_off + row_bytes];
-                    let cur_row = &stripe_buf[cur_off..cur_off + row_bytes];
-                    let nxt_row = &stripe_buf[nxt_off..nxt_off + row_bytes];
-                    accumulate_laplacian_dispatch(prev_row, cur_row, nxt_row, w, &weights, &mut stats);
-                }
+            //
+            // Whole pass elided when the caller's `FeatureSet` doesn't
+            // intersect `TIER1_EXTRAS_FEATURES` (no `LaplacianVariance`
+            // request) — saves a separate SIMD row walk per interior
+            // sampled row. Dominant `LaplacianVariance` consumer is
+            // `FeatureSet::SUPPORTED`; orchestrator-style callers like
+            // zenjpeg's `ADAPTIVE_FEATURES` don't request it.
+            if dispatch.wants_laplacian
+                && y_start + y_local >= 1
+                && y_start + y_local + 1 < h
+                && y_local >= 1
+            {
+                let prev_off = (y_local - 1) * row_bytes;
+                let cur_off = row_off;
+                let nxt_off = (y_local + 1) * row_bytes;
+                let prev_row = &stripe_buf[prev_off..prev_off + row_bytes];
+                let cur_row = &stripe_buf[cur_off..cur_off + row_bytes];
+                let nxt_row = &stripe_buf[nxt_off..nxt_off + row_bytes];
+                accumulate_laplacian_dispatch(prev_row, cur_row, nxt_row, w, &weights, &mut stats);
             }
 
             // SkinToneFraction + EdgeSlopeStdev were folded INTO
@@ -517,45 +574,59 @@ fn compute_stripe_phase(
 }
 
 /// Runtime dispatch wrapper for the magetypes f32x8 row pass.
+#[allow(clippy::too_many_arguments)]
 fn accumulate_row_dispatch(
     rgb: &[u8],
     row_off: usize,
     next_row_off: Option<usize>,
     width: usize,
     weights: &crate::luma::LumaWeights,
+    full: bool,
+    skin: bool,
     stats: &mut PixelStats,
 ) {
     let kr = weights.kr;
     let kg = weights.kg;
     let kb = weights.kb;
-    // BT.601 is the calibrated baseline for sRGB / BT.709 sources
-    // (see `crate::luma`). Specialise the kernel for that case so
-    // LLVM emits `vfmadd*` with immediate operands instead of register-
-    // loaded `kr_v / kg_v / kb_v` splats — frees three YMM registers
-    // and unblocks downstream register allocation in the AVX2 path.
-    // The `Unknown` primaries case routes here too because it shares
-    // the BT.601 defaults via `LumaWeights::for_primaries`.
+    // 8-arm dispatch on (BT601, FULL, SKIN). BT601=true const-folds
+    // luma weights to immediate vfmadd operands. FULL=true unlocks
+    // luma stats + Hasler M3 + edge-slope batching. SKIN=true unlocks
+    // BT.601 chroma matrix + Chai-Ngan gate. Splitting SKIN off FULL
+    // is the AVX2-register-pressure relief — `cargo asm` showed the
+    // joint kernel spilled 12 vmovups + rebroadcast 13 constants
+    // because all accumulators were live at once.
+    //
+    // Caller dispatch points:
+    // - zenjpeg ADAPTIVE_FEATURES → `<true, false, false>` (no extras)
+    // - just Variance / Colourfulness / EdgeSlope → `<*, true, false>`
+    // - just SkinToneFraction → `<*, false, true>`
+    // - FeatureSet::SUPPORTED → `<*, true, true>`
     let is_bt601 = weights.is_bt601_baseline();
-    let row_stats = if is_bt601 {
-        incant!(accumulate_row_simd::<true>(
-            rgb,
-            row_off,
-            next_row_off,
-            width,
-            kr,
-            kg,
-            kb
-        ))
-    } else {
-        incant!(accumulate_row_simd::<false>(
-            rgb,
-            row_off,
-            next_row_off,
-            width,
-            kr,
-            kg,
-            kb
-        ))
+    let row_stats = match (is_bt601, full, skin) {
+        (true, true, true) => incant!(accumulate_row_simd::<true, true, true>(
+            rgb, row_off, next_row_off, width, kr, kg, kb
+        )),
+        (true, true, false) => incant!(accumulate_row_simd::<true, true, false>(
+            rgb, row_off, next_row_off, width, kr, kg, kb
+        )),
+        (true, false, true) => incant!(accumulate_row_simd::<true, false, true>(
+            rgb, row_off, next_row_off, width, kr, kg, kb
+        )),
+        (true, false, false) => incant!(accumulate_row_simd::<true, false, false>(
+            rgb, row_off, next_row_off, width, kr, kg, kb
+        )),
+        (false, true, true) => incant!(accumulate_row_simd::<false, true, true>(
+            rgb, row_off, next_row_off, width, kr, kg, kb
+        )),
+        (false, true, false) => incant!(accumulate_row_simd::<false, true, false>(
+            rgb, row_off, next_row_off, width, kr, kg, kb
+        )),
+        (false, false, true) => incant!(accumulate_row_simd::<false, false, true>(
+            rgb, row_off, next_row_off, width, kr, kg, kb
+        )),
+        (false, false, false) => incant!(accumulate_row_simd::<false, false, false>(
+            rgb, row_off, next_row_off, width, kr, kg, kb
+        )),
     };
     stats.merge(&row_stats);
 }
@@ -714,7 +785,7 @@ fn stripe_block_stats_simd(
 /// Edge pass: still scalar (per-tier target_feature region from the
 /// `#[magetypes]` macro lets LLVM autovec the simple stencil).
 #[magetypes(define(f32x8), v4, v3, neon, wasm128, scalar)]
-fn accumulate_row_simd<const BT601: bool>(
+fn accumulate_row_simd<const BT601: bool, const FULL: bool, const SKIN: bool>(
     token: Token,
     rgb: &[u8],
     row_off: usize,
@@ -826,111 +897,131 @@ fn accumulate_row_simd<const BT601: bool>(
         // BT.601 luma: l = 0.299·r + 0.587·g + 0.114·b
         let l = r.mul_add(kr_v, g.mul_add(kg_v, b * kb_v));
         // Chroma stats (simplified): cb_stat = (b − l) / 255;
-        // cr_stat = (r − l) / 255. Used by the chroma_complexity /
-        // cb_sharpness / cr_sharpness shape signals — variance-based,
-        // so the offset doesn't matter.
+        // cr_stat = (r − l) / 255. Always-on (drives chroma_complexity
+        // and Cb/Cr sharpness shape signals).
         let cb = (b - l) * inv_255_v;
         let cr = (r - l) * inv_255_v;
-        // Hasler M3: rg = r − g; yb = 0.5·(r + g) − b
-        let rg = r - g;
-        let yb = (r + g).mul_add(half_v, -b);
 
-        // BT.601 chroma in the [0, 255] u8 representation that the
-        // skin-tone classifier was calibrated against. Three fma per
-        // channel — six fma total per chunk on top of the existing
-        // stats. Then six lane compares + five ANDs + one blend +
-        // one fma to produce a lane-wise running counter.
-        let cb_u8 = r.mul_add(cb_kr_v, g.mul_add(cb_kg_v, b.mul_add(cb_kb_v, off_128_v)));
-        let cr_u8 = r.mul_add(cr_kr_v, g.mul_add(cr_kg_v, b.mul_add(cr_kb_v, off_128_v)));
-        let m_y_lo = l.simd_ge(y_lo_v);
-        let m_y_hi = l.simd_le(y_hi_v);
-        let m_cb_lo = cb_u8.simd_ge(cb_lo_v);
-        let m_cb_hi = cb_u8.simd_le(cb_hi_v);
-        let m_cr_lo = cr_u8.simd_ge(cr_lo_v);
-        let m_cr_hi = cr_u8.simd_le(cr_hi_v);
-        let skin = m_y_lo & m_y_hi & m_cb_lo & m_cb_hi & m_cr_lo & m_cr_hi;
-        skin_count_v += f32x8::blend(skin, one_v, zero_v);
-
-        luma_sum_v += l;
-        luma_sq_v = l.mul_add(l, luma_sq_v);
         cb_sum_v += cb;
         cb_sq_v = cb.mul_add(cb, cb_sq_v);
         cr_sum_v += cr;
         cr_sq_v = cr.mul_add(cr, cr_sq_v);
-        rg_sum_v += rg;
-        rg_sq_v = rg.mul_add(rg, rg_sq_v);
-        yb_sum_v += yb;
-        yb_sq_v = yb.mul_add(yb, yb_sq_v);
+
+        // FULL-only accumulators: luma stats (Variance), Hasler M3
+        // (Colourfulness). Const-folds away on `!FULL`.
+        if FULL {
+            // Hasler M3: rg = r − g; yb = 0.5·(r + g) − b
+            let rg = r - g;
+            let yb = (r + g).mul_add(half_v, -b);
+            luma_sum_v += l;
+            luma_sq_v = l.mul_add(l, luma_sq_v);
+            rg_sum_v += rg;
+            rg_sq_v = rg.mul_add(rg, rg_sq_v);
+            yb_sum_v += yb;
+            yb_sq_v = yb.mul_add(yb, yb_sq_v);
+        }
+        // SKIN-only accumulators: BT.601 chroma matrix in [0, 255]
+        // for the Chai-Ngan skin-tone gate. Const-folds away on
+        // `!SKIN`. Independent of FULL — `cargo asm` showed the
+        // joint kernel spilled 12 vmovups + rebroadcast 13 constants
+        // because all accumulators were live; peeling SKIN off FULL
+        // shrinks the AVX2 register pressure for both halves.
+        if SKIN {
+            let cb_u8 =
+                r.mul_add(cb_kr_v, g.mul_add(cb_kg_v, b.mul_add(cb_kb_v, off_128_v)));
+            let cr_u8 =
+                r.mul_add(cr_kr_v, g.mul_add(cr_kg_v, b.mul_add(cr_kb_v, off_128_v)));
+            let m_y_lo = l.simd_ge(y_lo_v);
+            let m_y_hi = l.simd_le(y_hi_v);
+            let m_cb_lo = cb_u8.simd_ge(cb_lo_v);
+            let m_cb_hi = cb_u8.simd_le(cb_hi_v);
+            let m_cr_lo = cr_u8.simd_ge(cr_lo_v);
+            let m_cr_hi = cr_u8.simd_le(cr_hi_v);
+            let skin = m_y_lo & m_y_hi & m_cb_lo & m_cb_hi & m_cr_lo & m_cr_hi;
+            skin_count_v += f32x8::blend(skin, one_v, zero_v);
+        }
 
         iters_since_flush += 1;
         if iters_since_flush >= FLUSH {
-            luma_sum += luma_sum_v.reduce_add() as f64;
-            luma_sq_sum += luma_sq_v.reduce_add() as f64;
             cb_sum += cb_sum_v.reduce_add() as f64;
             cb_sq_sum += cb_sq_v.reduce_add() as f64;
             cr_sum += cr_sum_v.reduce_add() as f64;
             cr_sq_sum += cr_sq_v.reduce_add() as f64;
-            rg_sum += rg_sum_v.reduce_add() as f64;
-            rg_sq_sum += rg_sq_v.reduce_add() as f64;
-            yb_sum += yb_sum_v.reduce_add() as f64;
-            yb_sq_sum += yb_sq_v.reduce_add() as f64;
-            skin_count += skin_count_v.reduce_add() as u64;
-            luma_sum_v = f32x8::zero(token);
-            luma_sq_v = f32x8::zero(token);
             cb_sum_v = f32x8::zero(token);
             cb_sq_v = f32x8::zero(token);
             cr_sum_v = f32x8::zero(token);
             cr_sq_v = f32x8::zero(token);
-            rg_sum_v = f32x8::zero(token);
-            rg_sq_v = f32x8::zero(token);
-            yb_sum_v = f32x8::zero(token);
-            yb_sq_v = f32x8::zero(token);
-            skin_count_v = f32x8::zero(token);
+            if FULL {
+                luma_sum += luma_sum_v.reduce_add() as f64;
+                luma_sq_sum += luma_sq_v.reduce_add() as f64;
+                rg_sum += rg_sum_v.reduce_add() as f64;
+                rg_sq_sum += rg_sq_v.reduce_add() as f64;
+                yb_sum += yb_sum_v.reduce_add() as f64;
+                yb_sq_sum += yb_sq_v.reduce_add() as f64;
+                luma_sum_v = f32x8::zero(token);
+                luma_sq_v = f32x8::zero(token);
+                rg_sum_v = f32x8::zero(token);
+                rg_sq_v = f32x8::zero(token);
+                yb_sum_v = f32x8::zero(token);
+                yb_sq_v = f32x8::zero(token);
+            }
+            if SKIN {
+                skin_count += skin_count_v.reduce_add() as u64;
+                skin_count_v = f32x8::zero(token);
+            }
             iters_since_flush = 0;
         }
     }
     // Final flush of SIMD partials.
-    luma_sum += luma_sum_v.reduce_add() as f64;
-    luma_sq_sum += luma_sq_v.reduce_add() as f64;
     cb_sum += cb_sum_v.reduce_add() as f64;
     cb_sq_sum += cb_sq_v.reduce_add() as f64;
     cr_sum += cr_sum_v.reduce_add() as f64;
     cr_sq_sum += cr_sq_v.reduce_add() as f64;
-    rg_sum += rg_sum_v.reduce_add() as f64;
-    rg_sq_sum += rg_sq_v.reduce_add() as f64;
-    yb_sum += yb_sum_v.reduce_add() as f64;
-    yb_sq_sum += yb_sq_v.reduce_add() as f64;
-    skin_count += skin_count_v.reduce_add() as u64;
+    if FULL {
+        luma_sum += luma_sum_v.reduce_add() as f64;
+        luma_sq_sum += luma_sq_v.reduce_add() as f64;
+        rg_sum += rg_sum_v.reduce_add() as f64;
+        rg_sq_sum += rg_sq_v.reduce_add() as f64;
+        yb_sum += yb_sum_v.reduce_add() as f64;
+        yb_sq_sum += yb_sq_v.reduce_add() as f64;
+    }
+    if SKIN {
+        skin_count += skin_count_v.reduce_add() as u64;
+    }
 
     // Scalar tail for ≤7 leftover pixels — same float-domain math as
     // the SIMD lanes for bit-equal cross-tail consistency on the
-    // skin-tone gate.
+    // skin-tone gate. FULL-only accumulators are gated identically.
     for px in remainder.chunks_exact(3) {
         let r = px[0] as f32;
         let g = px[1] as f32;
         let b = px[2] as f32;
         let l = kr * r + kg * g + kb * b;
-        luma_sum += l as f64;
-        luma_sq_sum += (l * l) as f64;
         let cb = (b - l) * (1.0 / 255.0);
         let cr = (r - l) * (1.0 / 255.0);
         cb_sum += cb as f64;
         cb_sq_sum += (cb * cb) as f64;
         cr_sum += cr as f64;
         cr_sq_sum += (cr * cr) as f64;
-        let rg = r - g;
-        let yb = 0.5 * (r + g) - b;
-        rg_sum += rg as f64;
-        rg_sq_sum += (rg * rg) as f64;
-        yb_sum += yb as f64;
-        yb_sq_sum += (yb * yb) as f64;
-        // BT.601 chroma in u8 representation for the skin gate.
-        let cb_u8 = -0.168736 * r - 0.331264 * g + 0.500 * b + 128.0;
-        let cr_u8 = 0.500 * r - 0.418688 * g - 0.081312 * b + 128.0;
-        let in_skin = (40.0..=240.0).contains(&l)
-            && (77.0..=127.0).contains(&cb_u8)
-            && (133.0..=173.0).contains(&cr_u8);
-        skin_count += in_skin as u64;
+        if FULL {
+            luma_sum += l as f64;
+            luma_sq_sum += (l * l) as f64;
+            let rg = r - g;
+            let yb = 0.5 * (r + g) - b;
+            rg_sum += rg as f64;
+            rg_sq_sum += (rg * rg) as f64;
+            yb_sum += yb as f64;
+            yb_sq_sum += (yb * yb) as f64;
+        }
+        if SKIN {
+            // BT.601 chroma in u8 representation for the skin gate.
+            let cb_u8 = -0.168736 * r - 0.331264 * g + 0.500 * b + 128.0;
+            let cr_u8 = 0.500 * r - 0.418688 * g - 0.081312 * b + 128.0;
+            let in_skin = (40.0..=240.0).contains(&l)
+                && (77.0..=127.0).contains(&cb_u8)
+                && (133.0..=173.0).contains(&cr_u8);
+            skin_count += in_skin as u64;
+        }
     }
 
     // ---- Edges + chroma gradients: 8-pixel chunks with right & down neighbors ----
@@ -954,6 +1045,15 @@ fn accumulate_row_simd<const BT601: bool>(
             let c: &[u8; 24] = chunk.try_into().unwrap();
             let r_chunk: &[u8; 24] = right_iter.next().unwrap().try_into().unwrap();
             let d_chunk: &[u8; 24] = nr_iter.next().unwrap().try_into().unwrap();
+            // Stage gradient and mask values across the 8 lanes so the
+            // sqrt + mask-multiply that produces `edge_grad_sum` /
+            // `edge_grad_sq_sum` can run as ONE f32x8 sqrt + 2
+            // `reduce_add`s instead of 8 sequential scalar sqrts. The
+            // scalar inner pass still runs (chroma gradients + branch-
+            // free counter increments) — only the per-pixel sqrt is
+            // hoisted out of the loop body.
+            let mut grad_sq_arr = [0.0f32; 8];
+            let mut mask_arr = [0.0f32; 8];
             for i in 0..8 {
                 let cr_ = c[i * 3] as f32;
                 let cg_ = c[i * 3 + 1] as f32;
@@ -980,16 +1080,30 @@ fn accumulate_row_simd<const BT601: bool>(
                         + kb * d_chunk[i * 3 + 2] as f32;
                     grad_sq += (ld - l) * (ld - l);
                 }
-                // Branchless edge fold-in: one compare + a select-mul
-                // pattern lets the autovectorizer issue this as a
-                // mask-and-add without dropping out of SIMD.
                 let crossed = grad_sq > EDGE_THRESH_SQ;
-                let mask = crossed as u32 as f32; // 1.0 or 0.0
                 edge_count += crossed as u64;
-                edge_grad_count += crossed as u64;
-                let g_mag = grad_sq.sqrt();
-                edge_grad_sum += (g_mag * mask) as f64;
-                edge_grad_sq_sum += (grad_sq * mask) as f64;
+                if FULL {
+                    edge_grad_count += crossed as u64;
+                    grad_sq_arr[i] = grad_sq;
+                    mask_arr[i] = crossed as u32 as f32;
+                }
+            }
+            if FULL {
+                // ONE batched sqrt for all 8 lanes via rsqrt_approx:
+                // `sqrt(x) = x * (1 / sqrt(x))`. ~3× faster than
+                // batch `sqrt()`, ~12-bit precision (well above the
+                // edge-slope stddev's noise floor). Clamp grad_sq to
+                // [1.0, ∞) so non-edge lanes (mask=0) don't produce
+                // `0 * Inf = NaN` from `0 * rsqrt_approx(0)`.
+                let grad_sq_v = f32x8::load(token, &grad_sq_arr);
+                let mask_v = f32x8::load(token, &mask_arr);
+                let one_v = f32x8::splat(token, 1.0);
+                let safe_grad_sq = grad_sq_v.max(one_v);
+                let inv_sqrt = safe_grad_sq.rsqrt_approx();
+                let g_mag_v = grad_sq_v * inv_sqrt * mask_v;
+                let g_sq_masked_v = grad_sq_v * mask_v;
+                edge_grad_sum += g_mag_v.reduce_add() as f64;
+                edge_grad_sq_sum += g_sq_masked_v.reduce_add() as f64;
             }
         }
 
@@ -1031,12 +1145,14 @@ fn accumulate_row_simd<const BT601: bool>(
                 grad_sq += (ld - l) * (ld - l);
             }
             let crossed = grad_sq > EDGE_THRESH_SQ;
-            let mask = crossed as u32 as f32;
             edge_count += crossed as u64;
-            edge_grad_count += crossed as u64;
-            let g_mag = grad_sq.sqrt();
-            edge_grad_sum += (g_mag * mask) as f64;
-            edge_grad_sq_sum += (grad_sq * mask) as f64;
+            if FULL {
+                let mask = crossed as u32 as f32;
+                edge_grad_count += crossed as u64;
+                let g_mag = grad_sq.sqrt();
+                edge_grad_sum += (g_mag * mask) as f64;
+                edge_grad_sq_sum += (grad_sq * mask) as f64;
+            }
         }
     }
 

--- a/zenanalyze/src/tier1.rs
+++ b/zenanalyze/src/tier1.rs
@@ -58,6 +58,17 @@ struct PixelStats {
     laplacian_sum: f64,
     laplacian_sq_sum: f64,
     laplacian_count: u64,
+    /// Skin-tone pixel count: pigmentation-invariant Chai-Ngan YCbCr
+    /// gate computed lane-wise in the f32x8 stats pass alongside
+    /// luma/chroma stats. Branchless: lane mask → blend(1.0, 0.0) → sum.
+    skin_count: u64,
+    /// Edge-slope (gradient magnitude) running stats over pixels that
+    /// crossed `EDGE_THRESH_SQ`. Accumulated branchlessly inside the
+    /// existing edge inner loop — we already know `grad_sq` and
+    /// whether it crossed; multiply by the mask to add 0 on misses.
+    edge_grad_sum: f64,
+    edge_grad_sq_sum: f64,
+    edge_grad_count: u64,
 }
 
 impl PixelStats {
@@ -79,6 +90,10 @@ impl PixelStats {
         self.laplacian_sum += o.laplacian_sum;
         self.laplacian_sq_sum += o.laplacian_sq_sum;
         self.laplacian_count += o.laplacian_count;
+        self.skin_count += o.skin_count;
+        self.edge_grad_sum += o.edge_grad_sum;
+        self.edge_grad_sq_sum += o.edge_grad_sq_sum;
+        self.edge_grad_count += o.edge_grad_count;
     }
 }
 
@@ -141,7 +156,20 @@ pub fn extract_tier1_into(out: &mut RawAnalysis, stream: &mut RowStream<'_>, pix
     // range is small. Threshold 4 matches the noise-tolerant range
     // used by FlatColorBlockRatio and absorbs JPEG-grade chroma noise
     // around true neutrals. Ratio computed at the end of the tier.
-    let mut grayscale_pixels: u64 = 0;
+    // GrayscaleScore moved to the always-full-scan palette tier —
+    // 100 % coverage required because downstream uses the score as a
+    // binary classifier (`>= 0.99` ⇒ encode as grayscale). Stripe
+    // sampling here would let a single colour pixel slip past the
+    // gate at ~5 % budget. See `palette::scan_palette` and the
+    // grayscale_score writeback in `lib.rs`.
+    // SkinToneFraction and EdgeSlopeStdev are now computed inside
+    // accumulate_row_simd alongside luma/chroma stats — see the
+    // `skin_count`, `edge_grad_sum`, `edge_grad_sq_sum`,
+    // `edge_grad_count` fields on `PixelStats`. The previous
+    // separate scalar walks (`accumulate_per_pixel_extras_dispatch`,
+    // `count_skin_tone_pixels`, `accumulate_edge_slope_sums`) added
+    // 1-2 row passes over data already L1-resident from the SIMD
+    // pass; folding them in saves the load traffic.
     // Palette counting moved to the always-full-scan `palette` tier
     // (see `palette::scan_palette`). Tier 1 used to do this here but
     // budget-sampled palette undercounts colours; the dedicated tier
@@ -202,13 +230,14 @@ pub fn extract_tier1_into(out: &mut RawAnalysis, stream: &mut RowStream<'_>, pix
                 }
             }
 
-            // (Palette counting was here — moved to `palette` tier.)
-            // Grayscale walk over the row: per-pixel max channel gap
-            // < 4 ⇒ pixel is effectively neutral. The tight scalar
-            // loop autovectorizes well and the row data is hot in L1
-            // (just walked by the SIMD stats pass).
-            let row = &stripe_buf[row_off..row_off + row_bytes];
-            grayscale_pixels += count_grayscale_pixels(row);
+            // SkinToneFraction + EdgeSlopeStdev were folded INTO
+            // `accumulate_row_simd` — see the SIMD pass above and the
+            // `skin_count` / `edge_grad_*` accumulators on `PixelStats`.
+            // No separate per-pixel-extras row walk; one fewer load
+            // pass per row, all classification work inside the
+            // already-AVX2-active target_feature region.
+            let _ = next_row_off; // still used by the SIMD edge pass
+            let _ = row_bytes;
             sampled_pixels += w as u64;
             if next_row_off.is_some() {
                 sampled_interior += (w - 1) as u64;
@@ -382,19 +411,34 @@ pub fn extract_tier1_into(out: &mut RawAnalysis, stream: &mut RowStream<'_>, pix
             0.0
         };
     }
-    // Grayscale fraction: drives ColorMode::Grayscale-style decisions
-    // in zenjpeg, indexed-gray paths in png/avif/jxl. Counted across
-    // every sampled row in the stripe walk above.
+    // GrayscaleScore is no longer written here — see
+    // `palette::scan_palette` and `lib.rs` for the full-scan path.
+    // Skin-tone fraction: pigmentation-invariant chroma classifier
+    // (Chai & Ngan 1999). Computed lane-wise inside the SIMD stats
+    // pass — see `accumulate_row_simd::skin_count_v`.
     #[cfg(feature = "experimental")]
     {
-        out.grayscale_score = if sampled_pixels > 0 {
-            (grayscale_pixels as f64 / sampled_pixels as f64) as f32
+        out.skin_tone_fraction = if sampled_pixels > 0 {
+            (stats.skin_count as f64 / sampled_pixels as f64) as f32
         } else {
             0.0
         };
     }
-    // Suppress unused warning in default builds.
-    let _ = grayscale_pixels;
+    // Edge-slope stddev: dispersion of luma gradient magnitudes
+    // among pixels that crossed `|∇L| > 20`. Folded branchlessly
+    // into the SIMD edge inner loop — see
+    // `accumulate_row_simd::edge_grad_*`.
+    #[cfg(feature = "experimental")]
+    {
+        out.edge_slope_stdev = if stats.edge_grad_count >= 2 {
+            let n = stats.edge_grad_count as f64;
+            let mean = stats.edge_grad_sum / n;
+            let var = (stats.edge_grad_sq_sum / n - mean * mean).max(0.0);
+            var.sqrt() as f32
+        } else {
+            0.0
+        };
+    }
     // Suppress "unused variable" warnings on the always-computed
     // accumulators when the experimental writes are gated out.
     #[cfg(not(feature = "experimental"))]
@@ -484,15 +528,35 @@ fn accumulate_row_dispatch(
     let kr = weights.kr;
     let kg = weights.kg;
     let kb = weights.kb;
-    let row_stats = incant!(accumulate_row_simd(
-        rgb,
-        row_off,
-        next_row_off,
-        width,
-        kr,
-        kg,
-        kb
-    ));
+    // BT.601 is the calibrated baseline for sRGB / BT.709 sources
+    // (see `crate::luma`). Specialise the kernel for that case so
+    // LLVM emits `vfmadd*` with immediate operands instead of register-
+    // loaded `kr_v / kg_v / kb_v` splats — frees three YMM registers
+    // and unblocks downstream register allocation in the AVX2 path.
+    // The `Unknown` primaries case routes here too because it shares
+    // the BT.601 defaults via `LumaWeights::for_primaries`.
+    let is_bt601 = weights.is_bt601_baseline();
+    let row_stats = if is_bt601 {
+        incant!(accumulate_row_simd::<true>(
+            rgb,
+            row_off,
+            next_row_off,
+            width,
+            kr,
+            kg,
+            kb
+        ))
+    } else {
+        incant!(accumulate_row_simd::<false>(
+            rgb,
+            row_off,
+            next_row_off,
+            width,
+            kr,
+            kg,
+            kb
+        ))
+    };
     stats.merge(&row_stats);
 }
 
@@ -650,7 +714,7 @@ fn stripe_block_stats_simd(
 /// Edge pass: still scalar (per-tier target_feature region from the
 /// `#[magetypes]` macro lets LLVM autovec the simple stencil).
 #[magetypes(define(f32x8), v4, v3, neon, wasm128, scalar)]
-fn accumulate_row_simd(
+fn accumulate_row_simd<const BT601: bool>(
     token: Token,
     rgb: &[u8],
     row_off: usize,
@@ -660,6 +724,18 @@ fn accumulate_row_simd(
     kg: f32,
     kb: f32,
 ) -> PixelStats {
+    // Const-fold luma weights for the BT.601 baseline (sRGB / BT.709 /
+    // Unknown sources, the orchestrator hot path). When BT601 is true,
+    // the `if` collapses at compile time and `kr/kg/kb` become
+    // immediate operands of `vfmadd*` everywhere they appear in this
+    // body — no register-loaded splats, three fewer YMM lanes live
+    // through the chunk loop. When BT601 is false (BT.2020, P3,
+    // AdobeRGB), the runtime values pass through unchanged.
+    let (kr, kg, kb) = if BT601 {
+        (0.299_f32, 0.587_f32, 0.114_f32)
+    } else {
+        (kr, kg, kb)
+    };
     // Outer f64 accumulators — only touched during the periodic flush.
     let mut luma_sum: f64 = 0.0;
     let mut luma_sq_sum: f64 = 0.0;
@@ -676,12 +752,44 @@ fn accumulate_row_simd(
     let row = &rgb[row_off..row_off + width * 3];
     let next_row = next_row_off.map(|nr| &rgb[nr..nr + width * 3]);
 
+    // Skin-tone + edge-slope accumulators (folded in below). Skin
+    // tone is computed lane-wise in the f32x8 stats pass; edge slope
+    // is folded into the scalar inner edge loop branchlessly.
+    let mut skin_count: u64 = 0;
+    let mut edge_grad_sum: f64 = 0.0;
+    let mut edge_grad_sq_sum: f64 = 0.0;
+    let mut edge_grad_count: u64 = 0;
+
     // ---- f32x8 stats pass: 8 pixels (24 bytes) per chunk ----
     let kr_v = f32x8::splat(token, kr);
     let kg_v = f32x8::splat(token, kg);
     let kb_v = f32x8::splat(token, kb);
     let inv_255_v = f32x8::splat(token, 1.0 / 255.0);
     let half_v = f32x8::splat(token, 0.5);
+
+    // BT.601 chroma encoding constants. These are FIXED (independent
+    // of source primaries) — they define the encoder's YCbCr space,
+    // which is what the Chai-Ngan skin-tone classifier was calibrated
+    // against. The per-primaries `kr/kg/kb` only affect luma.
+    let cb_kr_v = f32x8::splat(token, -0.168736);
+    let cb_kg_v = f32x8::splat(token, -0.331264);
+    let cb_kb_v = f32x8::splat(token, 0.500000);
+    let cr_kr_v = f32x8::splat(token, 0.500000);
+    let cr_kg_v = f32x8::splat(token, -0.418688);
+    let cr_kb_v = f32x8::splat(token, -0.081312);
+    let off_128_v = f32x8::splat(token, 128.0);
+    // Chai-Ngan (1999) gates: Y in [40, 240], Cb in [77, 127],
+    // Cr in [133, 173]. All compared in float-domain u8 space —
+    // the gate margins (≥ 5 units) absorb any 1-LSB rounding drift
+    // between the float SIMD path and the integer scalar tail.
+    let y_lo_v = f32x8::splat(token, 40.0);
+    let y_hi_v = f32x8::splat(token, 240.0);
+    let cb_lo_v = f32x8::splat(token, 77.0);
+    let cb_hi_v = f32x8::splat(token, 127.0);
+    let cr_lo_v = f32x8::splat(token, 133.0);
+    let cr_hi_v = f32x8::splat(token, 173.0);
+    let one_v = f32x8::splat(token, 1.0);
+    let zero_v = f32x8::zero(token);
 
     let mut luma_sum_v = f32x8::zero(token);
     let mut luma_sq_v = f32x8::zero(token);
@@ -693,6 +801,7 @@ fn accumulate_row_simd(
     let mut rg_sq_v = f32x8::zero(token);
     let mut yb_sum_v = f32x8::zero(token);
     let mut yb_sq_v = f32x8::zero(token);
+    let mut skin_count_v = f32x8::zero(token);
 
     const FLUSH: usize = 32;
     let mut iters_since_flush = 0usize;
@@ -716,12 +825,31 @@ fn accumulate_row_simd(
 
         // BT.601 luma: l = 0.299·r + 0.587·g + 0.114·b
         let l = r.mul_add(kr_v, g.mul_add(kg_v, b * kb_v));
-        // Chroma: cb = (b − l) / 255; cr = (r − l) / 255
+        // Chroma stats (simplified): cb_stat = (b − l) / 255;
+        // cr_stat = (r − l) / 255. Used by the chroma_complexity /
+        // cb_sharpness / cr_sharpness shape signals — variance-based,
+        // so the offset doesn't matter.
         let cb = (b - l) * inv_255_v;
         let cr = (r - l) * inv_255_v;
         // Hasler M3: rg = r − g; yb = 0.5·(r + g) − b
         let rg = r - g;
         let yb = (r + g).mul_add(half_v, -b);
+
+        // BT.601 chroma in the [0, 255] u8 representation that the
+        // skin-tone classifier was calibrated against. Three fma per
+        // channel — six fma total per chunk on top of the existing
+        // stats. Then six lane compares + five ANDs + one blend +
+        // one fma to produce a lane-wise running counter.
+        let cb_u8 = r.mul_add(cb_kr_v, g.mul_add(cb_kg_v, b.mul_add(cb_kb_v, off_128_v)));
+        let cr_u8 = r.mul_add(cr_kr_v, g.mul_add(cr_kg_v, b.mul_add(cr_kb_v, off_128_v)));
+        let m_y_lo = l.simd_ge(y_lo_v);
+        let m_y_hi = l.simd_le(y_hi_v);
+        let m_cb_lo = cb_u8.simd_ge(cb_lo_v);
+        let m_cb_hi = cb_u8.simd_le(cb_hi_v);
+        let m_cr_lo = cr_u8.simd_ge(cr_lo_v);
+        let m_cr_hi = cr_u8.simd_le(cr_hi_v);
+        let skin = m_y_lo & m_y_hi & m_cb_lo & m_cb_hi & m_cr_lo & m_cr_hi;
+        skin_count_v += f32x8::blend(skin, one_v, zero_v);
 
         luma_sum_v += l;
         luma_sq_v = l.mul_add(l, luma_sq_v);
@@ -746,6 +874,7 @@ fn accumulate_row_simd(
             rg_sq_sum += rg_sq_v.reduce_add() as f64;
             yb_sum += yb_sum_v.reduce_add() as f64;
             yb_sq_sum += yb_sq_v.reduce_add() as f64;
+            skin_count += skin_count_v.reduce_add() as u64;
             luma_sum_v = f32x8::zero(token);
             luma_sq_v = f32x8::zero(token);
             cb_sum_v = f32x8::zero(token);
@@ -756,6 +885,7 @@ fn accumulate_row_simd(
             rg_sq_v = f32x8::zero(token);
             yb_sum_v = f32x8::zero(token);
             yb_sq_v = f32x8::zero(token);
+            skin_count_v = f32x8::zero(token);
             iters_since_flush = 0;
         }
     }
@@ -770,8 +900,11 @@ fn accumulate_row_simd(
     rg_sq_sum += rg_sq_v.reduce_add() as f64;
     yb_sum += yb_sum_v.reduce_add() as f64;
     yb_sq_sum += yb_sq_v.reduce_add() as f64;
+    skin_count += skin_count_v.reduce_add() as u64;
 
-    // Scalar tail for ≤7 leftover pixels.
+    // Scalar tail for ≤7 leftover pixels — same float-domain math as
+    // the SIMD lanes for bit-equal cross-tail consistency on the
+    // skin-tone gate.
     for px in remainder.chunks_exact(3) {
         let r = px[0] as f32;
         let g = px[1] as f32;
@@ -791,6 +924,13 @@ fn accumulate_row_simd(
         rg_sq_sum += (rg * rg) as f64;
         yb_sum += yb as f64;
         yb_sq_sum += (yb * yb) as f64;
+        // BT.601 chroma in u8 representation for the skin gate.
+        let cb_u8 = -0.168736 * r - 0.331264 * g + 0.500 * b + 128.0;
+        let cr_u8 = 0.500 * r - 0.418688 * g - 0.081312 * b + 128.0;
+        let in_skin = (40.0..=240.0).contains(&l)
+            && (77.0..=127.0).contains(&cb_u8)
+            && (133.0..=173.0).contains(&cr_u8);
+        skin_count += in_skin as u64;
     }
 
     // ---- Edges + chroma gradients: 8-pixel chunks with right & down neighbors ----
@@ -840,9 +980,16 @@ fn accumulate_row_simd(
                         + kb * d_chunk[i * 3 + 2] as f32;
                     grad_sq += (ld - l) * (ld - l);
                 }
-                if grad_sq > EDGE_THRESH_SQ {
-                    edge_count += 1;
-                }
+                // Branchless edge fold-in: one compare + a select-mul
+                // pattern lets the autovectorizer issue this as a
+                // mask-and-add without dropping out of SIMD.
+                let crossed = grad_sq > EDGE_THRESH_SQ;
+                let mask = crossed as u32 as f32; // 1.0 or 0.0
+                edge_count += crossed as u64;
+                edge_grad_count += crossed as u64;
+                let g_mag = grad_sq.sqrt();
+                edge_grad_sum += (g_mag * mask) as f64;
+                edge_grad_sq_sum += (grad_sq * mask) as f64;
             }
         }
 
@@ -883,9 +1030,13 @@ fn accumulate_row_simd(
                     kr * rgb[doff] as f32 + kg * rgb[doff + 1] as f32 + kb * rgb[doff + 2] as f32;
                 grad_sq += (ld - l) * (ld - l);
             }
-            if grad_sq > EDGE_THRESH_SQ {
-                edge_count += 1;
-            }
+            let crossed = grad_sq > EDGE_THRESH_SQ;
+            let mask = crossed as u32 as f32;
+            edge_count += crossed as u64;
+            edge_grad_count += crossed as u64;
+            let g_mag = grad_sq.sqrt();
+            edge_grad_sum += (g_mag * mask) as f64;
+            edge_grad_sq_sum += (grad_sq * mask) as f64;
         }
     }
 
@@ -900,6 +1051,10 @@ fn accumulate_row_simd(
         cb_grad_sum,
         cr_grad_sum,
         chroma_grad_count,
+        skin_count,
+        edge_grad_sum,
+        edge_grad_sq_sum,
+        edge_grad_count,
         rg_sum,
         rg_sq_sum,
         yb_sum,
@@ -921,7 +1076,7 @@ fn accumulate_row_simd(
 /// shifted-neighbour loads are aligned and pure mul/add — LLVM emits
 /// the FMA chain directly.
 #[magetypes(define(f32x8), v4, v3, neon, wasm128, scalar)]
-fn accumulate_laplacian_simd(
+fn accumulate_laplacian_simd<const BT601: bool>(
     token: Token,
     prev_row: &[u8],
     cur_row: &[u8],
@@ -931,6 +1086,11 @@ fn accumulate_laplacian_simd(
     kg: f32,
     kb: f32,
 ) -> (f64, f64, u64) {
+    let (kr, kg, kb) = if BT601 {
+        (0.299_f32, 0.587_f32, 0.114_f32)
+    } else {
+        (kr, kg, kb)
+    };
     if width < 3 {
         return (0.0, 0.0, 0);
     }
@@ -1015,9 +1175,15 @@ fn accumulate_laplacian_dispatch(
     let kr = weights.kr;
     let kg = weights.kg;
     let kb = weights.kb;
-    let (s, sq, n) = incant!(accumulate_laplacian_simd(
-        prev_row, cur_row, next_row, width, kr, kg, kb
-    ));
+    let (s, sq, n) = if weights.is_bt601_baseline() {
+        incant!(accumulate_laplacian_simd::<true>(
+            prev_row, cur_row, next_row, width, kr, kg, kb
+        ))
+    } else {
+        incant!(accumulate_laplacian_simd::<false>(
+            prev_row, cur_row, next_row, width, kr, kg, kb
+        ))
+    };
     stats.laplacian_sum += s;
     stats.laplacian_sq_sum += sq;
     stats.laplacian_count += n;
@@ -1032,19 +1198,270 @@ fn accumulate_laplacian_dispatch(
 /// Compiled at the per-tier `target_feature` regime via `#[autoversion]`
 /// so LLVM autovectorizes the channel-gap compare into pmaxub /
 /// pminub on x86_64 (and equivalent on NEON / WASM).
+/// Count pixels in the canonical YCbCr skin-tone region. The
+/// chrominance bounds `Cb ∈ [77, 127]` and `Cr ∈ [133, 173]` are the
+/// Chai & Ngan (1999) values, which generalise across all skin
+/// pigmentations because chroma quantifies hue, not lightness. The
+/// luma gate `Y ∈ [40, 240]` covers deep shadow on dark skin to
+/// bright highlight on light skin without rejecting either end.
+///
+/// Integer BT.601 conversion matches the rest of the analyzer
+/// (matches the qr/qg/qb 77/150/29 fixed-point luma already used by
+/// `count_grayscale_pixels` callers, and the Cb/Cr coefficients used
+/// by tier3 — `(-43·R - 85·G + 128·B + 128) >> 8` for Cb-128, etc.).
 #[archmage::autoversion(v4x, v4, v3, neon, scalar)]
-fn count_grayscale_pixels(row: &[u8]) -> u64 {
-    const GRAYSCALE_THRESHOLD: u8 = 4;
+fn count_skin_tone_pixels(row: &[u8]) -> u64 {
     let mut count: u64 = 0;
     for px in row.chunks_exact(3) {
-        let r = px[0];
-        let g = px[1];
-        let b = px[2];
-        let mx = r.max(g).max(b);
-        let mn = r.min(g).min(b);
-        if mx - mn <= GRAYSCALE_THRESHOLD {
+        let r = px[0] as i32;
+        let g = px[1] as i32;
+        let b = px[2] as i32;
+        let y = (77 * r + 150 * g + 29 * b) >> 8;
+        // Cb / Cr in [0, 255] u8 representation.
+        let cb = ((-43 * r - 85 * g + 128 * b) >> 8) + 128;
+        let cr = ((128 * r - 107 * g - 21 * b) >> 8) + 128;
+        if (40..=240).contains(&y) && (77..=127).contains(&cb) && (133..=173).contains(&cr) {
             count += 1;
         }
     }
     count
+}
+
+/// Output of the fused per-pixel scalar pass.
+#[derive(Default, Clone, Copy)]
+struct PerPixelExtras {
+    skin_tone: u64,
+    edge_sum: f64,
+    edge_sq_sum: f64,
+    edge_count: u64,
+}
+
+/// Fused per-pixel scalar pass producing skin-tone count and
+/// edge-slope (sum, sum², count) in a single walk over the row.
+/// `GrayscaleScore` was promoted to the always-full-scan palette tier
+/// (100 % coverage required for the binary classifier — see
+/// `palette::scan_palette`).
+///
+/// Autoversioned to v4x / v4 / v3 / NEON / scalar so each tier picks
+/// up the appropriate target_feature region. The `chunks_exact(3)`
+/// pattern over the row's RGB triplets gives LLVM bounds-check-free
+/// indexing on the inner loads.
+#[archmage::autoversion(v4x, v4, v3, neon, scalar)]
+fn accumulate_per_pixel_extras_dispatch(
+    row: &[u8],
+    next_row: Option<&[u8]>,
+    width: usize,
+    weights: &crate::luma::LumaWeights,
+) -> PerPixelExtras {
+    let mut out = PerPixelExtras::default();
+    if width < 1 {
+        return out;
+    }
+    let qr = weights.qr;
+    let qg = weights.qg;
+    let qb = weights.qb;
+    let row_bytes = width * 3;
+    let row_full = &row[..row_bytes];
+
+    // First sweep: skin-tone, no neighbour deps.
+    for px in row_full.chunks_exact(3) {
+        let r_i = px[0] as i32;
+        let g_i = px[1] as i32;
+        let b_i = px[2] as i32;
+        // Skin-tone: BT.601 fixed-point Y/Cb/Cr in u8.
+        let y = (qr * r_i + qg * g_i + qb * b_i) >> 8;
+        let cb = ((-43 * r_i - 85 * g_i + 128 * b_i) >> 8) + 128;
+        let cr = ((128 * r_i - 107 * g_i - 21 * b_i) >> 8) + 128;
+        if (40..=240).contains(&y) && (77..=127).contains(&cb) && (133..=173).contains(&cr) {
+            out.skin_tone += 1;
+        }
+    }
+
+    // Second sweep: edge-slope, needs current + right + below.
+    if width >= 2 {
+        let row_left = &row[..row_bytes - 3];
+        let row_right = &row[3..row_bytes];
+        let mut sum: f64 = 0.0;
+        let mut sq_sum: f64 = 0.0;
+        let mut count: u64 = 0;
+        match next_row {
+            Some(nr) => {
+                let nr = &nr[..row_bytes - 3];
+                for ((cur, right), down) in row_left
+                    .chunks_exact(3)
+                    .zip(row_right.chunks_exact(3))
+                    .zip(nr.chunks_exact(3))
+                {
+                    let l = (qr * cur[0] as i32 + qg * cur[1] as i32 + qb * cur[2] as i32) >> 8;
+                    let lr =
+                        (qr * right[0] as i32 + qg * right[1] as i32 + qb * right[2] as i32) >> 8;
+                    let ld = (qr * down[0] as i32 + qg * down[1] as i32 + qb * down[2] as i32) >> 8;
+                    let dx = lr - l;
+                    let dy = ld - l;
+                    let g_sq = (dx * dx + dy * dy) as f64;
+                    if g_sq > 400.0 {
+                        let g = g_sq.sqrt();
+                        sum += g;
+                        sq_sum += g * g;
+                        count += 1;
+                    }
+                }
+            }
+            None => {
+                for (cur, right) in row_left.chunks_exact(3).zip(row_right.chunks_exact(3)) {
+                    let l = (qr * cur[0] as i32 + qg * cur[1] as i32 + qb * cur[2] as i32) >> 8;
+                    let lr =
+                        (qr * right[0] as i32 + qg * right[1] as i32 + qb * right[2] as i32) >> 8;
+                    let dx = lr - l;
+                    let g_sq = (dx * dx) as f64;
+                    if g_sq > 400.0 {
+                        let g = g_sq.sqrt();
+                        sum += g;
+                        sq_sum += g * g;
+                        count += 1;
+                    }
+                }
+            }
+        }
+        out.edge_sum = sum;
+        out.edge_sq_sum = sq_sum;
+        out.edge_count = count;
+    }
+
+    out
+}
+
+/// Edge-slope dispatcher: pick the chunked autoversioned kernel based
+/// on whether a next row is available. Either kernel walks the row
+/// in 3-byte pixel chunks paired with a 3-byte-shifted view of the
+/// same row (the bounds-check-free fixed-array indexing the
+/// autoversion macro turns into per-arch `pmaddubsw` / `pmullw` /
+/// FMA on aligned-by-construction loads).
+fn accumulate_edge_slope_sums(
+    row: &[u8],
+    next_row: Option<&[u8]>,
+    width: usize,
+    weights: &crate::luma::LumaWeights,
+    grad_sum: &mut f64,
+    grad_sq_sum: &mut f64,
+    grad_count: &mut u64,
+) {
+    if width < 2 {
+        return;
+    }
+    let row_bytes = width * 3;
+    let row_left = &row[..row_bytes - 3];
+    let row_right = &row[3..row_bytes];
+    let mut sum: f64 = 0.0;
+    let mut sq_sum: f64 = 0.0;
+    let mut count: u64 = 0;
+    match next_row {
+        Some(nr) => {
+            let nr = &nr[..row_bytes - 3];
+            accumulate_edge_slope_with_next(
+                row_left,
+                row_right,
+                nr,
+                weights.qr,
+                weights.qg,
+                weights.qb,
+                &mut sum,
+                &mut sq_sum,
+                &mut count,
+            );
+        }
+        None => {
+            accumulate_edge_slope_horizontal(
+                row_left,
+                row_right,
+                weights.qr,
+                weights.qg,
+                weights.qb,
+                &mut sum,
+                &mut sq_sum,
+                &mut count,
+            );
+        }
+    }
+    *grad_sum += sum;
+    *grad_sq_sum += sq_sum;
+    *grad_count += count;
+}
+
+/// Edge-slope kernel for the "next row exists" case (interior rows).
+/// Walks row pixels paired with their right-neighbour and the same
+/// column in the next row. `chunks_exact(3)` and `zip` over equal-
+/// length slices give LLVM bounds-check-free indexing on the inner
+/// triplet of u8 loads, which the per-arch target_feature macro
+/// expansion then vectorises.
+#[archmage::autoversion(v4x, v4, v3, neon, scalar)]
+fn accumulate_edge_slope_with_next(
+    row_left: &[u8],
+    row_right: &[u8],
+    next_row: &[u8],
+    qr: i32,
+    qg: i32,
+    qb: i32,
+    sum: &mut f64,
+    sq_sum: &mut f64,
+    count: &mut u64,
+) {
+    let mut s: f64 = 0.0;
+    let mut sq: f64 = 0.0;
+    let mut n: u64 = 0;
+    for ((cur, right), down) in row_left
+        .chunks_exact(3)
+        .zip(row_right.chunks_exact(3))
+        .zip(next_row.chunks_exact(3))
+    {
+        let l = (qr * cur[0] as i32 + qg * cur[1] as i32 + qb * cur[2] as i32) >> 8;
+        let lr = (qr * right[0] as i32 + qg * right[1] as i32 + qb * right[2] as i32) >> 8;
+        let ld = (qr * down[0] as i32 + qg * down[1] as i32 + qb * down[2] as i32) >> 8;
+        let dx = lr - l;
+        let dy = ld - l;
+        let g_sq = (dx * dx + dy * dy) as f64;
+        if g_sq > 400.0 {
+            let g = g_sq.sqrt();
+            s += g;
+            sq += g * g;
+            n += 1;
+        }
+    }
+    *sum += s;
+    *sq_sum += sq;
+    *count += n;
+}
+
+/// Edge-slope kernel for the "no next row" case (last image row).
+/// Same pattern as the `with_next` kernel but without the down-row
+/// load, so `dy = 0` and the threshold is purely against `dx²`.
+#[archmage::autoversion(v4x, v4, v3, neon, scalar)]
+fn accumulate_edge_slope_horizontal(
+    row_left: &[u8],
+    row_right: &[u8],
+    qr: i32,
+    qg: i32,
+    qb: i32,
+    sum: &mut f64,
+    sq_sum: &mut f64,
+    count: &mut u64,
+) {
+    let mut s: f64 = 0.0;
+    let mut sq: f64 = 0.0;
+    let mut n: u64 = 0;
+    for (cur, right) in row_left.chunks_exact(3).zip(row_right.chunks_exact(3)) {
+        let l = (qr * cur[0] as i32 + qg * cur[1] as i32 + qb * cur[2] as i32) >> 8;
+        let lr = (qr * right[0] as i32 + qg * right[1] as i32 + qb * right[2] as i32) >> 8;
+        let dx = lr - l;
+        let g_sq = (dx * dx) as f64;
+        if g_sq > 400.0 {
+            let g = g_sq.sqrt();
+            s += g;
+            sq += g * g;
+            n += 1;
+        }
+    }
+    *sum += s;
+    *sq_sum += sq;
+    *count += n;
 }

--- a/zenanalyze/src/tier1.rs
+++ b/zenanalyze/src/tier1.rs
@@ -847,14 +847,36 @@ fn accumulate_row_simd(
         }
 
         // Scalar tail for the remaining 0..7 edge pixels.
+        //
+        // Accumulates the **same** four reductions as the SIMD edge
+        // loop above (luma edge_count + cb/cr gradient sums + count).
+        // Earlier revisions only updated `edge_count` here, silently
+        // dropping the rightmost 1–7 column positions per row from
+        // the chroma sharpness signal — a measurable undercount on
+        // small or non-multiple-of-8 widths.
         let processed = (width - 1) / 8 * 8;
         for x in processed..width - 1 {
             let off = row_off + x * 3;
-            let l = kr * rgb[off] as f32 + kg * rgb[off + 1] as f32 + kb * rgb[off + 2] as f32;
+            let cr_ = rgb[off] as f32;
+            let cg_ = rgb[off + 1] as f32;
+            let cb_ = rgb[off + 2] as f32;
+            let l = kr * cr_ + kg * cg_ + kb * cb_;
             let roff = row_off + (x + 1) * 3;
-            let lr = kr * rgb[roff] as f32 + kg * rgb[roff + 1] as f32 + kb * rgb[roff + 2] as f32;
+            let rr_ = rgb[roff] as f32;
+            let rg_ = rgb[roff + 1] as f32;
+            let rb_ = rgb[roff + 2] as f32;
+            let lr = kr * rr_ + kg * rg_ + kb * rb_;
             let gx = lr - l;
             let mut grad_sq = gx * gx;
+            // Chroma gradients (matched against the SIMD edge loop's
+            // same definitions: Cb = (B−Y)/255, Cr = (R−Y)/255).
+            let cb_cur = (cb_ - l) / 255.0;
+            let cb_right = (rb_ - lr) / 255.0;
+            let cr_cur = (cr_ - l) / 255.0;
+            let cr_right = (rr_ - lr) / 255.0;
+            cb_grad_sum += (cb_right - cb_cur).abs() as f64;
+            cr_grad_sum += (cr_right - cr_cur).abs() as f64;
+            chroma_grad_count += 1;
             if has_next {
                 let doff = next_row_off.unwrap() + x * 3;
                 let ld =

--- a/zenanalyze/src/tier2_chroma.rs
+++ b/zenanalyze/src/tier2_chroma.rs
@@ -66,8 +66,19 @@ fn gradient_diff_ycbcr(
     let edge = (a0.0 - a2.0).abs();
     let no_edge_boost = y_max * 2 - edge;
     let boost = ((no_edge_boost + contrast_boost).max(0) as u32) / 32;
-    let cb_diff = (cb_d.pow(2) as u32).saturating_mul(boost) / 128;
-    let cr_diff = (cr_d.pow(2) as u32).saturating_mul(boost) / 128;
+    // u64 intermediates: post-symmetry-repair `cr_d` reaches ±6120
+    // (Cr = 6R − 5G − B + 6×255 ⇒ second-difference range is ±6120).
+    // `cr_d² × boost_max = 37 454 400 × 215 = 8 052 696 000 > u32::MAX`,
+    // so the previous `(cr_d.pow(2) as u32).saturating_mul(boost)` was
+    // silently clamping the saturated-chroma case to u32::MAX / 128 =
+    // 33 554 431 instead of the real 62 911 687 — a 1.87× undercount
+    // of the per-group `max_diff_cr`. The SIMD path uses f32
+    // throughout and was unaffected; this matched it. Cb's range is
+    // narrower (max product ≈ 2.01 B, fits in u32), but using u64
+    // for both keeps the two paths symmetric and rules out future
+    // symmetry-repair surprises.
+    let cb_diff = ((cb_d.pow(2) as u64 * boost as u64) / 128) as u32;
+    let cr_diff = ((cr_d.pow(2) as u64 * boost as u64) / 128) as u32;
     (cb_diff, cr_diff)
 }
 
@@ -197,8 +208,22 @@ fn image_sharpness_breakdown(
     // p99 peak: 99th percentile of per-group max-pixel-diffs. With
     // a single hot pixel, the absolute max grows linearly with image
     // size; p99 is more stable. Falls back to the running global max
-    // when the sample is too small (<= 4 entries) for percentile to
+    // when the sample is too small (≤ 4 entries) for percentile to
     // mean anything.
+    //
+    // **Accuracy note:** this is genuinely the 99th percentile only
+    // for `N ≥ 100` samples. At smaller N the index `floor(0.99 * (N
+    // − 1))` lands at a coarser percentile:
+    //
+    //   N = 5  → 80th percentile
+    //   N = 10 → 90th
+    //   N = 50 → 98th
+    //   N ≥ 100 → ~99th
+    //
+    // Tier 2 hits N ≥ 100 row-groups on any image taller than ~600
+    // px, which is the dominant case. Smaller images get a coarser-
+    // percentile peak that still serves the "robust against single
+    // hot pixel" goal — accepted trade-off, not a bug.
     fn percentile_99(samples: &mut [u32], fallback: u32) -> u32 {
         if samples.len() <= 4 {
             return fallback;
@@ -209,8 +234,22 @@ fn image_sharpness_breakdown(
     let peak_cb = percentile_99(&mut peak_samples_cb, max_diff.0);
     let peak_cr = percentile_99(&mut peak_samples_cr, max_diff.1);
 
-    // Peak normalization: same `(6 * 256 * 2)² / 100` reference scale
-    // as before — keeps the peak field in [0, 100] for typical images.
+    // Peak normalization: `(6 * 256 * 2)² / 100` reference scale,
+    // carried over from the pre-symmetry-repair code where Cr's
+    // effective range was narrower.
+    //
+    // **Output range:** for natural photographic content the peak
+    // field typically lands < 100 (the original calibration target).
+    // After the symmetry repair (CHANGELOG note above) the SIMD
+    // path's true `max_diff_cr` is ≈ 62 911 687, which divides to
+    // a peak of ≈ 666 — saturated synthetic content (e.g. alternating
+    // pure-red / pure-green columns) reaches that ceiling. Code that
+    // calibrates against `cb_peak_sharpness` / `cr_peak_sharpness`
+    // must NOT clamp to [0, 100]; production photos do, but
+    // synthetic / chart / extreme-chroma inputs don't.
+    // Renormalising the peak fields onto a stable [0, 100] scale is a
+    // follow-up calibration task tracked in `infer_bucket`'s
+    // `CALIBRATION-PENDING` note.
     let max_diff_max = (6 * 256 * 2u32).pow(2);
     let peak_div = (max_diff_max / 100).max(1);
 

--- a/zenanalyze/src/tier3.rs
+++ b/zenanalyze/src/tier3.rs
@@ -267,6 +267,14 @@ fn luma_histogram_stats(stream: &mut RowStream<'_>) -> LumaHistStats {
             line_art_score: 0.0,
         };
     }
+    // Per-primaries fixed-point luma weights — keeps wide-gamut
+    // bytes interpreted with the right matrix (BT.2020 for Rec.2020,
+    // etc.). sRGB/BT.709 keeps the BT.601 baseline (66/129/25) so
+    // the trained histogram thresholds still apply.
+    let w = crate::luma::LumaWeights::for_primaries(stream.primaries());
+    let qr = w.qr as u32;
+    let qg = w.qg as u32;
+    let qb = w.qb as u32;
     let mut bins = [0u32; 32];
     let mut n = 0u32;
     let mut carry: usize = 0;
@@ -277,7 +285,7 @@ fn luma_histogram_stats(stream: &mut RowStream<'_>) -> LumaHistStats {
         while x < width {
             let off = x * 3;
             let p = &row[off..off + 3];
-            let y = ((66 * p[0] as u32 + 129 * p[1] as u32 + 25 * p[2] as u32 + 128) >> 8) as u8;
+            let y = ((qr * p[0] as u32 + qg * p[1] as u32 + qb * p[2] as u32 + 128) >> 8) as u8;
             bins[(y >> 3) as usize] += 1;
             n += 1;
             x += 4;
@@ -530,6 +538,15 @@ fn dct_stats(stream: &mut RowStream<'_>, max_blocks: usize) -> Tier3DctStats {
             gradient_fraction: 0.0,
         };
     }
+    // Per-primaries luma weights — used in the per-block fixed-point
+    // YCbCr build below. Wide-gamut u8 sources go through the DCT
+    // pipeline with the right matrix for their primaries; sRGB /
+    // BT.709 keeps the BT.601 baseline (66/129/25) so trained
+    // thresholds still apply.
+    let lw = crate::luma::LumaWeights::for_primaries(stream.primaries());
+    let qr = lw.qr;
+    let qg = lw.qg;
+    let qb = lw.qb;
     let blocks_x = width / 8;
     let blocks_y = height / 8;
     let total_blocks = blocks_x * blocks_y;
@@ -617,7 +634,16 @@ fn dct_stats(stream: &mut RowStream<'_>, max_blocks: usize) -> Tier3DctStats {
                     let r = p[0] as i32;
                     let g = p[1] as i32;
                     let b = p[2] as i32;
-                    let l_i = (66 * r + 129 * g + 25 * b + 128) >> 8;
+                    let l_i = (qr * r + qg * g + qb * b + 128) >> 8;
+                    // Cb / Cr keep their BT.601-derived integer
+                    // matrix here. The per-primaries adjustment
+                    // shifts luma; chroma differences (B−Y / R−Y)
+                    // would also drift, but the chroma-DCT
+                    // compressibility / noise-floor signals are
+                    // ratio-based and small per-primaries drift on
+                    // the chroma matrix doesn't materially move
+                    // them. Revisit if a corpus eval shows wide-
+                    // gamut chroma stats reading off vs sRGB.
                     let cb_i = ((-38 * r - 74 * g + 112 * b + 128) >> 8) + 128;
                     let cr_i = ((112 * r - 94 * g - 18 * b + 128) >> 8) + 128;
                     blk_y[y][x] = l_i as f32 - 128.0;

--- a/zenanalyze/src/tier3.rs
+++ b/zenanalyze/src/tier3.rs
@@ -119,8 +119,10 @@ struct Tier3DctStats {
     /// normalized to `[0, 1]` by dividing by 32.
     noise_floor_uv: f32,
     /// Fraction `[0, 1]` of sampled luma 8×8 blocks where the
-    /// low-zigzag (positions 1..16) energy is ≥ 90 % of the total
-    /// AC energy. **Smooth-content / gradient signal** — drives JXL
+    /// low-zigzag (indices 1–15, the 15 AC positions matched by
+    /// the same `zz < 16` predicate as `high_freq_energy_ratio`)
+    /// energy is ≥ 90 % of the total AC energy. **Smooth-content /
+    /// gradient signal** — drives JXL
     /// `with_force_strategy` (DCT16 / DCT32 selection — larger
     /// transforms pay off when most energy is in the lowest
     /// frequencies) and zenrav1e's deblock strength. Distinct from
@@ -130,9 +132,17 @@ struct Tier3DctStats {
     gradient_fraction: f32,
 }
 
-/// libwebp `GetAlpha`-style score on a single 8×8 DCT block. Returns
-/// `[0, 255]` where higher = harder to compress (more spread AC,
-/// fewer near-zero coefficients).
+/// libwebp `GetAlpha`-style score on a single 8×8 DCT block. Higher
+/// = harder to compress (more spread AC, fewer near-zero coefficients).
+///
+/// **Range:** the formula `256 * last_non_zero / max_count` returns
+/// values in `[0, 256 × 63 / 2] = [0, 8064]`, not `[0, 255]` as
+/// earlier docs claimed. `last_non_zero` ∈ `[0, 63]` is the highest
+/// histogram bin with at least one coefficient; `max_count` ≥ 2 by
+/// the guard below. On real corpora `compressibility_y` lands in
+/// `[0, ~30]` for photos and `compressibility_uv` even lower —
+/// nowhere near the theoretical max — but downstream calibration
+/// must NOT clamp or normalise against 255.
 ///
 /// Build a 64-bin histogram of `|AC[k]| / bin_div` (clipped to 63),
 /// find `max_count` and `last_non_zero` index, return
@@ -144,8 +154,7 @@ struct Tier3DctStats {
 /// for luma (the libwebp convention) and `BIN_DIV_CHROMA = 8` for
 /// chroma. Chroma DCT coefficient magnitudes run ~half luma's; the
 /// finer chroma bin spreads the histogram into the same dynamic
-/// range as luma, so the chroma α uses the full 0-255 output rather
-/// than piling up near 0.
+/// range as luma so chroma α isn't suppressed near zero.
 #[inline(always)]
 fn block_alpha(coeffs: &[[f32; 8]; 8], bin_div: f32) -> u32 {
     let mut histo = [0u32; 64];
@@ -505,14 +514,15 @@ const DCT_COEF_T: [[f32; 8]; 8] = {
 };
 
 /// Ratio of high-frequency to low-frequency AC DCT energy on sampled
-/// 8×8 luma blocks. `Σ AC[zz≥16] / max(1, Σ AC[zz∈1..16])` where `zz`
-/// is the JPEG ITU-T T.81 zigzag index — the same scan order JPEG
-/// itself uses to drop high frequencies first. The split at `zz=16`
-/// puts the upper-left 4×4 triangle (the lowest 16 zigzag positions
-/// after DC, mostly `u + v ≤ 3`) on the "low" side and the lower-right
-/// 6×6+ region on the "high" side — symmetric in horizontal/vertical
-/// detail, unlike the older raster-order split which biased toward
-/// vertical content.
+/// 8×8 luma blocks. `Σ AC[zz ≥ 16] / max(1, Σ AC[zz ∈ 1..=15])` where
+/// `zz` is the JPEG ITU-T T.81 zigzag index — the same scan order
+/// JPEG itself uses to drop high frequencies first. The split is at
+/// the predicate `zz < 16` (low side ⇒ zigzag indices 1–15 = **15
+/// AC positions** after DC; zigzag 16 and beyond go to the high
+/// side). The 15 low positions cover most of the upper-left 4×4
+/// triangle (`u + v ≤ 3`), keeping the split symmetric in
+/// horizontal/vertical detail, unlike the older raster-order split
+/// which biased toward vertical content.
 ///
 /// Naive separable 1D DCT — exactness isn't required for a feature,
 /// only stable scale and ordering. A faster approximate DCT could

--- a/zenanalyze/src/tier3.rs
+++ b/zenanalyze/src/tier3.rs
@@ -966,6 +966,24 @@ fn dct2d_8_three_planes_simd(
 /// caller's monomorphized variant, so the unused branches contribute
 /// zero code and zero runtime cost.
 ///
+/// **Empirical saturation.** Each likelihood is a weighted sum of
+/// clamped sub-components and is `clamp(0, 1)`'d again at the end.
+/// On a 219-image labeled corpus the observed maxes are:
+///
+/// - `text_likelihood`: max 0.71 (entropy_low + edge_hi + chroma_lo
+///   don't all max simultaneously on real text)
+/// - `screen_content_likelihood`: max 0.70 (typical screens have
+///   > 4000 distinct color bins, forcing `palette_small` to 0)
+/// - `natural_likelihood`: max 0.69 (entropy_hi + palette_large +
+///   chroma_moderate + not_flat don't all max simultaneously)
+///
+/// Recommended consumer thresholds (best F1 on the labeled corpus):
+/// `text_likelihood >= 0.30`, `screen_content_likelihood >= 0.60`,
+/// `natural_likelihood >= 0.06` (photo detection). Thresholds at
+/// or above 0.8 fire on nothing. See
+/// `docs/calibration-corpus-2026-04-27.md` for the full empirical
+/// distribution and AUC table.
+///
 /// [`text_likelihood`]: crate::feature::AnalysisFeature::TextLikelihood
 /// [`natural_likelihood`]: crate::feature::AnalysisFeature::NaturalLikelihood
 /// [`screen_content_likelihood`]: crate::feature::AnalysisFeature::ScreenContentLikelihood

--- a/zenanalyze/src/tier3.rs
+++ b/zenanalyze/src/tier3.rs
@@ -45,7 +45,7 @@ pub(crate) const DEFAULT_HF_MAX_BLOCKS: usize = 1024;
 pub fn populate_tier3(out: &mut RawAnalysis, stream: &mut RowStream<'_>, hf_max_blocks: usize) {
     let h_stats = luma_histogram_stats(stream);
     out.luma_histogram_entropy = h_stats.entropy;
-    #[cfg(feature = "experimental")]
+    #[cfg(feature = "composites")]
     {
         out.line_art_score = h_stats.line_art_score;
     }
@@ -584,8 +584,12 @@ fn dct_stats(stream: &mut RowStream<'_>, max_blocks: usize) -> Tier3DctStats {
     // compresses the heavy right tail (texture blocks vs flat
     // blocks differ by 4-5 orders of magnitude in raw energy) and
     // gives a mean / std that lives on a useful 0-7 scale.
-    let mut aq_log_sum: f64 = 0.0;
-    let mut aq_log_sq_sum: f64 = 0.0;
+    //
+    // We stage the raw `block_ac` values into a Vec during the main
+    // DCT loop and batch the `log10(1 + ac)` reduction afterwards
+    // via magetypes `log2_lowp` — vectorising 8 lanes per call vs
+    // 8 sequential scalar `f64::ln()` invocations (~50 cycles each).
+    let mut block_acs: Vec<f32> = Vec::with_capacity(max_blocks.min(4096));
     // Per-block low-AC-energy, retained for noise-floor estimation.
     // 10th percentile across blocks ≈ noise floor (flattest blocks'
     // residual AC). 4-byte storage × max_blocks = ~4 KB at default.
@@ -694,9 +698,7 @@ fn dct_stats(stream: &mut RowStream<'_>, max_blocks: usize) -> Tier3DctStats {
                     high_energy += e;
                 }
             }
-            let block_log = (1.0 + block_ac).ln() / core::f64::consts::LN_10;
-            aq_log_sum += block_log;
-            aq_log_sq_sum += block_log * block_log;
+            block_acs.push(block_ac as f32);
             block_low_y.push(block_low_y_ac as f32);
 
             // Per-block gradient flag. Threshold 0.9 picks blocks
@@ -780,6 +782,13 @@ fn dct_stats(stream: &mut RowStream<'_>, max_blocks: usize) -> Tier3DctStats {
         0.0
     };
 
+    // Batched log10(1 + ac) over `block_acs` via magetypes `ln_lowp`,
+    // dispatched to v4 / v3 / NEON / WASM128 / scalar. Replaces the
+    // per-block scalar `f64::ln()` (was ~50 cycles each × N blocks)
+    // with one `ln_lowp` call per 8 blocks at low precision (well
+    // above the noise floor for an aq_map_std on the 0–7 log scale).
+    let (aq_log_sum, aq_log_sq_sum) =
+        log10_sum_and_sq_sum_dispatch(&block_acs);
     let (aq_map_mean, aq_map_std) = if blocks_sampled > 0 {
         let n = blocks_sampled as f64;
         let mean = aq_log_sum / n;
@@ -987,6 +996,7 @@ fn dct2d_8_three_planes_simd(
 /// [`text_likelihood`]: crate::feature::AnalysisFeature::TextLikelihood
 /// [`natural_likelihood`]: crate::feature::AnalysisFeature::NaturalLikelihood
 /// [`screen_content_likelihood`]: crate::feature::AnalysisFeature::ScreenContentLikelihood
+#[cfg(feature = "composites")]
 pub fn compute_derived_likelihoods<const T3: bool, const PAL: bool>(out: &mut RawAnalysis) {
     let chroma_sh = out.cb_sharpness + out.cr_sharpness;
     let chroma_lo = (0.005 - chroma_sh).clamp(0.0, 0.005) / 0.005;
@@ -1019,4 +1029,69 @@ pub fn compute_derived_likelihoods<const T3: bool, const PAL: bool>(out: &mut Ra
             (entropy_hi * 0.3 + palette_large * 0.25 + chroma_moderate * 0.2 + not_flat * 0.25)
                 .clamp(0.0, 1.0);
     }
+}
+
+/// `composites`-disabled stub — keeps the call site in `lib.rs`
+/// unconditional. With `composites` off, no likelihood fields exist
+/// on `RawAnalysis`, so the body collapses to a no-op.
+#[cfg(not(feature = "composites"))]
+pub fn compute_derived_likelihoods<const T3: bool, const PAL: bool>(_out: &mut RawAnalysis) {}
+
+/// Dispatcher for the batched `log10(1 + ac)` reduction over the
+/// `block_acs` accumulator collected during the DCT-stats pass.
+/// Returns `(Σ log10(1+ac), Σ log10(1+ac)²)` as f64 — same shape
+/// the per-block scalar version produced.
+fn log10_sum_and_sq_sum_dispatch(block_acs: &[f32]) -> (f64, f64) {
+    incant!(log10_sum_and_sq_sum_simd(block_acs))
+}
+
+/// SIMD batched `log10(1 + ac)` and its square-sum, vectorised
+/// 8 lanes at a time via magetypes `log10_lowp`. The low-precision
+/// variant is ~12-bit accurate — far above the noise floor on the
+/// `aq_map_std` 0–7 log scale that consumes this output. Switching
+/// from per-block scalar `f64::ln() / LN_10` (~50 cycles each) to
+/// `log10_lowp` over an 8-wide vector removes a per-block transcendental
+/// call from the hot Tier 3 DCT loop.
+#[magetypes(define(f32x8), v4, v3, neon, wasm128, scalar)]
+fn log10_sum_and_sq_sum_simd(token: Token, block_acs: &[f32]) -> (f64, f64) {
+    let one_v = f32x8::splat(token, 1.0);
+    let mut sum_v = f32x8::zero(token);
+    let mut sq_sum_v = f32x8::zero(token);
+    let mut sum_f64: f64 = 0.0;
+    let mut sq_sum_f64: f64 = 0.0;
+    // FLUSH cadence — same `f32`-mantissa argument as the row-stats
+    // pass: log10 outputs land in `[0, ~7]` so partial sums of 32
+    // 8-lane chunks reach ~1.8 K, well below the 16 M f32 mantissa
+    // boundary.
+    const FLUSH: usize = 32;
+    let mut iters_since_flush = 0usize;
+    let chunks = block_acs.chunks_exact(8);
+    let remainder = chunks.remainder();
+    for chunk in chunks {
+        let arr: &[f32; 8] = chunk.try_into().unwrap();
+        let ac_v = f32x8::load(token, arr);
+        let log_v = (ac_v + one_v).log10_lowp();
+        sum_v += log_v;
+        sq_sum_v = log_v.mul_add(log_v, sq_sum_v);
+        iters_since_flush += 1;
+        if iters_since_flush >= FLUSH {
+            sum_f64 += sum_v.reduce_add() as f64;
+            sq_sum_f64 += sq_sum_v.reduce_add() as f64;
+            sum_v = f32x8::zero(token);
+            sq_sum_v = f32x8::zero(token);
+            iters_since_flush = 0;
+        }
+    }
+    sum_f64 += sum_v.reduce_add() as f64;
+    sq_sum_f64 += sq_sum_v.reduce_add() as f64;
+    // Scalar tail (≤ 7 leftover blocks) — use the same `log10_lowp`
+    // semantics the SIMD pass produced so the lowp/scalar boundary
+    // doesn't drift the aggregate. Native `f32::log10` is fine here
+    // because the tail count is tiny (typical ≤ 7 calls per analysis).
+    for &ac in remainder {
+        let l = (ac + 1.0).log10();
+        sum_f64 += l as f64;
+        sq_sum_f64 += (l as f64) * (l as f64);
+    }
+    (sum_f64, sq_sum_f64)
 }

--- a/zenjpeg/Cargo.toml
+++ b/zenjpeg/Cargo.toml
@@ -56,7 +56,12 @@ zenpixels = { workspace = true }
 # Image content analyzers (variance, edges, chroma sharpness, DCT energy)
 # used by `EncoderConfig::adaptive`. Pulls rows on demand from any
 # PixelSlice via zenpixels-convert internally.
-zenanalyze = { workspace = true }
+# `composites` enables the classifier-style likelihoods
+# (TextLikelihood, ScreenContentLikelihood, NaturalLikelihood,
+# LineArtScore) that drive the adaptive path. Their combinator
+# coefficients are calibration-driven and may drift in 0.1.x —
+# zenjpeg pins to whichever zenanalyze patch ships in lockstep.
+zenanalyze = { workspace = true, features = ["composites"] }
 garb = { workspace = true }  # SIMD pixel format conversions (rgb↔rgba/bgra)
 tinyvec = { workspace = true }  # Stack-allocated bounded vectors
 memchr = "2"  # SIMD byte search — used in detect::scanner to find marker bytes


### PR DESCRIPTION
## Summary

- RGBA-class 32-bpp inputs (RGBA8 / BGRA8 / Rgbx8 / Bgrx8) now skip RowConverter entirely. New `RowStream::Inner::StripAlpha8` path resolves channel indices at construction, then does a tight strip-and-maybe-swap into the existing row scratch. No converter alloc, no multi-stage plan, no per-row transfer/matrix/narrow CPU work.
- `CLAUDE.md` inside the crate locks **"no 0.2.x — every change in 0.1.x is additive"** as a non-negotiable guardrail.
- README rewritten with the full descriptor-gap signal table, every cargo-feature group, error-variant block, five-pass tier architecture (incl. tier_depth + StripAlpha8), 4 K perf for RGB8 + RGBA8.
- Stripped stale "DRAFT — not yet wired" lead-in from `feature.rs`.

Still routes through Convert for layouts that genuinely need it (RGBA16, RGBA-F32, grayscale, CMYK). u8-promotion bit-equality is already locked, so deferring RGBA16's native path doesn't cost any analyzer precision.

## Test plan
- [x] `cargo test -p zenanalyze` — 95 passing on default features
- [x] `cargo test -p zenanalyze --features experimental` — 135 passing (incl. 2 new strip-alpha unit tests + 1 new perf test)
- [x] `cargo clippy -p zenanalyze --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p zenanalyze --all-targets --features experimental -- -D warnings` — clean
- [x] Workspace `cargo check` — clean