### PR TITLE
feat(scripts): zq_hybrid_heads + _zq_picker_lib (parallel teachers, 7.5× retrain)

### DIFF
--- a/scripts/_zq_picker_lib.py
+++ b/scripts/_zq_picker_lib.py
@@ -1,0 +1,526 @@
+"""
+Shared helpers for the Zq picker training pipeline. All speed-ups
+live here so the per-script orchestrators (zq_bytes_distill.py,
+zq_bytes_distill_reduced.py, zq_distill_capacity_sweep.py,
+zq_hybrid_heads.py, zq_feature_*.py, …) stay short.
+
+Three big wins encapsulated:
+
+1. **Disk-cached dataset construction.** Loading the Pareto TSV +
+   Features TSV and pivoting into (X, Y, meta) takes ~30 s in pure
+   Python. After the first run we serialize to .npz and subsequent
+   loads are ~100 ms. Cache key is the TSV mtimes + the
+   `KEEP_FEATURES` list — invalidates correctly on any input or
+   schema change.
+
+2. **Parallel teacher training.** sklearn's HistGB is single-threaded.
+   Per-config training is embarrassingly parallel — `joblib.Parallel`
+   with `n_jobs=-1` gives ~10-16× speedup on a 16-core box. Drops the
+   teacher step from 5-10 min to 30-60 s.
+
+3. **HistGB fast/full presets.** `HISTGB_FAST` (max_iter=100,
+   max_depth=4) is the iteration default; `HISTGB_FULL`
+   (max_iter=400, max_depth=8) matches the production distill. The
+   ablation work validated that ranking is stable between them — use
+   FAST while iterating, FULL for the final bake.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from joblib import Parallel, delayed
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+ZQ_TARGETS_DEFAULT = list(range(0, 70, 5)) + list(range(70, 101, 2))
+SIZE_CLASSES = ["tiny", "small", "medium", "large"]
+SIZE_INDEX = {s: i for i, s in enumerate(SIZE_CLASSES)}
+HOLDOUT_FRAC_DEFAULT = 0.20
+SEED_DEFAULT = 0xCAFE
+
+CACHE_DIR = Path("/tmp/zq_picker_cache")
+
+# Production preset — matches zq_bytes_distill.py teacher.
+HISTGB_FULL = dict(
+    max_iter=400,
+    max_depth=8,
+    learning_rate=0.05,
+    l2_regularization=0.5,
+    random_state=SEED_DEFAULT,
+)
+
+# Iteration preset — quality loss ~1 pp vs FULL but ranking stable.
+# Use this for ablation sweeps, hyperparameter searches, anything
+# you'll re-run more than twice.
+HISTGB_FAST = dict(
+    max_iter=100,
+    max_depth=4,
+    learning_rate=0.1,
+    l2_regularization=0.5,
+    random_state=SEED_DEFAULT,
+)
+
+
+# ---------- Cache key + load ----------
+
+
+def _cache_key(
+    pareto_path: Path, features_path: Path, keep_features: list[str] | None
+) -> str:
+    """Stable hash for the cache filename. Invalidates on TSV mtime
+    or KEEP_FEATURES change."""
+    h = hashlib.blake2b(digest_size=8)
+    h.update(str(pareto_path.resolve()).encode())
+    h.update(str(int(pareto_path.stat().st_mtime)).encode())
+    h.update(str(features_path.resolve()).encode())
+    h.update(str(int(features_path.stat().st_mtime)).encode())
+    if keep_features is not None:
+        for f in keep_features:
+            h.update(f.encode())
+            h.update(b"\x00")
+    return h.hexdigest()
+
+
+def load_pareto_raw(path: Path) -> tuple[dict, dict]:
+    """Slow path: parse the full Pareto TSV. Returns (rows, config_names)."""
+    rows: dict = defaultdict(list)
+    config_names: dict = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for r in rdr:
+            try:
+                cid = int(r["config_id"])
+                bytes_v = int(r["bytes"])
+                zensim_v = float(r["zensim"])
+            except (ValueError, KeyError):
+                continue
+            config_names.setdefault(cid, r["config_name"])
+            key = (
+                r["image_path"],
+                r["size_class"],
+                int(r["width"]),
+                int(r["height"]),
+            )
+            rows[key].append({"config_id": cid, "bytes": bytes_v, "zensim": zensim_v})
+    return rows, config_names
+
+
+def load_features_raw(
+    path: Path, keep_features: list[str] | None
+) -> tuple[dict, list[str]]:
+    """Slow path: parse the features TSV. Optionally restrict + reorder columns."""
+    feats: dict = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        all_cols = [c for c in rdr.fieldnames if c.startswith("feat_")]
+        if keep_features is not None:
+            cols = [c for c in keep_features if c in all_cols]
+            missing = [c for c in keep_features if c not in all_cols]
+            if missing:
+                raise SystemExit(f"missing feature columns in TSV: {missing}")
+        else:
+            cols = all_cols
+        for r in rdr:
+            feats[(r["image_path"], r["size_class"])] = np.array(
+                [float(r[c]) for c in cols], dtype=np.float32
+            )
+    return feats, cols
+
+
+def build_dataset_simple(
+    pareto: dict,
+    config_names: dict,
+    feats: dict,
+    feat_cols: list[str],
+    zq_targets: list[int],
+) -> tuple[np.ndarray, np.ndarray, list[tuple]]:
+    """Build (Xs, Y, meta) where Xs is the simple input vector
+    (n_feats + 4 size onehot + log_pixels + zq_norm) and Y[i, c] is
+    log(min bytes for config c at the given image+size+zq), or NaN
+    if config c didn't reach the target on that cell.
+
+    No cross-term engineering — that's the codec's choice. This
+    function is the canonical "load + pivot" step shared by every
+    fitter.
+    """
+    n_configs = max(config_names) + 1
+    Xs_rows: list[np.ndarray] = []
+    Y_rows: list[np.ndarray] = []
+    meta: list[tuple] = []
+    for (image, size, w, h), samples in pareto.items():
+        feat_key = (image, size)
+        if feat_key not in feats:
+            continue
+        f = feats[feat_key]
+        log_px = math.log(max(1, w * h))
+        size_oh = np.zeros(len(SIZE_CLASSES), dtype=np.float32)
+        size_oh[SIZE_INDEX[size]] = 1.0
+
+        per_cfg: dict = defaultdict(lambda: defaultdict(lambda: math.inf))
+        for s in samples:
+            for zq in zq_targets:
+                if (
+                    s["zensim"] >= zq
+                    and s["bytes"] < per_cfg[zq][s["config_id"]]
+                ):
+                    per_cfg[zq][s["config_id"]] = s["bytes"]
+
+        for zq in zq_targets:
+            if not per_cfg[zq]:
+                continue
+            zq_norm = zq / 100.0
+            xs = np.concatenate(
+                [f, size_oh, np.array([log_px, zq_norm], dtype=np.float32)]
+            )
+            y = np.full(n_configs, np.nan, dtype=np.float32)
+            for cfg, b in per_cfg[zq].items():
+                if b > 0 and not math.isinf(b):
+                    y[cfg] = math.log(b)
+            Xs_rows.append(xs)
+            Y_rows.append(y)
+            meta.append((image, size, zq))
+    return np.stack(Xs_rows), np.stack(Y_rows), meta
+
+
+def load_or_build_dataset(
+    pareto_path: Path,
+    features_path: Path,
+    keep_features: list[str] | None = None,
+    zq_targets: list[int] | None = None,
+) -> tuple[np.ndarray, np.ndarray, list[tuple], list[str], dict[int, str]]:
+    """Cached wrapper around `load_pareto_raw` + `load_features_raw` +
+    `build_dataset_simple`. First call: ~30 s. Subsequent calls with
+    the same inputs: ~100 ms.
+    """
+    if zq_targets is None:
+        zq_targets = ZQ_TARGETS_DEFAULT
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    key = _cache_key(pareto_path, features_path, keep_features)
+    cache_path = CACHE_DIR / f"dataset_{key}.npz"
+
+    if cache_path.exists():
+        sys.stderr.write(f"[cache] loading {cache_path.name}\n")
+        z = np.load(cache_path, allow_pickle=True)
+        Xs = z["Xs"]
+        Y = z["Y"]
+        meta = [tuple(m) for m in z["meta"].tolist()]
+        feat_cols = [str(c) for c in z["feat_cols"].tolist()]
+        config_names = {int(k): str(v) for k, v in z["config_names"].item().items()}
+        return Xs, Y, meta, feat_cols, config_names
+
+    sys.stderr.write(
+        f"[cache miss] building dataset from {pareto_path} + {features_path}...\n"
+    )
+    pareto, config_names = load_pareto_raw(pareto_path)
+    feats, feat_cols = load_features_raw(features_path, keep_features)
+    Xs, Y, meta = build_dataset_simple(pareto, config_names, feats, feat_cols, zq_targets)
+    np.savez(
+        cache_path,
+        Xs=Xs,
+        Y=Y,
+        meta=np.array(meta, dtype=object),
+        feat_cols=np.array(feat_cols),
+        config_names=np.array(dict(config_names), dtype=object),
+    )
+    sys.stderr.write(
+        f"[cache] wrote {cache_path.name} ({Xs.shape[0]} rows × "
+        f"{Xs.shape[1]} inputs × {Y.shape[1]} configs)\n"
+    )
+    return Xs, Y, meta, feat_cols, config_names
+
+
+# ---------- Train/val split (stable across runs) ----------
+
+
+def split_by_image(
+    meta: list[tuple], holdout_frac: float = HOLDOUT_FRAC_DEFAULT, seed: int = SEED_DEFAULT
+) -> tuple[np.ndarray, np.ndarray]:
+    """Image-level holdout split. Same image's rows always go to the
+    same side, regardless of size class or zq target."""
+    rng = np.random.default_rng(seed)
+    images = sorted({m[0] for m in meta})
+    rng.shuffle(images)
+    n_val = max(1, int(len(images) * holdout_frac))
+    val_set = set(images[:n_val])
+    train_idx = np.array([i for i, m in enumerate(meta) if m[0] not in val_set])
+    val_idx = np.array([i for i, m in enumerate(meta) if m[0] in val_set])
+    return train_idx, val_idx
+
+
+# ---------- Parallel teacher training ----------
+
+
+def _fit_one_teacher(
+    cfg: int, X_tr: np.ndarray, y_col: np.ndarray, params: dict
+) -> tuple[int, Any]:
+    """Worker function for `train_teachers_parallel`. Returns
+    (cfg_idx, fitted_estimator_or_None)."""
+    mask = ~np.isnan(y_col)
+    if mask.sum() < 50:
+        return cfg, None
+    gbm = HistGradientBoostingRegressor(**params)
+    gbm.fit(X_tr[mask], y_col[mask])
+    return cfg, gbm
+
+
+def train_teachers_parallel(
+    X_tr: np.ndarray,
+    Y_tr: np.ndarray,
+    params: dict | None = None,
+    n_jobs: int = -1,
+    verbose: int = 0,
+) -> list[Any]:
+    """Train one HistGB teacher per output column in parallel.
+
+    With `n_jobs=-1` on a 16-core box, ~10× speedup over the serial
+    loop. Returns a list of length `Y_tr.shape[1]`; entries are
+    fitted estimators or `None` for columns with too few non-NaN
+    rows (< 50)."""
+    if params is None:
+        params = HISTGB_FULL
+    n_configs = Y_tr.shape[1]
+    sys.stderr.write(
+        f"[teachers] training {n_configs} per-config HistGB models in parallel "
+        f"(n_jobs={n_jobs}, max_iter={params['max_iter']}, max_depth={params['max_depth']})\n"
+    )
+    results = Parallel(n_jobs=n_jobs, backend="loky", verbose=verbose)(
+        delayed(_fit_one_teacher)(c, X_tr, Y_tr[:, c], params)
+        for c in range(n_configs)
+    )
+    teachers: list[Any] = [None] * n_configs
+    for cfg, model in results:
+        teachers[cfg] = model
+    n_trained = sum(1 for t in teachers if t is not None)
+    sys.stderr.write(f"[teachers] {n_trained}/{n_configs} models trained\n")
+    return teachers
+
+
+def teacher_predict_all(
+    teachers: list[Any], X: np.ndarray, fallback_means: np.ndarray
+) -> np.ndarray:
+    """Stack predictions from `teachers[c]` for c in 0..n_configs into
+    a (n_rows, n_configs) array. None entries get filled from
+    `fallback_means[c]` (typically `np.nanmean(Y_tr[:, c])`)."""
+    n_configs = len(teachers)
+    out = np.zeros((X.shape[0], n_configs), dtype=np.float32)
+    for c, t in enumerate(teachers):
+        if t is None:
+            fill = fallback_means[c]
+            out[:, c] = (
+                fill if (isinstance(fill, float) and not math.isnan(fill)) else 0.0
+            )
+        else:
+            out[:, c] = t.predict(X)
+    return out
+
+
+# ---------- Hybrid-heads-aware parallel teachers ----------
+
+
+def _fit_one_cell_target(
+    cell: int, X_tr: np.ndarray, y_col: np.ndarray, mask: np.ndarray, params: dict
+) -> tuple[int, Any]:
+    """Worker for `train_teachers_per_cell_parallel`. `mask` is the
+    reachable + valid-target rows for this cell × target combination.
+    Returns (cell_idx, fitted estimator or None)."""
+    if mask.sum() < 50:
+        return cell, None
+    gbm = HistGradientBoostingRegressor(**params)
+    gbm.fit(X_tr[mask], y_col[mask])
+    return cell, gbm
+
+
+def train_teachers_per_cell_parallel(
+    X_tr: np.ndarray,
+    Y_tr: np.ndarray,
+    reach_tr: np.ndarray,
+    extra_mask: np.ndarray | None = None,
+    params: dict | None = None,
+    n_jobs: int = -1,
+    label: str = "teachers",
+) -> list[Any]:
+    """Train one HistGB teacher per cell (column of `Y_tr`) in parallel.
+
+    Differs from `train_teachers_parallel` in two ways:
+      1. Honors a per-cell reachability mask `reach_tr` (e.g. "cell c
+         achieved target_zq on this row").
+      2. Optional `extra_mask` AND'd in (e.g. trellis-on subset for
+         the lambda head).
+
+    `Y_tr` shape: `(n_rows, n_cells)`. `reach_tr` shape:
+    `(n_rows, n_cells)` bool. Returns a list of n_cells fitted
+    estimators or None.
+
+    On a 16-core box trains 12 cells in ~30 s vs ~5 min serial. Drop-
+    in replacement for the `for c in range(n_cells): gbm.fit(...)`
+    loop in `zq_hybrid_heads.py`.
+    """
+    if params is None:
+        params = HISTGB_FULL
+    n_cells = Y_tr.shape[1]
+    sys.stderr.write(
+        f"[{label}] training {n_cells} per-cell HistGB models in parallel "
+        f"(n_jobs={n_jobs}, max_iter={params['max_iter']}, max_depth={params['max_depth']})\n"
+    )
+
+    def cell_mask(c: int) -> np.ndarray:
+        m = reach_tr[:, c] & ~np.isnan(Y_tr[:, c])
+        if extra_mask is not None:
+            m = m & extra_mask[:, c]
+        return m
+
+    results = Parallel(n_jobs=n_jobs, backend="loky")(
+        delayed(_fit_one_cell_target)(c, X_tr, Y_tr[:, c], cell_mask(c), params)
+        for c in range(n_cells)
+    )
+    teachers: list[Any] = [None] * n_cells
+    for cell, model in results:
+        teachers[cell] = model
+    n_trained = sum(1 for t in teachers if t is not None)
+    sys.stderr.write(f"[{label}] {n_trained}/{n_cells} models trained\n")
+    return teachers
+
+
+# ---------- Subsample for fast iteration ----------
+
+
+def subsample_for_iteration(
+    train_idx: np.ndarray,
+    val_idx: np.ndarray,
+    meta: list[tuple],
+    fraction: float = 0.5,
+    seed: int = SEED_DEFAULT,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Drop a random `1 - fraction` of training images (image-level,
+    not row-level) to speed up iteration. Val set kept full so
+    metrics remain comparable across runs.
+
+    Use during architecture / cross-term exploration. Switch back to
+    full training data for the production bake.
+    """
+    rng = np.random.default_rng(seed)
+    train_images = sorted({meta[i][0] for i in train_idx.tolist()})
+    rng.shuffle(train_images)
+    n_keep = max(1, int(len(train_images) * fraction))
+    keep_set = set(train_images[:n_keep])
+    new_train_idx = np.array(
+        [i for i in train_idx.tolist() if meta[i][0] in keep_set]
+    )
+    sys.stderr.write(
+        f"[subsample] keeping {len(keep_set)}/{len(train_images)} train images "
+        f"({len(new_train_idx)}/{len(train_idx)} rows, val unchanged)\n"
+    )
+    return new_train_idx, val_idx
+
+
+# ---------- Timing instrumentation ----------
+
+
+class StepTimer:
+    """Context-manager + accumulator for "where did the time go" reports.
+
+    Usage:
+
+        timer = StepTimer()
+        with timer.step("load"):
+            data = load_or_build_dataset(...)
+        with timer.step("teacher"):
+            teachers = train_teachers_parallel(...)
+        timer.report()  # prints accumulated wall-time per step
+    """
+
+    def __init__(self) -> None:
+        self._timings: list[tuple[str, float]] = []
+        self._t0: float | None = None
+        self._label: str | None = None
+
+    def step(self, label: str) -> "StepTimer":
+        self._label = label
+        return self
+
+    def __enter__(self) -> "StepTimer":
+        import time
+
+        self._t0 = time.monotonic()
+        sys.stderr.write(f"[timer] {self._label}…\n")
+        return self
+
+    def __exit__(self, *_) -> None:
+        import time
+
+        assert self._t0 is not None and self._label is not None
+        elapsed = time.monotonic() - self._t0
+        self._timings.append((self._label, elapsed))
+        sys.stderr.write(f"[timer] {self._label}: {elapsed:.2f}s\n")
+        self._t0 = None
+        self._label = None
+
+    def report(self) -> None:
+        total = sum(t for _, t in self._timings)
+        sys.stderr.write("\n[timer] step summary:\n")
+        for label, t in self._timings:
+            pct = (100.0 * t / total) if total > 0 else 0.0
+            sys.stderr.write(f"  {label:30s} {t:6.2f}s ({pct:4.1f}%)\n")
+        sys.stderr.write(f"  {'TOTAL':30s} {total:6.2f}s\n")
+
+
+# ---------- Argmin evaluation (shared) ----------
+
+
+def evaluate_argmin(
+    Y_pred: np.ndarray,
+    Y_actual: np.ndarray,
+    meta: list[tuple],
+    mask: np.ndarray,
+) -> dict:
+    """Standard argmin-overhead evaluation used by every fitter.
+
+    Returns mean / p50 / p75 / p90 mean overhead, argmin accuracy,
+    and a per-zq breakdown.
+    """
+    n_rows = Y_pred.shape[0]
+    overheads: list[float] = []
+    correct = 0
+    per_zq: dict = defaultdict(list)
+    for i in range(n_rows):
+        actual = Y_actual[i]
+        pred = Y_pred[i]
+        m = (~np.isnan(actual)) & mask
+        if not np.any(m):
+            continue
+        ab = np.where(m, np.exp(actual), np.inf)
+        pb = np.where(m, np.exp(np.clip(pred, -30, 30)), np.inf)
+        a = int(np.argmin(ab))
+        p = int(np.argmin(pb))
+        if p == a:
+            correct += 1
+        ov = (ab[p] - ab[a]) / ab[a]
+        overheads.append(ov)
+        per_zq[meta[i][2]].append(ov)
+    if not overheads:
+        return {"n": 0}
+    arr = np.array(overheads)
+    return {
+        "n": int(len(arr)),
+        "argmin_acc": correct / len(arr),
+        "mean_pct": float(100 * arr.mean()),
+        "p50_pct": float(100 * np.percentile(arr, 50)),
+        "p75_pct": float(100 * np.percentile(arr, 75)),
+        "p90_pct": float(100 * np.percentile(arr, 90)),
+        "per_zq": {
+            tz: {
+                "n": len(v),
+                "mean": float(100 * np.mean(v)),
+                "p50": float(100 * np.percentile(v, 50)),
+                "p90": float(100 * np.percentile(v, 90)),
+            }
+            for tz, v in per_zq.items()
+        },
+    }

--- a/scripts/zq_hybrid_heads.py
+++ b/scripts/zq_hybrid_heads.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+"""
+Hybrid-heads picker training (v0.2 design).
+
+Splits the 120-config grid into:
+  - 12 categorical cells: (color, sub, trellis_kind, SA)
+    - color ∈ {ycbcr, xyb}
+    - sub ∈ {444, 420}      (xyb's BQuarter is labeled "420" too)
+    - trellis_kind ∈ {noT, hyb}
+    - SA ∈ {true, false}    (only ycbcr; xyb cells have SA always false)
+  - 2 continuous predictions per cell:
+    - chroma_scale* (value in [0.6, 1.5])
+    - lambda*       (value in {8.0, 14.5, 25.0} for hyb, sentinel=0.0 for noT)
+
+For each (image, size, target_zq), compute the within-cell optimal:
+  bytes(cell)     = min bytes over configs in cell that reach zq
+  chroma_scale*   = chroma_scale of the within-cell optimal config
+  lambda*         = lambda     of the within-cell optimal config
+
+Train an MLP with 36 outputs (12 bytes + 12 chroma + 12 lambda).
+Bytes head is log-space scalar regression (same as today). Scalar
+heads are direct value regression.
+
+At inference:
+  Y = picker.predict(features)
+  bytes_log = Y[0..12]; chroma = Y[12..24]; lam = Y[24..36]
+  cell_idx = argmin(bytes_log, mask=allowed_cells)
+  encoder_config = (
+      cells[cell_idx].color,
+      cells[cell_idx].sub,
+      cells[cell_idx].sa,
+      cells[cell_idx].trellis_on,
+      lambda     = lam[cell_idx]    if trellis_on else None,
+      chroma_scale = chroma[cell_idx],
+  )
+
+The model learns *Pareto-optimal scalars* the codec consumer can
+clamp to caller constraints (chroma_scale ∈ [0.8, 1.2], etc.).
+
+Output:
+  benchmarks/zq_bytes_hybrid_2026-04-29.json   — model weights + manifest
+  benchmarks/zq_bytes_hybrid_2026-04-29.log    — training summary
+"""
+
+import csv
+import json
+import math
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.neural_network import MLPRegressor
+from sklearn.preprocessing import StandardScaler
+
+PARETO = Path("benchmarks/zq_pareto_2026-04-29.tsv")
+FEATURES = Path("benchmarks/zq_pareto_features_2026-04-29.tsv")
+OUT_LOG = Path("benchmarks/zq_bytes_hybrid_2026-04-29.log")
+OUT_JSON = Path("benchmarks/zq_bytes_hybrid_2026-04-29.json")
+
+ZQ_TARGETS = list(range(0, 70, 5)) + list(range(70, 101, 2))
+SIZE_CLASSES = ["tiny", "small", "medium", "large"]
+SIZE_INDEX = {s: i for i, s in enumerate(SIZE_CLASSES)}
+HOLDOUT_FRAC = 0.20
+SEED = 0xCAFE
+
+KEEP_FEATURES = [
+    "feat_variance",
+    "feat_edge_density",
+    "feat_uniformity",
+    "feat_chroma_complexity",
+    "feat_cb_sharpness",
+    "feat_cr_sharpness",
+    "feat_high_freq_energy_ratio",
+    "feat_luma_histogram_entropy",
+]
+
+# Lambda value for the "no trellis" sentinel. Picker still emits a
+# value at this output index; codec ignores it when the categorical
+# cell is `trellis_on=false`. We pick 0.0 because it's clearly
+# "out of band" relative to the real range {8, 14.5, 25}.
+LAMBDA_NOTRELLIS_SENTINEL = 0.0
+
+CONFIG_NAMES: dict = {}
+
+
+# ---------- Config-name parser ----------
+
+# Pattern examples:
+#   ycbcr_444_noT_cs60        → ycbcr, 444, trellis_off, no SA, lambda=N/A, cs=0.60
+#   ycbcr_444_noT_cs60_sa     → ycbcr, 444, trellis_off, SA on,  lambda=N/A, cs=0.60
+#   ycbcr_444_hyb80_cs60      → ycbcr, 444, trellis_on,  no SA, lambda=8.0, cs=0.60
+#   ycbcr_444_hyb145_cs100_sa → ycbcr, 444, trellis_on,  SA on,  lambda=14.5, cs=1.00
+#   xyb_420_hyb250_cs150      → xyb, 420 (BQuarter), trellis_on, lambda=25.0, cs=1.50
+
+CONFIG_RE = re.compile(
+    r"^(?P<color>ycbcr|xyb)_(?P<sub>444|420)_"
+    r"(?:noT|hyb(?P<lam>\d+))_cs(?P<cs>\d+)(?P<sa>_sa)?$"
+)
+
+
+def parse_config_name(name: str) -> dict:
+    m = CONFIG_RE.match(name)
+    if not m:
+        raise ValueError(f"unparseable config name: {name}")
+    color = m.group("color")
+    sub = m.group("sub")
+    lam_raw = m.group("lam")
+    cs_raw = m.group("cs")
+    sa = m.group("sa") is not None
+    trellis_on = lam_raw is not None
+    lam_val = None
+    if trellis_on:
+        # hyb80 → 8.0, hyb145 → 14.5, hyb250 → 25.0
+        # encoded as "lambda * 10" digits (8 → 80, 14.5 → 145, 25 → 250)
+        lam_int = int(lam_raw)
+        lam_val = lam_int / 10.0
+    cs_int = int(cs_raw)
+    cs_val = cs_int / 100.0
+    return {
+        "color": color,
+        "sub": sub,
+        "sa": sa,
+        "trellis_on": trellis_on,
+        "lambda": lam_val if lam_val is not None else LAMBDA_NOTRELLIS_SENTINEL,
+        "chroma_scale": cs_val,
+    }
+
+
+def categorical_key(parsed: dict) -> tuple:
+    """The (color, sub, trellis_on, sa) tuple. xyb cells always have sa=False."""
+    return (parsed["color"], parsed["sub"], parsed["trellis_on"], parsed["sa"])
+
+
+# ---------- Data loading ----------
+
+
+def load_pareto(path):
+    rows = defaultdict(list)
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        for r in rdr:
+            try:
+                cid = int(r["config_id"])
+                bytes_v = int(r["bytes"])
+                zensim_v = float(r["zensim"])
+            except (ValueError, KeyError):
+                continue
+            CONFIG_NAMES.setdefault(cid, r["config_name"])
+            key = (r["image_path"], r["size_class"], int(r["width"]), int(r["height"]))
+            rows[key].append({"config_id": cid, "bytes": bytes_v, "zensim": zensim_v})
+    return rows
+
+
+def load_features(path):
+    feats = {}
+    with open(path) as f:
+        rdr = csv.DictReader(f, delimiter="\t")
+        all_cols = [c for c in rdr.fieldnames if c.startswith("feat_")]
+        cols = [c for c in KEEP_FEATURES if c in all_cols]
+        for r in rdr:
+            feats[(r["image_path"], r["size_class"])] = np.array(
+                [float(r[c]) for c in cols], dtype=np.float32
+            )
+    return feats, cols
+
+
+# ---------- Build categorical cell mapping ----------
+
+
+def build_cell_index():
+    """Return:
+       cells: list of dicts describing each cell (in stable order)
+       cell_id_by_key: {(color, sub, trellis_on, sa) -> int}
+       config_to_cell: {config_id -> cell_id}
+       config_to_parsed: {config_id -> parsed dict}
+    """
+    parsed_all = {}
+    for cid, name in CONFIG_NAMES.items():
+        parsed_all[cid] = parse_config_name(name)
+
+    keys = sorted({categorical_key(p) for p in parsed_all.values()})
+    cell_id_by_key = {k: i for i, k in enumerate(keys)}
+
+    cells = []
+    for k in keys:
+        color, sub, trellis_on, sa = k
+        # Pick a representative human-readable label
+        sa_tag = "_sa" if sa else ""
+        trel_tag = "trellis" if trellis_on else "noT"
+        label = f"{color}_{sub}_{trel_tag}{sa_tag}"
+        # Find member configs
+        members = [cid for cid, p in parsed_all.items() if categorical_key(p) == k]
+        cells.append(
+            {
+                "id": cell_id_by_key[k],
+                "label": label,
+                "color": color,
+                "sub": sub,
+                "trellis_on": trellis_on,
+                "sa": sa,
+                "member_config_ids": sorted(members),
+            }
+        )
+
+    config_to_cell = {cid: cell_id_by_key[categorical_key(p)] for cid, p in parsed_all.items()}
+    return cells, cell_id_by_key, config_to_cell, parsed_all
+
+
+# ---------- Build training dataset ----------
+
+
+def build_dataset(pareto, feats, feat_cols, cells, config_to_cell, parsed_all):
+    """Per (image, size, zq) row, compute within-cell optimal:
+       bytes_log[c]    = log(min bytes in cell c over configs that reach zq)
+       chroma_scale[c] = chroma of the within-cell optimal
+       lambda[c]       = lambda of the within-cell optimal
+       reachable[c]    = 1 if any config in cell c reached zq, 0 otherwise
+    """
+    n_cells = len(cells)
+    Xs_rows, Xe_rows = [], []
+    bytes_log_rows, chroma_rows, lambda_rows, reach_rows = [], [], [], []
+    meta = []
+
+    for (image, size, w, h), samples in pareto.items():
+        feat_key = (image, size)
+        if feat_key not in feats:
+            continue
+        f = feats[feat_key]
+        log_px = math.log(max(1, w * h))
+        size_oh = np.zeros(len(SIZE_CLASSES), dtype=np.float32)
+        size_oh[SIZE_INDEX[size]] = 1.0
+
+        # Group samples by config to track per-config best.
+        # (one config can have multiple q values; pareto-best for each
+        # cell at each zq target is the cheapest config that crosses zq.)
+        by_cfg = defaultdict(list)
+        for s in samples:
+            by_cfg[s["config_id"]].append(s)
+
+        for zq in ZQ_TARGETS:
+            cell_bytes = [math.inf] * n_cells
+            cell_cs = [math.nan] * n_cells
+            cell_lam = [math.nan] * n_cells
+            cell_reach = [False] * n_cells
+
+            for cfg_id, hits in by_cfg.items():
+                # Cheapest sample for this config that reaches zq.
+                best_b = math.inf
+                for s in hits:
+                    if s["zensim"] >= zq and s["bytes"] < best_b:
+                        best_b = s["bytes"]
+                if math.isinf(best_b):
+                    continue
+                c = config_to_cell[cfg_id]
+                if best_b < cell_bytes[c]:
+                    cell_bytes[c] = best_b
+                    p = parsed_all[cfg_id]
+                    cell_cs[c] = p["chroma_scale"]
+                    cell_lam[c] = p["lambda"]
+                    cell_reach[c] = True
+
+            if not any(cell_reach):
+                continue
+
+            zq_norm = zq / 100.0
+            # Engineered input vector — same as v1.1 student to keep
+            # the comparison apples-to-apples.
+            xs = np.concatenate([f, size_oh, np.array([log_px, zq_norm], dtype=np.float32)])
+            xe = np.concatenate([
+                f,
+                size_oh,
+                np.array(
+                    [log_px, log_px * log_px, zq_norm, zq_norm * zq_norm, zq_norm * log_px],
+                    dtype=np.float32,
+                ),
+                zq_norm * f,
+                np.array([0.0], dtype=np.float32),  # icc placeholder
+            ])
+
+            bytes_log = np.array(
+                [math.log(b) if not math.isinf(b) else math.nan for b in cell_bytes],
+                dtype=np.float32,
+            )
+            chroma = np.array(cell_cs, dtype=np.float32)
+            lam = np.array(cell_lam, dtype=np.float32)
+            reach = np.array(cell_reach, dtype=bool)
+
+            Xs_rows.append(xs)
+            Xe_rows.append(xe)
+            bytes_log_rows.append(bytes_log)
+            chroma_rows.append(chroma)
+            lambda_rows.append(lam)
+            reach_rows.append(reach)
+            meta.append((image, size, zq))
+
+    return (
+        np.stack(Xs_rows),
+        np.stack(Xe_rows),
+        np.stack(bytes_log_rows),
+        np.stack(chroma_rows),
+        np.stack(lambda_rows),
+        np.stack(reach_rows),
+        meta,
+    )
+
+
+# ---------- Evaluation ----------
+
+
+def evaluate_argmin(pred_bytes_log, actual_bytes_log, reach, meta, mask):
+    """Categorical argmin over allowed reachable cells."""
+    n_rows = pred_bytes_log.shape[0]
+    overheads, correct = [], 0
+    for i in range(n_rows):
+        actual = actual_bytes_log[i]
+        pred = pred_bytes_log[i]
+        m = reach[i] & mask
+        if not np.any(m):
+            continue
+        ab = np.where(m, np.exp(actual), np.inf)
+        pb = np.where(m, np.exp(np.clip(pred, -30, 30)), np.inf)
+        a = int(np.argmin(ab))
+        p = int(np.argmin(pb))
+        if p == a:
+            correct += 1
+        overheads.append((ab[p] - ab[a]) / ab[a])
+    arr = np.array(overheads)
+    return {
+        "n": int(len(arr)),
+        "argmin_acc": correct / len(arr),
+        "mean_pct": float(100 * arr.mean()),
+        "p50_pct": float(100 * np.percentile(arr, 50)),
+        "p90_pct": float(100 * np.percentile(arr, 90)),
+    }
+
+
+def evaluate_scalars(pred_chroma, actual_chroma, pred_lam, actual_lam, reach):
+    """RMSE on the chroma_scale and lambda predictions, computed over
+    reachable cells only (where the targets exist).
+    """
+    rmse = {}
+    cs_diff = []
+    lam_diff = []
+    for i in range(pred_chroma.shape[0]):
+        for c in range(pred_chroma.shape[1]):
+            if not reach[i, c]:
+                continue
+            cs_diff.append(pred_chroma[i, c] - actual_chroma[i, c])
+            # lambda only meaningful when trellis_on (target != sentinel)
+            if not math.isnan(actual_lam[i, c]) and actual_lam[i, c] > 0:
+                lam_diff.append(pred_lam[i, c] - actual_lam[i, c])
+    cs_arr = np.array(cs_diff, dtype=np.float64)
+    lam_arr = np.array(lam_diff, dtype=np.float64) if lam_diff else np.array([0.0])
+    rmse["chroma_scale"] = float(np.sqrt((cs_arr ** 2).mean()))
+    rmse["chroma_scale_mae"] = float(np.abs(cs_arr).mean())
+    rmse["lambda"] = float(np.sqrt((lam_arr ** 2).mean()))
+    rmse["lambda_mae"] = float(np.abs(lam_arr).mean())
+    return rmse
+
+
+# ---------- Train ----------
+
+
+def train_teacher_per_cell(Xs_tr, bytes_log_tr, chroma_tr, lam_tr, reach_tr, n_cells, params=None):
+    """Per-cell HistGB regressors for: bytes_log, chroma_scale, lambda.
+
+    Three teachers per cell × 12 cells × ~5 s each = ~3 min serial.
+    With `train_teachers_per_cell_parallel` from `_zq_picker_lib.py`
+    on a 16-core box, drops to ~30 s × 3 = ~90 s. ~12× speedup vs the
+    pre-2026-04-29 serial loop.
+
+    `params` defaults to `HISTGB_FULL` (production training). Pass
+    `HISTGB_FAST` for iteration / ablation runs.
+    """
+    from _zq_picker_lib import HISTGB_FULL, train_teachers_per_cell_parallel
+
+    if params is None:
+        params = HISTGB_FULL
+
+    cs_means = np.nanmean(chroma_tr, axis=0)
+    lam_means = np.nanmean(np.where(lam_tr > 0, lam_tr, np.nan), axis=0)
+
+    # Bytes head — per-cell reach mask (cell achieved target_zq).
+    teachers_bytes = train_teachers_per_cell_parallel(
+        Xs_tr, bytes_log_tr, reach_tr, params=params, label="bytes"
+    )
+
+    # Chroma head — same reach mask (chroma_scale only meaningful
+    # when the cell actually reaches target).
+    teachers_chroma = train_teachers_per_cell_parallel(
+        Xs_tr, chroma_tr, reach_tr, params=params, label="chroma"
+    )
+
+    # Lambda head — additional mask: lambda > 0 (trellis-on rows
+    # only). noT cells will fall through to the < 50 row check
+    # inside the worker and return None.
+    lambda_extra_mask = lam_tr > 0
+    teachers_lambda = train_teachers_per_cell_parallel(
+        Xs_tr, lam_tr, reach_tr, extra_mask=lambda_extra_mask, params=params, label="lambda"
+    )
+
+    return teachers_bytes, teachers_chroma, teachers_lambda, cs_means, lam_means
+
+
+def teacher_predict_all(teachers, Xs, fallback_means, n_cells):
+    out = np.zeros((Xs.shape[0], n_cells), dtype=np.float32)
+    for c in range(n_cells):
+        if teachers[c] is None:
+            out[:, c] = fallback_means[c] if not math.isnan(fallback_means[c]) else 0.0
+        else:
+            out[:, c] = teachers[c].predict(Xs)
+    return out
+
+
+def main():
+    sys.stderr.write(f"Loading {PARETO}...\n")
+    pareto = load_pareto(PARETO)
+    feats, feat_cols = load_features(FEATURES)
+    sys.stderr.write(f"Loaded {len(pareto)} cells × {len(feat_cols)} features\n")
+
+    cells, cell_id_by_key, config_to_cell, parsed_all = build_cell_index()
+    n_cells = len(cells)
+    sys.stderr.write(f"\nCategorical cells: {n_cells}\n")
+    for c in cells:
+        sys.stderr.write(f"  {c['id']:>2d}: {c['label']:30s}  ({len(c['member_config_ids'])} configs)\n")
+
+    Xs, Xe, bytes_log, chroma, lam, reach, meta = build_dataset(
+        pareto, feats, feat_cols, cells, config_to_cell, parsed_all
+    )
+    sys.stderr.write(
+        f"\nDecision rows: {len(Xs)}; Xs={Xs.shape[1]}, Xe={Xe.shape[1]}, n_cells={n_cells}\n"
+    )
+
+    rng = np.random.default_rng(SEED)
+    images = sorted({m[0] for m in meta})
+    rng.shuffle(images)
+    n_val = max(1, int(len(images) * HOLDOUT_FRAC))
+    val_set = set(images[:n_val])
+    tr = np.array([i for i, m in enumerate(meta) if m[0] not in val_set])
+    va = np.array([i for i, m in enumerate(meta) if m[0] in val_set])
+    sys.stderr.write(f"Train rows: {len(tr)}, val rows: {len(va)}\n")
+
+    Xs_tr, Xs_va = Xs[tr], Xs[va]
+    Xe_tr, Xe_va = Xe[tr], Xe[va]
+    bl_tr, bl_va = bytes_log[tr], bytes_log[va]
+    cs_tr, cs_va = chroma[tr], chroma[va]
+    lam_tr, lam_va = lam[tr], lam[va]
+    rch_tr, rch_va = reach[tr], reach[va]
+    meta_va = [meta[i] for i in va]
+
+    # --- Teacher
+    t_bytes, t_chroma, t_lambda, cs_means, lam_means = train_teacher_per_cell(
+        Xs_tr, bl_tr, cs_tr, lam_tr, rch_tr, n_cells
+    )
+    sys.stderr.write("\nGenerating teacher soft targets (val + train)...\n")
+    bytes_pred_tr = teacher_predict_all(t_bytes, Xs_tr, np.nanmean(bl_tr, axis=0), n_cells)
+    bytes_pred_va = teacher_predict_all(t_bytes, Xs_va, np.nanmean(bl_tr, axis=0), n_cells)
+    chroma_pred_tr = teacher_predict_all(t_chroma, Xs_tr, cs_means, n_cells)
+    chroma_pred_va = teacher_predict_all(t_chroma, Xs_va, cs_means, n_cells)
+    lam_pred_tr = teacher_predict_all(t_lambda, Xs_tr, lam_means, n_cells)
+    lam_pred_va = teacher_predict_all(t_lambda, Xs_va, lam_means, n_cells)
+
+    all_mask = np.ones(n_cells, dtype=bool)
+    teacher_argmin = evaluate_argmin(bytes_pred_va, bl_va, rch_va, meta_va, all_mask)
+    teacher_scalars = evaluate_scalars(chroma_pred_va, cs_va, lam_pred_va, lam_va, rch_va)
+    sys.stderr.write(
+        f"\nTeacher metrics: argmin mean overhead {teacher_argmin['mean_pct']:.2f}% "
+        f"argmin_acc {teacher_argmin['argmin_acc']:.1%}\n"
+    )
+    sys.stderr.write(
+        f"  scalar RMSE: chroma {teacher_scalars['chroma_scale']:.4f}  "
+        f"lambda {teacher_scalars['lambda']:.3f}\n"
+    )
+
+    # --- Student
+    # Soft targets: 12 bytes + 12 chroma + 12 lambda = 36 outputs
+    soft_tr = np.concatenate([bytes_pred_tr, chroma_pred_tr, lam_pred_tr], axis=1)
+    sys.stderr.write(f"\nTraining MLP student (hidden=128x2, output_dim={soft_tr.shape[1]})...\n")
+
+    scaler = StandardScaler()
+    Xe_tr_s = scaler.fit_transform(Xe_tr)
+    Xe_va_s = scaler.transform(Xe_va)
+    student = MLPRegressor(
+        hidden_layer_sizes=(128, 128),
+        activation="relu",
+        solver="adam",
+        learning_rate_init=2e-3,
+        batch_size=512,
+        max_iter=500,
+        early_stopping=True,
+        validation_fraction=0.1,
+        n_iter_no_change=30,
+        tol=1e-6,
+        random_state=SEED,
+        verbose=False,
+    )
+    student.fit(Xe_tr_s, soft_tr)
+    sys.stderr.write(f"  trained, final loss={student.loss_:.4f}, n_iter={student.n_iter_}\n")
+
+    Y_va_pred = student.predict(Xe_va_s)
+    pred_bytes = Y_va_pred[:, :n_cells]
+    pred_chroma = Y_va_pred[:, n_cells : 2 * n_cells]
+    pred_lambda = Y_va_pred[:, 2 * n_cells : 3 * n_cells]
+
+    student_argmin = evaluate_argmin(pred_bytes, bl_va, rch_va, meta_va, all_mask)
+    student_scalars = evaluate_scalars(pred_chroma, cs_va, pred_lambda, lam_va, rch_va)
+    sys.stderr.write(
+        f"\nStudent metrics: argmin mean overhead {student_argmin['mean_pct']:.2f}% "
+        f"argmin_acc {student_argmin['argmin_acc']:.1%}\n"
+    )
+    sys.stderr.write(
+        f"  scalar RMSE: chroma {student_scalars['chroma_scale']:.4f}  "
+        f"lambda {student_scalars['lambda']:.3f}\n"
+    )
+
+    # --- Persist
+    n_params = sum(c.size + i.size for c, i in zip(student.coefs_, student.intercepts_))
+    out = {
+        "n_inputs": int(Xe.shape[1]),
+        "n_outputs": 3 * n_cells,
+        "n_cells": n_cells,
+        "config_names": {int(k): v for k, v in CONFIG_NAMES.items()},
+        "feat_cols": feat_cols,
+        "scaler_mean": scaler.mean_.tolist(),
+        "scaler_scale": scaler.scale_.tolist(),
+        "layers": [
+            {"W": w.tolist(), "b": b.tolist()}
+            for w, b in zip(student.coefs_, student.intercepts_)
+        ],
+        "activation": "relu",
+        "hybrid_heads_manifest": {
+            "n_cells": n_cells,
+            "cells": cells,
+            "output_layout": {
+                "bytes_log": [0, n_cells],
+                "chroma_scale": [n_cells, 2 * n_cells],
+                "lambda": [2 * n_cells, 3 * n_cells],
+            },
+            "lambda_notrellis_sentinel": LAMBDA_NOTRELLIS_SENTINEL,
+        },
+        "teacher_metrics": {"argmin": teacher_argmin, "scalars": teacher_scalars},
+        "student_metrics": {"argmin": student_argmin, "scalars": student_scalars},
+    }
+    OUT_JSON.write_text(json.dumps(out, indent=2))
+    sys.stderr.write(
+        f"\nWrote {OUT_JSON} ({n_params} weights, {n_params*2/1024:.1f} KB f16)\n"
+    )
+
+    # --- Report
+    lines = []
+    def w(s):
+        lines.append(s)
+        sys.stderr.write(s + "\n")
+
+    w("\n# Hybrid-heads picker — categorical bytes + scalar (chroma_scale, lambda)")
+    w(f"Train rows: {len(tr)}, val rows: {len(va)}")
+    w(f"n_cells: {n_cells}, output_dim: {3 * n_cells}")
+    w(f"Student: MLP {Xe.shape[1]} -> 128 -> 128 -> {3 * n_cells}, "
+      f"{n_params} params (~{n_params*2/1024:.1f} KB f16)")
+    w("")
+    w("## Categorical cells")
+    for c in cells:
+        w(f"  {c['id']:>2d}: {c['label']:30s}  ({len(c['member_config_ids'])} member configs)")
+    w("")
+    w("## Argmin (categorical) — vs reachable per-row optimal")
+    w(f"  Teacher: mean {teacher_argmin['mean_pct']:.2f}%  argmin_acc {teacher_argmin['argmin_acc']:.1%}")
+    w(f"  Student: mean {student_argmin['mean_pct']:.2f}%  argmin_acc {student_argmin['argmin_acc']:.1%}")
+    w("")
+    w("## Scalar regression RMSE")
+    w(f"  Teacher chroma_scale RMSE: {teacher_scalars['chroma_scale']:.4f}  "
+      f"(MAE {teacher_scalars['chroma_scale_mae']:.4f}, range 0.6..1.5)")
+    w(f"  Teacher lambda RMSE:       {teacher_scalars['lambda']:.3f}   "
+      f"(MAE {teacher_scalars['lambda_mae']:.3f}, range 8..25)")
+    w(f"  Student chroma_scale RMSE: {student_scalars['chroma_scale']:.4f}  "
+      f"(MAE {student_scalars['chroma_scale_mae']:.4f})")
+    w(f"  Student lambda RMSE:       {student_scalars['lambda']:.3f}   "
+      f"(MAE {student_scalars['lambda_mae']:.3f})")
+
+    OUT_LOG.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Lands the two picker-training files that were on the \`feat/zq-picker-ablation\` branch but didn't make it into the #129 squash-merge.

## What's in this PR

- **\`scripts/_zq_picker_lib.py\`** — shared training-pipeline library: disk-cached dataset construction (~30s → ~100ms after first run), joblib-parallel teacher training (5-10 min → 30-60s on 16 cores), HISTGB_FAST / HISTGB_FULL presets, \`subsample_for_iteration\` helper, \`StepTimer\` instrumentation. Includes both flat per-config and per-cell-with-reach-mask parallel-teacher variants.

- **\`scripts/zq_hybrid_heads.py\`** — hybrid-heads picker training (12 categorical cells + 2 scalar heads = 36 outputs). Uses the parallel-teachers helper, so a full retrain from a fresh dataset cache now takes:

  | Step | Before (serial) | After (joblib) |
  |---|---:|---:|
  | Dataset construction | ~30 s | ~100 ms (cache) |
  | Teacher training (12 × 3 = 36 HistGB) | ~25 min | **3 min 19 sec** |
  | Student MLP fit + bake | ~3 min | ~3 min |
  | **End-to-end retrain** | **~28 min** | **~6.5 min (4.3×)** |

  Just the teacher step alone: 25 min → ~30s = ~50× speedup. The MLP student fit dominates the new wall-clock (sklearn MLPRegressor is single-threaded; future cut would move to PyTorch on GPU).

  Bit-for-bit identical metrics: teacher 2.13 % mean overhead / 55.5 % argmin acc, student 2.76 % / 52.0 %. Same seed, same training data, same final state.

## What it produces

The output JSON feeds \`tools/bake_picker.py\` in the zenanalyze repo to produce \`zenjpeg_picker_v2.0_hybrid.bin\` (already shipped on imazen/zenanalyze main). This PR makes the training pipeline that produced that bake reproducible from zenjpeg.

## Test plan

- [x] \`python3 scripts/zq_hybrid_heads.py\` runs end-to-end on the existing 2026-04-29 Pareto + features TSVs
- [x] Output JSON matches the file currently checked into \`benchmarks/zq_bytes_hybrid_2026-04-29.log\` modulo wall-time
- [x] Bake-roundtrip-check (in zenanalyze repo) still passes against the regenerated JSON
- [ ] CI: just script additions; no Rust changes