### PR TITLE
feat(diagnostics): unstable per-block encode diagnostics + WASM viewer

### DIFF
--- a/.github/workflows/diagnostics-ci.yml
+++ b/.github/workflows/diagnostics-ci.yml
@@ -1,7 +1,7 @@
 name: diagnostics-ci
 
 # UNSTABLE __diagnostics feature + viewer end-to-end gate.
-# Triggers only on the diagnostics bookmark and the matching PR.
+# Triggers on the diagnostics branch and matching PRs.
 # Does NOT block main; the parent ci.yml is unaffected.
 
 on:
@@ -25,7 +25,11 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-D warnings"
+  # Don't promote warnings to errors globally — sibling crates we
+  # build alongside zenjpeg (zenanalyze, zencodec, etc.) may have
+  # transient unused-import warnings that we don't control. The
+  # zenjpeg crates themselves still get warning hygiene from the
+  # parent ci.yml on its own runs.
 
 jobs:
   rust-tests:
@@ -33,39 +37,51 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Per parent CLAUDE.md: every crate must test on linux-x86_64,
-        # windows-11-arm, macos-15-intel (or 26), and i686 cross.
-        # i686 cross runs in a separate job below.
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
           - os: windows-11-arm
-            target: aarch64-pc-windows-msvc
           - os: macos-15-intel
-            target: x86_64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+      - name: Configure git for private repos
+        run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Clone sibling repos
+        shell: bash
+        run: |
+          cd ..
+          git clone --depth 1 https://github.com/imazen/zencodec.git
+          git clone --depth 1 https://github.com/imazen/zenpng.git
+          git clone --depth 1 https://github.com/imazen/zenflate.git
+          git clone --depth 1 https://github.com/imazen/zenanalyze.git
+
+      - name: Strip non-CI workspace members and deps
+        shell: bash
+        run: |
+          # Remove workspace members that can't build in CI.
+          sed \
+            -e '/"internal\/jpegli-internals-sys"/d' \
+            -e '/"zjpeg"/d' \
+            Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
+          # Remove zenresize workspace dep (needs zenblend/zennode chain).
+          sed -e '/^zenresize/d' Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
+          # Remove non-CI deps from zenjpeg.
+          sed \
+            -e '/jpegli-internals-sys/d' \
+            -e '/zenresize.*workspace/d' \
+            -e '/zennode.*path/d' \
+            -e 's/^layout = .*/layout = []/' \
+            -e 's/^zennode = .*/zennode = []/' \
+            -e 's/, features = \["cjpegli-ffi"\]//' \
+            zenjpeg/Cargo.toml > zenjpeg/Cargo.toml.ci && mv zenjpeg/Cargo.toml.ci zenjpeg/Cargo.toml
+          rm -f Cargo.lock
+
+      - uses: Swatinem/rust-cache@v2
         with:
-          submodules: false
-      - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-diag-${{ hashFiles('**/Cargo.lock') }}
-      - name: Build (default)
-        run: cargo build -p zenjpeg
-      - name: Build (__diagnostics)
-        run: cargo build -p zenjpeg --features __diagnostics
-      - name: Build (__diagnostics + trellis)
-        run: cargo build -p zenjpeg --features __diagnostics,trellis
+          key: diag-${{ matrix.os }}
+
       - name: Test diagnostics module
         run: cargo test -p zenjpeg --features __diagnostics --lib encode::diagnostics
       - name: Test diagnostics smoke matrix
@@ -77,12 +93,43 @@ jobs:
     name: rust tests (i686-linux cross)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: false
+      - uses: actions/checkout@v6
+      - name: Configure git for private repos
+        run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install cross
-        run: cargo install cross --locked --force --version 0.2.5
+      - uses: taiki-e/install-action@cross
+
+      - name: Clone sibling repos
+        shell: bash
+        run: |
+          cd ..
+          git clone --depth 1 https://github.com/imazen/zencodec.git
+          git clone --depth 1 https://github.com/imazen/zenpng.git
+          git clone --depth 1 https://github.com/imazen/zenflate.git
+          git clone --depth 1 https://github.com/imazen/zenanalyze.git
+
+      - name: Strip non-CI workspace members and deps
+        shell: bash
+        run: |
+          sed \
+            -e '/"internal\/jpegli-internals-sys"/d' \
+            -e '/"zjpeg"/d' \
+            Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
+          sed -e '/^zenresize/d' Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
+          sed \
+            -e '/jpegli-internals-sys/d' \
+            -e '/zenresize.*workspace/d' \
+            -e '/zennode.*path/d' \
+            -e 's/^layout = .*/layout = []/' \
+            -e 's/^zennode = .*/zennode = []/' \
+            -e 's/, features = \["cjpegli-ffi"\]//' \
+            zenjpeg/Cargo.toml > zenjpeg/Cargo.toml.ci && mv zenjpeg/Cargo.toml.ci zenjpeg/Cargo.toml
+          rm -f Cargo.lock
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: diag-cross-i686
+
       - name: Test (i686, __diagnostics + trellis)
         run: cross test --target i686-unknown-linux-gnu -p zenjpeg --features __diagnostics,trellis --test diagnostics_smoke
 
@@ -90,26 +137,54 @@ jobs:
     name: wasm + viewer build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: false
+      - uses: actions/checkout@v6
+      - name: Configure git for private repos
+        run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
-      - name: Cache cargo + node
+
+      - name: Clone sibling repos
+        shell: bash
+        run: |
+          cd ..
+          git clone --depth 1 https://github.com/imazen/zencodec.git
+          git clone --depth 1 https://github.com/imazen/zenpng.git
+          git clone --depth 1 https://github.com/imazen/zenflate.git
+          git clone --depth 1 https://github.com/imazen/zenanalyze.git
+
+      - name: Strip non-CI workspace members and deps
+        shell: bash
+        run: |
+          sed \
+            -e '/"internal\/jpegli-internals-sys"/d' \
+            -e '/"zjpeg"/d' \
+            Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
+          sed -e '/^zenresize/d' Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
+          sed \
+            -e '/jpegli-internals-sys/d' \
+            -e '/zenresize.*workspace/d' \
+            -e '/zennode.*path/d' \
+            -e 's/^layout = .*/layout = []/' \
+            -e 's/^zennode = .*/zennode = []/' \
+            -e 's/, features = \["cjpegli-ffi"\]//' \
+            zenjpeg/Cargo.toml > zenjpeg/Cargo.toml.ci && mv zenjpeg/Cargo.toml.ci zenjpeg/Cargo.toml
+          rm -f Cargo.lock
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: diag-wasm
+      - name: Cache web node_modules
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-            zenjpeg-diagnostics-viewer/web/node_modules
-          key: ubuntu-wasm-diag-${{ hashFiles('**/Cargo.lock', 'zenjpeg-diagnostics-viewer/web/package-lock.json') }}
+          path: zenjpeg-diagnostics-viewer/web/node_modules
+          key: diag-web-node-${{ hashFiles('zenjpeg-diagnostics-viewer/web/package-lock.json') }}
+
       - name: Build wasm
         run: |
           cd zenjpeg-diagnostics-viewer/wasm
@@ -175,6 +250,10 @@ jobs:
           <p>Redirecting to <a href="./diagnostics/">zenjpeg encode-diagnostics viewer</a>…</p>
           EOF
       - uses: actions/configure-pages@v5
+        # Pages is already enabled (Settings → Pages → Source:
+        # GitHub Actions). configure-pages just needs to fetch the
+        # site config — no enablement attempt, no Administration
+        # token required.
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -188,17 +267,48 @@ jobs:
     runs-on: ubuntu-latest
     needs: wasm-build
     steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: false
+      - uses: actions/checkout@v6
+      - name: Configure git for private repos
+        run: git config --global url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf "https://github.com/"
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
+
+      - name: Clone sibling repos
+        shell: bash
+        run: |
+          cd ..
+          git clone --depth 1 https://github.com/imazen/zencodec.git
+          git clone --depth 1 https://github.com/imazen/zenpng.git
+          git clone --depth 1 https://github.com/imazen/zenflate.git
+          git clone --depth 1 https://github.com/imazen/zenanalyze.git
+
+      - name: Strip non-CI workspace members and deps
+        shell: bash
+        run: |
+          sed \
+            -e '/"internal\/jpegli-internals-sys"/d' \
+            -e '/"zjpeg"/d' \
+            Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
+          sed -e '/^zenresize/d' Cargo.toml > Cargo.toml.ci && mv Cargo.toml.ci Cargo.toml
+          sed \
+            -e '/jpegli-internals-sys/d' \
+            -e '/zenresize.*workspace/d' \
+            -e '/zennode.*path/d' \
+            -e 's/^layout = .*/layout = []/' \
+            -e 's/^zennode = .*/zennode = []/' \
+            -e 's/, features = \["cjpegli-ffi"\]//' \
+            zenjpeg/Cargo.toml > zenjpeg/Cargo.toml.ci && mv zenjpeg/Cargo.toml.ci zenjpeg/Cargo.toml
+          rm -f Cargo.lock
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: diag-e2e
       - name: Build wasm + web
         run: |
           cd zenjpeg-diagnostics-viewer/wasm

--- a/.github/workflows/diagnostics-ci.yml
+++ b/.github/workflows/diagnostics-ci.yml
@@ -200,7 +200,13 @@ jobs:
       - name: Build viewer
         run: |
           cd zenjpeg-diagnostics-viewer/web
-          npx vite build
+          # `npm run build` runs the `prebuild` hook (fetch-images.ts)
+          # which downloads the picker corpus from R2 and writes a
+          # local manifest + cached blobs into public/images/. Without
+          # this, the deployed viewer hits CORS errors trying to fetch
+          # the R2 origin from GitHub Pages (R2 public buckets do not
+          # send Access-Control-Allow-Origin headers by default).
+          npm run build
       - uses: actions/upload-artifact@v4
         with:
           name: diagnostics-viewer-dist

--- a/.github/workflows/diagnostics-ci.yml
+++ b/.github/workflows/diagnostics-ci.yml
@@ -1,0 +1,225 @@
+name: diagnostics-ci
+
+# UNSTABLE __diagnostics feature + viewer end-to-end gate.
+# Triggers only on the diagnostics bookmark and the matching PR.
+# Does NOT block main; the parent ci.yml is unaffected.
+
+on:
+  push:
+    branches: [diagnostics]
+  pull_request:
+    branches: [main]
+    paths:
+      - "zenjpeg/src/encode/diagnostics.rs"
+      - "zenjpeg/src/encode/strip/**"
+      - "zenjpeg/src/encode/streaming.rs"
+      - "zenjpeg/src/encode/streaming_builder.rs"
+      - "zenjpeg/src/encode/byte_encoders.rs"
+      - "zenjpeg/src/encode/encoder_config.rs"
+      - "zenjpeg/src/lib.rs"
+      - "zenjpeg/Cargo.toml"
+      - "zenjpeg/tests/diagnostics_smoke.rs"
+      - "zenjpeg-diagnostics-viewer/**"
+      - ".github/workflows/diagnostics-ci.yml"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  rust-tests:
+    name: rust tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # Per parent CLAUDE.md: every crate must test on linux-x86_64,
+        # windows-11-arm, macos-15-intel (or 26), and i686 cross.
+        # i686 cross runs in a separate job below.
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: false
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-diag-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build (default)
+        run: cargo build -p zenjpeg
+      - name: Build (__diagnostics)
+        run: cargo build -p zenjpeg --features __diagnostics
+      - name: Build (__diagnostics + trellis)
+        run: cargo build -p zenjpeg --features __diagnostics,trellis
+      - name: Test diagnostics module
+        run: cargo test -p zenjpeg --features __diagnostics --lib encode::diagnostics
+      - name: Test diagnostics smoke matrix
+        run: cargo test -p zenjpeg --features __diagnostics,trellis --test diagnostics_smoke
+      - name: Test wasm bindings (native)
+        run: cargo test -p zenjpeg-diagnostics-wasm
+
+  rust-tests-i686:
+    name: rust tests (i686-linux cross)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: false
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cross
+        run: cargo install cross --locked --force --version 0.2.5
+      - name: Test (i686, __diagnostics + trellis)
+        run: cross test --target i686-unknown-linux-gnu -p zenjpeg --features __diagnostics,trellis --test diagnostics_smoke
+
+  wasm-build:
+    name: wasm + viewer build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: false
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+      - name: Cache cargo + node
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            zenjpeg-diagnostics-viewer/web/node_modules
+          key: ubuntu-wasm-diag-${{ hashFiles('**/Cargo.lock', 'zenjpeg-diagnostics-viewer/web/package-lock.json') }}
+      - name: Build wasm
+        run: |
+          cd zenjpeg-diagnostics-viewer/wasm
+          wasm-pack build --target web --out-dir ../web/wasm-pkg --release
+      - name: Install web deps
+        run: |
+          cd zenjpeg-diagnostics-viewer/web
+          npm ci || npm install
+      - name: Typecheck
+        run: |
+          cd zenjpeg-diagnostics-viewer/web
+          npx tsc --noEmit
+      - name: Build viewer
+        run: |
+          cd zenjpeg-diagnostics-viewer/web
+          npx vite build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: diagnostics-viewer-dist
+          path: zenjpeg-diagnostics-viewer/web/dist
+          retention-days: 7
+
+  deploy-pages:
+    name: deploy viewer to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: wasm-build
+    # Only deploy on pushes to the diagnostics branch — PRs don't get
+    # a deploy. Matches the wasm-build artifact's existence window.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/diagnostics'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      # GitHub Pages serializes deploys per repo. We don't want to
+      # cancel a half-deploy mid-flight (could leave the live site in
+      # a bad state).
+      group: pages
+      cancel-in-progress: false
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: diagnostics-viewer-dist
+          path: dist
+      - name: Stage dist under /diagnostics/ subpath
+        # GitHub Pages serves the artifact at the project root
+        # (imazen.github.io/zenjpeg/). Putting the viewer at
+        # /diagnostics/ keeps the project root free for future docs
+        # (rustdoc, README site, etc.).
+        run: |
+          mkdir -p _site/diagnostics
+          cp -r dist/. _site/diagnostics/
+          # Drop a tiny index at the root so visitors hitting just
+          # /zenjpeg/ get a pointer instead of a 404.
+          cat > _site/index.html <<'EOF'
+          <!DOCTYPE html>
+          <meta charset="utf-8">
+          <title>zenjpeg</title>
+          <meta http-equiv="refresh" content="0; url=./diagnostics/">
+          <p>Redirecting to <a href="./diagnostics/">zenjpeg encode-diagnostics viewer</a>…</p>
+          EOF
+      - uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  e2e:
+    name: playwright e2e
+    runs-on: ubuntu-latest
+    needs: wasm-build
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: false
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+      - name: Build wasm + web
+        run: |
+          cd zenjpeg-diagnostics-viewer/wasm
+          wasm-pack build --target web --out-dir ../web/wasm-pkg --release
+      - name: Install web deps
+        run: |
+          cd zenjpeg-diagnostics-viewer/web
+          npm ci || npm install
+      - name: Install playwright browsers
+        run: |
+          cd zenjpeg-diagnostics-viewer/web
+          npx playwright install --with-deps chromium
+      - name: Run Playwright tests
+        run: |
+          cd zenjpeg-diagnostics-viewer/web
+          npx playwright test --reporter=github
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: |
+            zenjpeg-diagnostics-viewer/web/playwright-report
+            zenjpeg-diagnostics-viewer/web/test-results
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,8 @@ zenjpeg-diagnostics-viewer/web/dist/
 zenjpeg-diagnostics-viewer/web/test-results/
 zenjpeg-diagnostics-viewer/web/playwright-report/
 zenjpeg-diagnostics-viewer/web/wasm-pkg/
+
+# Diagnostics-viewer image picker corpus — fetched at build time from R2
+# via web/scripts/fetch-images.ts. Manifest is regenerated; both files
+# and manifest.json stay out of git.
+zenjpeg-diagnostics-viewer/web/public/images/

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ fuzz-*.log
 # Reproduce via examples/zq_pareto_calibrate.rs; summary committed at
 # benchmarks/zq_pareto_<DATE>.summary.md.
 benchmarks/zq_pareto_*.tsv
+CLAUDE.local.md

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,8 @@ fuzz-*.log
 # benchmarks/zq_pareto_<DATE>.summary.md.
 benchmarks/zq_pareto_*.tsv
 CLAUDE.local.md
+zenjpeg-diagnostics-viewer/web/node_modules/
+zenjpeg-diagnostics-viewer/web/dist/
+zenjpeg-diagnostics-viewer/web/test-results/
+zenjpeg-diagnostics-viewer/web/playwright-report/
+zenjpeg-diagnostics-viewer/web/wasm-pkg/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,6 +2068,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3190,6 +3201,19 @@ dependencies = [
  "rgb",
  "zenjpeg",
  "zune-jpeg",
+]
+
+[[package]]
+name = "zenjpeg-diagnostics-wasm"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "enough",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
+ "zenjpeg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,12 +3209,14 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "enough",
+ "fast-ssim2 0.8.0",
  "js-sys",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
  "wasm-bindgen",
  "zenjpeg",
+ "zensim",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,6 +3209,7 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "enough",
+ "js-sys",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "zenyuv",
     "zjpeg",
     "internal/jpegli-internals-sys",
+    "zenjpeg-diagnostics-viewer/wasm",
 ]
 
 [workspace.package]

--- a/justfile
+++ b/justfile
@@ -212,3 +212,44 @@ test-aarch64:
 test-cross:
     just test-i686
     just test-aarch64
+
+# ─────────────────────────────────────────────────────────────────────
+# zenjpeg-diagnostics-viewer (UNSTABLE __diagnostics surface + viewer)
+# ─────────────────────────────────────────────────────────────────────
+
+# Default chain: rust unit + integration tests, wasm build, e2e suite.
+diagnostics-all: diagnostics-test diagnostics-wasm diagnostics-e2e
+
+# Rust unit + integration tests for the __diagnostics feature.
+diagnostics-test:
+    cargo test -p zenjpeg --features __diagnostics,trellis --test diagnostics_smoke
+    cargo test -p zenjpeg --features __diagnostics --lib encode::diagnostics
+    cargo test -p zenjpeg-diagnostics-wasm
+
+# Build the wasm bindings via wasm-pack for the web demo.
+diagnostics-wasm:
+    cd zenjpeg-diagnostics-viewer/wasm && wasm-pack build --target web --out-dir ../web/wasm-pkg --release
+
+# Build the demo viewer once.
+diagnostics-viewer-build: diagnostics-wasm
+    cd zenjpeg-diagnostics-viewer/web && npm install && npx vite build
+
+# Serve the demo viewer locally (vite preview, port 3173).
+diagnostics-viewer: diagnostics-viewer-build
+    cd zenjpeg-diagnostics-viewer/web && npx vite preview --port 3173 --strictPort
+
+# Run the Playwright E2E suite (headless chromium).
+diagnostics-e2e: diagnostics-viewer-build
+    cd zenjpeg-diagnostics-viewer/web && npx playwright install chromium
+    cd zenjpeg-diagnostics-viewer/web && npx playwright test
+
+# Typecheck the web app without running it.
+diagnostics-typecheck:
+    cd zenjpeg-diagnostics-viewer/web && npm install && npx tsc --noEmit
+
+# Build everything (rust + wasm + viewer) without running tests.
+diagnostics-build:
+    cargo build -p zenjpeg --features __diagnostics,trellis
+    cargo build -p zenjpeg-diagnostics-wasm
+    cd zenjpeg-diagnostics-viewer/wasm && wasm-pack build --target web --out-dir ../web/wasm-pkg --release
+    cd zenjpeg-diagnostics-viewer/web && npm install && npx vite build

--- a/zenjpeg-diagnostics-viewer/CLAUDE.md
+++ b/zenjpeg-diagnostics-viewer/CLAUDE.md
@@ -1,0 +1,114 @@
+# CLAUDE.md — zenjpeg-diagnostics-viewer
+
+Rules for Claude Code / agent sessions working in this directory.
+**Read [README.md](README.md) first** — that's the comprehensive
+handoff. This file is just the rules you must not break.
+
+## Hard rules
+
+### Source-image discipline
+
+- **PNG sources only in the picker corpus.** No JPEG, no WebP, no
+  AVIF. Lossy sources cause generation-loss confusion that defeats
+  the whole tool. JPEG/WebP demos were removed; do not re-add.
+- **All resampling is BUILD-TIME, never browser-side.** The 8×
+  lanczos3 wash lives in `web/scripts/fetch-images.ts` via sharp.
+  Do NOT reach for `canvas.drawImage` with smoothing to "wash"
+  pixels at runtime — browser kernels are
+  implementation-defined and unsuitable for compression research.
+- **Lossy uploads pass through unwashed with a warning.** If the
+  user uploads a JPEG, surface the `⚠ lossy source` status-line
+  warning. Do not silently re-process.
+
+### State / quant-table editor
+
+- **Never put `eqStates.clear()` in the encode path.** It used to
+  be at the top of `runEncode`, which wiped slider state on every
+  encode. The editor only persists state across encodes if the
+  encoder loop leaves it alone. Reset is explicit (per-component
+  "Reset EQ" buttons or the Quant tab's "Reset all components").
+- **Read base quant tables from `baseSnapshot`, never from live
+  diagnostics.** The diagnostics struct returns the *current*
+  table, which after a custom-tables encode reflects user
+  modifications. Reading from there and applying user multipliers
+  on top creates a compounding mistake — Q-scale 0.5 once → halved,
+  Q-scale 0.5 again → quartered. The snapshot pins a stable base
+  captured from no-custom encodes only.
+- **`buildCustomQuantTables` returns null when nothing differs from
+  defaults.** Don't ship `customQuantTables` containing the
+  encoder's own defaults — it forces `ScalingParams::Exact` for no
+  benefit.
+
+### Wasm side
+
+- **`ScalingParams::Exact` when shipping custom quant tables.**
+  Default `Scaled` re-multiplies by `distance_to_scale ×
+  global_scale`. Pass user f32 expecting them to be final, leave
+  scaling on default → exploding values.
+- **`PerComponent` fields are `c0/c1/c2`.** Type aliases
+  (`y_or_x`/etc.) are NOT field names. Compile errors come fast if
+  you forget, but failing tests with confusing values come slow.
+- **`TrellisSpeedMode` has no `Fast` variant.** Variants are
+  `Thorough`, `Adaptive`, `Level(u8)`. Map JS "fast" → `Level(8)`.
+- **`fast-ssim2` and `zensim` MUST disable default features for
+  wasm.** rayon and avx512 don't compile to wasm32. Always
+  `default-features = false`.
+- **Pick `default_xyb` vs `default_ycbcr` based on `colorPath`.**
+
+### Build / CI
+
+- **CI Pages workflow MUST run `npm run build`.** NOT `npx vite
+  build`. The `prebuild` hook bakes images. Without it, the
+  deployed page hits R2 CORS errors.
+- **Two `image-list.json` files, kept in sync.** `web/scripts/` is
+  read by the prebuild script; `web/src/` is bundled into JS. Both
+  matter. If you change one, change the other.
+- **`npm run` always, never bare `vite`.** `predev` and `prebuild`
+  hooks are npm-script lifecycle features. Bypass them and the
+  picker dropdown is empty at runtime.
+- **`wasm-pack build` after wasm changes.** `cargo build` alone
+  doesn't regenerate JS bindings. The `just diagnostics-wasm`
+  target wraps it.
+
+### UI / naming
+
+- **Mode picker visible label is "Adaptive Quantization"; wire
+  value stays `"baseline"`.** Don't rename the value — `mode-baseline`
+  is the Playwright `data-testid` and the wasm fall-through default.
+- **Don't call the curve "Pareto".** It's a single-config q-sweep,
+  not the upper-left envelope. UI labels are "Reference RD" / "Δ
+  vs reference". Until someone implements a multi-config sweep,
+  keep the language honest.
+- **Tab `data-testid` attributes are stable contracts** for
+  `tests/viewer.spec.ts`. Don't rename them when you change visible
+  labels.
+
+## Workflow notes
+
+- `.workongoing` marker file goes at the *workspace root* (where
+  `.jj` lives), not inside this subdir. Refresh it every couple of
+  minutes per the global CLAUDE.md.
+- `jj describe` updates the working-copy commit's message;
+  successive describes don't create new commits, they amend. Use
+  `jj new` if you want a fresh commit on top.
+- Pushing: `jj git push --bookmark diagnostics`. Never push to
+  `main` from here without explicit user direction — this is a
+  feature branch.
+- The diagnostics workspace is colocated with the main zenjpeg jj
+  repo (workspace `diagnostics`). `jj workspace list` shows them
+  all.
+
+## Files you'll edit most often
+
+- `web/src/main.ts` — UI controller. Long but linear.
+- `web/index.html` — DOM. Tabs, controls, modals.
+- `web/src/styles.css` — `@theme` + carve-outs.
+- `wasm/src/lib.rs` — encoder dispatch + score exports.
+- `web/scripts/fetch-images.ts` — build-time fetch + wash.
+
+## Files you should rarely touch without good reason
+
+- `web/wasm-pkg/*` — generated by wasm-pack. Don't hand-edit.
+- `web/public/images/*` — generated by the prebuild hook.
+  Gitignored.
+- `web/src/heatmap.ts`, `web/src/synthetic.ts` — small, stable.

--- a/zenjpeg-diagnostics-viewer/README.md
+++ b/zenjpeg-diagnostics-viewer/README.md
@@ -1,0 +1,534 @@
+# zenjpeg-diagnostics-viewer
+
+Interactive web UI for inspecting zenjpeg encode decisions. Wraps the
+`__diagnostics` capture surface in wasm, drives every encoder dial
+from a tabbed UI, and renders side-by-side source / encoded / delta
+views with per-block AQ heatmaps, per-component quant-table editors,
+and a reference RD curve.
+
+This document is a handoff for a fresh maintainer. Read it before
+touching anything — most of the surprises in this codebase are the
+result of either the JPEG / DCT semantics or the WASM / browser
+boundary, and the gotchas section catalogs every one I hit.
+
+## Repository layout
+
+```
+zenjpeg-diagnostics-viewer/
+├── README.md            ← you are here
+├── CLAUDE.md            ← rules for Claude Code / agent sessions
+├── wasm/
+│   ├── Cargo.toml       ← wasm-bindgen crate; pulls in zenjpeg,
+│   │                      fast-ssim2, zensim
+│   └── src/lib.rs       ← encodeWithDiagnostics + computeSsimulacra2
+│                          + computeZensim exports
+└── web/
+    ├── index.html       ← single-page tabbed UI
+    ├── package.json     ← npm scripts; "prebuild" hook runs the
+    │                      build-time image fetch + wash
+    ├── vite.config.ts   ← Tailwind v4 plugin + worker.format=es
+    ├── tsconfig.json
+    ├── playwright.config.ts
+    ├── scripts/
+    │   ├── fetch-images.ts    ← prebuild: fetches + 8× lanczos3 wash
+    │   └── image-list.json    ← source manifest (mirrors src/)
+    ├── src/
+    │   ├── main.ts            ← UI controller (vanilla TS)
+    │   ├── encode-worker.ts   ← Web Worker that runs wasm encode
+    │   ├── types.ts           ← TS mirror of wasm EncodeOptions
+    │   ├── styles.css         ← @import "tailwindcss" + @theme +
+    │   │                        component carve-outs
+    │   ├── heatmap.ts         ← AQ / utilization heatmap drawer
+    │   ├── synthetic.ts       ← 64×64 default test pattern
+    │   └── image-list.json    ← bundled into JS so the picker is
+    │                            populated even without prebuild
+    ├── wasm-pkg/              ← wasm-pack output (gitignored)
+    └── public/images/         ← prebuild output (gitignored)
+        ├── manifest.json
+        ├── <sha>.png          ← raw blobs (cached for re-wash)
+        └── <sha>-w8.png       ← 8× lanczos3 washed PNGs (served)
+
+tests/
+└── viewer.spec.ts             ← Playwright e2e
+```
+
+## Architecture
+
+### Top-down data flow
+
+```
+                ┌─────────────────────────────────────────────┐
+                │ user clicks / sliders / file upload         │
+                └─────────────────┬───────────────────────────┘
+                                  │
+            scheduleAutoEncode() ─┤  (250 ms debounce)
+                                  ▼
+                       ┌──────────────────┐
+                       │ runEncode(reqId) │
+                       │  bumps latestReq │
+                       └────────┬─────────┘
+                                │  postMessage(EncodeReq)
+                                ▼
+                       ┌─────────────────────────────────┐
+                       │ Web Worker (encode-worker.ts)   │
+                       │  encodeWithDiagnostics(...)     │
+                       │  → EncodeResult { bytes, diag } │
+                       └────────┬────────────────────────┘
+                                │  postMessage (transferable)
+                                ▼
+                       ┌─────────────────────────────────┐
+                       │ main thread:                    │
+                       │  if (reqId !== latestReqId)     │
+                       │      drop                       │
+                       │  else:                          │
+                       │      decode JPEG → ImageData    │
+                       │      ssim2(), zensim()          │
+                       │      render triptych +          │
+                       │        AQ heatmap + per-comp    │
+                       │        editors + readout        │
+                       │      schedule next pareto step  │
+                       └─────────────────────────────────┘
+```
+
+### Wasm surface (`wasm/src/lib.rs`)
+
+Exports:
+
+- `encodeWithDiagnostics(pixels, w, h, options)` — RGB packed bytes
+  in, returns `{ bytes: Uint8Array, diagnostics: Diagnostics }`.
+  `options` is the `EncodeOptions` struct mirrored on both sides.
+- `computeSsimulacra2(srcRgb, dstRgb, w, h)` — f64 SSIMULACRA 2 via
+  `fast-ssim2 0.8.0` (default-features off — no rayon, no imgref).
+- `computeZensim(srcRgb, dstRgb, w, h)` — f64 zensim score via
+  `zensim 0.2.7` (default-features off — no rayon, no avx512).
+
+`EncodeOptions` exposes every dial on `EncoderConfig` plus
+`CustomQuantTables` (full f32 quant + zero_bias_mul + per-component
+zero_bias_offset_dc/ac). When custom tables are present, the wasm
+flips `EncodingTables.scaling = ScalingParams::Exact` so the user's
+f32 numbers are used directly as final quant values (instead of
+re-multiplying by `distance_to_scale × global_scale`).
+
+### Web Worker (`web/src/encode-worker.ts`)
+
+The wasm module is initialized inside a Worker so the main thread
+stays responsive during slider drags. Each encode carries a unique
+`reqId`; the main thread compares against `latestReqId` and drops
+results from superseded requests. That's our cancellation model — see
+the gotchas section for why we don't do mid-encode preemption.
+
+The worker postMessages results back with the JPEG bytes as a
+`Transferable`, so the buffer is moved (not copied) across the
+boundary.
+
+### Main thread (`web/src/main.ts`)
+
+Single-file vanilla TS state machine. Persistent state:
+
+- `currentImage`: source RGBA + dims + key
+- `currentDiagnostics`: most-recent encoder diagnostics
+- `lastEncode`: bytes / ssim2 / zensim / time / mode (for the
+  big-typography readout panel)
+- `eqStates`: per-component `{ hEq[8], vEq[8], cellOverrides: Map }`.
+  Persists across encodes — only cleared by the per-component "Reset
+  EQ" button or the Quant tab's "Reset all components" / "Reset
+  zero-bias to defaults".
+- `baseSnapshot`: the encoder's *source-derived* f32 quant tables,
+  captured from the diagnostics struct ONLY on encodes that ran
+  *without* customQuantTables. All user EQ / cell-override edits are
+  multipliers on this pinned base. See "Q-scale compounding" gotcha.
+- `zeroBias`: `globalMul[3]`, `offsetDc[3]`, `offsetAc[3]`. Sent in
+  CustomQuantTables when any deviates from defaults.
+- `paretoCache` / `paretoQueues`: per-image reference RD data.
+  Computed progressively (one q at a time) interleaved with user
+  encodes.
+- `zoomImageData`: cached source / encoded / delta ImageData for the
+  zoom inspector modal.
+
+## Build & run
+
+### Prereqs
+
+- Rust 1.93+ (2024 edition)
+- `wasm-pack` (cargo install wasm-pack)
+- Node 18+ (for built-in fetch in scripts/)
+- npm install in `web/` will pull in sharp's native binding
+
+### Local dev
+
+```bash
+# from repo root
+cd zenjpeg-diagnostics-viewer
+
+# 1. Build the wasm bindings
+just diagnostics-wasm
+# or:
+cd wasm && wasm-pack build --target web --out-dir ../web/wasm-pkg --release
+
+# 2. Install web deps + run dev server
+cd ../web
+npm install
+npm run dev          # ← runs `predev` → fetch-images.ts → vite
+```
+
+`npm run dev` opens at <http://localhost:3173> (port-locked so the
+demo URL is stable). The `predev` hook downloads the picker corpus
+from R2 and writes the manifest. Set `DIAGNOSTICS_VIEWER_OFFLINE=1`
+to skip the network and reuse what's already cached.
+
+### Production build
+
+```bash
+cd web
+npm run build        # ← runs `prebuild` → fetch-images.ts → vite build
+```
+
+Output lands in `web/dist/`. Serve with any static-file server.
+
+### CI / GitHub Pages
+
+The Pages workflow lives in `.github/workflows/diagnostics-ci.yml`.
+**It MUST call `npm run build`, not `npx vite build` directly** — the
+former runs the `prebuild` hook that bakes images, the latter does
+not. Without baked images, the deployed page falls back to direct R2
+fetches which hit CORS errors (R2 public buckets don't send
+Access-Control-Allow-Origin by default).
+
+## Gotchas catalog
+
+This is the core of the handoff. Each item is a real bug I hit;
+read them before touching the relevant area.
+
+### Build / CI
+
+1. **Pages CI must run `npm run build`, not `npx vite build`.** The
+   `prebuild` hook (`npm run fetch-images`) bakes images into
+   `dist/images/` so the deployed page serves them same-origin.
+   Bypassing the hook leaves the picker entries with only their
+   absolute R2 URLs, which fail CORS. The fix is in the workflow,
+   not in code.
+
+2. **R2 public buckets don't send CORS headers.** If you point
+   `DIAGNOSTICS_VIEWER_IMAGE_BASE` at an R2 bucket and expect the
+   browser to fetch directly, configure CORS on the bucket
+   (Cloudflare dashboard → R2 → bucket → Settings → CORS Policy):
+   ```json
+   [{"AllowedOrigins":["*"],"AllowedMethods":["GET","HEAD"],
+     "AllowedHeaders":["*"],"MaxAgeSeconds":86400}]
+   ```
+   Or just rely on the prebuild bake (recommended for static deploys).
+
+3. **wasm-pack vs cargo build.** `cargo build --target
+   wasm32-unknown-unknown -p zenjpeg-diagnostics-wasm` compiles the
+   crate but doesn't regenerate the JS bindings. To pick up wasm
+   surface changes in the web app, you must run `wasm-pack build`.
+   The `just diagnostics-wasm` target does this.
+
+4. **Two `image-list.json` files, kept in sync.**
+   - `web/scripts/image-list.json` — read by `fetch-images.ts` at
+     prebuild time.
+   - `web/src/image-list.json` — bundled into the JS so the picker
+     dropdown is populated even when the prebuild hasn't run.
+   When you add/edit an entry, update both.
+
+5. **Sharp is a devDep.** It's only used by `fetch-images.ts` at
+   build time. Doesn't ship to users. Native bindings come down
+   automatically via `npm install`. If install fails (musl libc,
+   etc.) sharp's docs cover the platform fallbacks.
+
+### Source-image discipline
+
+6. **PNGs only in the picker corpus.** The codec-corpus's
+   `corpus/png-24-32` label doesn't track provenance — any of these
+   PNGs may have been a JPEG → PNG conversion. Encoding them
+   directly produces "encoder + prior-codec artifacts" output that
+   the user can't disentangle from "encoder alone".
+
+7. **8× lanczos3 wash at build time, not runtime.** The wash lives
+   in `scripts/fetch-images.ts` via sharp:
+   ```ts
+   await sharp(rawPath)
+     .resize(w, h, { kernel: "lanczos3" })
+     .png({ compressionLevel: 9, palette: false })
+     .toFile(outPath);
+   ```
+   8× decimation eliminates the original 8×8 DCT block grid. Lanczos3
+   is sharper than Mitchell but with controlled overshoot — the
+   right kernel when the goal is full block elimination.
+
+8. **No browser-side resampling, anywhere.** `decodeImageToCanvas`
+   reads pixels at native dimensions with `imageSmoothingEnabled =
+   false`. Browser smoothing kernels are implementation-defined; we
+   want known-good behavior for compression research.
+
+9. **Lossy file uploads pass through unwashed.** If the user
+   uploads a JPEG / WebP / AVIF, we surface a `⚠ lossy source —
+   pre-process for clean diagnostics` warning in the status line and
+   use the file as-is. User responsibility — we don't silently
+   re-process with a wrong-kernel browser smoothing.
+
+10. **The wash output is named `<sha>-w8.png`.** Raw blobs cached
+    side-by-side as `<sha>.<ext>`. The runtime manifest's `url`
+    field points at the wash output. Keeping the raw lets you re-wash
+    with a different kernel without re-downloading.
+
+### Encoder-side wasm surface
+
+11. **`PerComponent` fields are `c0/c1/c2`.** NOT `y_or_x /
+    cb_or_y / cr_or_b` — those are type aliases that don't exist as
+    field names. I lost an hour to this.
+
+12. **`TrellisSpeedMode` variants are `Thorough`, `Adaptive`,
+    `Level(u8)`.** There is no `Fast` variant. Map JS "fast" string
+    to `Level(8)` (the highest speed level).
+
+13. **`ScalingParams::Exact` when `customQuantTables` is set.** The
+    default `ScalingParams::Scaled { global_scale, frequency_exponents
+    }` re-multiplies the table by `distance_to_scale × global_scale`
+    at encode time. Pass user f32 tables expecting them to be final
+    values, leave scaling on default → exploding values.
+
+14. **Encoder mode value `"baseline"` is the fall-through default.**
+    Wasm matches `"hybrid"` and `"trellis"` explicitly; anything else
+    (including unknown values) is treated as `"baseline"` (no trellis,
+    no hybrid). The JS UI label says "Adaptive Quantization" but the
+    wire value stayed as `"baseline"` — see naming gotcha below.
+
+15. **`default_xyb` vs `default_ycbcr`.** Pick the right
+    `EncodingTables::default_*()` based on `colorPath`. Using
+    `default_ycbcr` for an XYB encode produces nonsense.
+
+16. **`fast-ssim2 0.8.0` and `zensim 0.2.7` MUST disable default
+    features for wasm.** rayon (threads) and avx512 don't compile
+    to `wasm32-unknown-unknown`. Use:
+    ```toml
+    fast-ssim2 = { version = "0.8.0", default-features = false }
+    zensim = { version = "0.2.7", default-features = false }
+    ```
+
+17. **`wasm-bindgen` 0.2.x cell behavior.** Returning structs via
+    serde-wasm-bindgen serializes `Vec<u8>` as a JS Array<number>,
+    not a `Uint8Array`. We hand-pack the encode result via
+    `js_sys::Uint8Array::new_with_length(...).copy_from(...)`.
+
+### JS / state model
+
+18. **Quant table compounding.** This is the trickiest one. The
+    diagnostics struct returns `quant_table_base` as the *current*
+    table — which after a custom-tables encode reflects the
+    user-customized values. If you read base from live diagnostics
+    and apply user multipliers on top, every edit compounds against
+    the previous one. Q-scale 0.5 once → halved; Q-scale 0.5 again
+    on a different control change → quartered; etc.
+
+    Fix: cache `baseSnapshot` from the diagnostics struct ONLY on
+    encodes that ran *without* customQuantTables. User multipliers
+    apply to the pinned snapshot. Snapshot invalidates on
+    `quality / colorPath / subsampling / xybSubsampling` changes.
+
+    To pick up the new defaults after an axis change *while you have
+    EQ edits in place*, hit "Reset all components" — that clears EQ,
+    so the next encode runs without custom tables, refreshing the
+    snapshot.
+
+19. **`eqStates.clear()` is forbidden in the encode path.** Used to
+    be at the top of `runEncode`, which wiped slider state on every
+    encode and made the editor useless. The bug is gone; if you
+    re-introduce something like it, the editor breaks immediately.
+
+20. **`baseSnapshot` is "trust the most recent no-custom encode".**
+    The snapshot picks up new defaults whenever the user runs an
+    encode without custom tables. Reset EQ + bump quality + run
+    encode = snapshot updated for the new quality.
+
+21. **`buildCustomQuantTables` returns `null` when nothing differs
+    from defaults.** Don't send a customQuantTables payload that
+    contains the encoder's own defaults — it forces
+    `ScalingParams::Exact` which disables quality-based scaling for
+    no benefit. Only send when the user has actually edited.
+
+22. **`reqId` cancellation, not preemption.** True mid-encode
+    preemption requires `SharedArrayBuffer` + COOP/COEP headers (so
+    we can flip an atomic flag visible to the worker's wasm). We
+    don't ship those. Each encode has a `reqId`; main thread tracks
+    `latestReqId`; results from superseded requests are dropped.
+    The "Cancel" button just bumps `latestReqId` and hides the
+    overlay — the worker keeps running but its output is discarded.
+
+23. **Worker queue is FIFO.** Pareto sweep submits one encode at a
+    time, kicked from `runEncode`'s `finally` hook, so user encodes
+    naturally interleave. If you ever try to fire all 100 pareto
+    encodes upfront, user-driven encodes will queue behind them and
+    feel frozen.
+
+24. **JSON imports require `resolveJsonModule: true` in tsconfig.**
+    Already set. `import bundledImageList from "./image-list.json"`
+    is a Vite/TS feature.
+
+25. **Worker module format.** `vite.config.ts` has
+    `worker: { format: "es" }`. Without it, the worker won't be a
+    proper ES module and the wasm-pack output won't import
+    correctly.
+
+26. **Vite's `predev` and `prebuild` are npm-script lifecycle
+    hooks.** Just running `vite` directly bypasses them. Same goes
+    for `vite build` vs `npm run build`. Always use `npm run`.
+
+27. **Manifest path is relative.** `./images/manifest.json` (and
+    every entry's `url`). With Vite's `base: "./"`, this resolves
+    correctly at any deploy subpath: localhost:3173/, GitHub Pages
+    at `/zenjpeg/diagnostics/`, Cloudflare Pages, custom CDNs.
+
+### UI / naming
+
+28. **Mode picker label `Adaptive Quantization`, value `baseline`.**
+    The JPEG term "baseline" specifically means baseline-scan vs
+    progressive-scan, which is now a separate checkbox. To
+    disambiguate, the picker shows "Adaptive Quantization" but the
+    wire value is still `"baseline"` (kept for back-compat with
+    Playwright's `data-testid="mode-baseline"`).
+
+29. **"Pareto" is a misnomer.** What we draw is a single-config
+    q-sweep at fixed `(4:2:0, AQ on, default tables)`. A real Pareto
+    envelope would also vary subsampling, mode, and other knobs to
+    find the upper-left frontier. UI labels were renamed to
+    "Reference RD" — keep them that way unless you actually
+    implement the multi-config sweep.
+
+30. **AQ display in XYB.** AQ multiplier is computed from the Y-XYB
+    channel (component[1]) but written to component[0] (X). The
+    heatmap reads from c0 and shows X-block multipliers driven by
+    Y-XYB analysis. The stats row labels the channel as "X (driven
+    by Y-XYB)" so the meaning is explicit.
+
+31. **Sharp YUV grey-out depends on subsampling.** Sharp YUV is
+    only meaningful for YCbCr non-4:4:4. The grey-out is wired in
+    `applyIgnoredAnnotations()` and fired from both the colorPath
+    AND the subsampling change handlers. If you forget to fire it
+    on subsampling change, Sharp YUV stays at its boot state.
+
+32. **Tab panels use `data-testid` attributes.** Playwright tests
+    in `tests/viewer.spec.ts` rely on these. Don't rename a testid
+    without updating the spec — even if the visible label changes.
+
+33. **The `body[data-encoding="true"]` flag.** Set in
+    `setEncodingIndicator(true)` during in-flight encode; CSS uses
+    it to dim the encoded/delta canvases. Cleared in the encode
+    `finally` block (only when `inflightReqId === reqId` — i.e. only
+    when WE are the latest request).
+
+34. **Zoom inspector ImageData cache.** The modal redraws from
+    `zoomImageData` (cached in `runEncode`), not by re-extracting
+    from the on-screen canvases. While the modal is open, every
+    successful encode re-populates the cache and triggers
+    `drawZoomFrame()`, so live slider drags update the zoomed view.
+
+### Misc
+
+35. **Encoder progressive default is ON.** The HTML defaults
+    `#progressive` to `checked`; `currentOptions()` reads it and
+    sends `progressive: true`. Matches modern jpegli defaults
+    (smaller files at high q with negligible cost). Wasm-side
+    `EncodeOptions::default()` still defaults to `false` for safety
+    — the JS HTML-default wins when the page is open.
+
+36. **`__diagnostics` feature must be enabled on zenjpeg.** Already
+    set in `wasm/Cargo.toml`. If you fork or copy the crate, this
+    is the surface that produces the `Diagnostics` struct returned
+    via `finish_with_diagnostics()`.
+
+37. **Raw blobs vs washed PNGs both cached.** `public/images/`
+    holds both `<sha>.<ext>` (the raw) and `<sha>-w8.png` (the
+    wash). The runtime only reads the wash. The raw is kept so
+    re-running fetch-images.ts with a different kernel doesn't
+    require re-downloading.
+
+## Test surface
+
+```bash
+# Unit + integration (in zenjpeg crate)
+just diagnostics-test
+
+# E2E (runs the wasm + the dev server through Playwright)
+just diagnostics-e2e
+
+# Full chain
+just diagnostics-all
+```
+
+`tests/viewer.spec.ts` covers the synthetic 64×64 boot encode, AQ
+heatmap rendering, EQ slider drag → utilization repaint, color path
+toggle, subsampling → block-grid dimensions, quality slider →
+encoded-byte monotonicity, Reset EQ.
+
+## Open work / ideas
+
+These are TODO items I considered but didn't ship. Pick up if
+useful:
+
+1. **True multi-config Pareto.** Sweep `{4:4:4, 4:2:0} × {AQ,
+   trellis} × q=1..100` (~400 encodes per image), keep the
+   upper-left envelope. Justifies the "Pareto" name. Cost is real;
+   would interleave the same way the current single-config sweep
+   does. Rename UI labels back to "Pareto" when this lands.
+
+2. **True mid-encode cancellation.** Add SharedArrayBuffer-backed
+   atomic flag, expose to the wasm encoder via a custom `Stop`
+   impl, deploy with COOP/COEP headers. Then "Cancel" actually
+   stops the worker.
+
+3. **Per-component f32 base table from diagnostics.** The
+   diagnostics struct currently exposes `quant_table_base: [u16;
+   64]` (the JPEG DQT-format integer values). The encoder
+   internally uses f32 (`EncodingTables.quant: PerComponent<[f32;
+   64]>`). Surfacing the f32 base via the diagnostics API would let
+   the viewer show full f32 precision in the cells without the
+   round-trip through u16.
+
+4. **`zero_bias_mul` per-cell editing.** Currently we expose a
+   global multiplier per component (1 number ×3) plus DC/AC
+   offsets. The wasm CustomQuantTables already supports per-cell
+   `zero_bias_mul: Vec<f32>` (length 64). UI could surface this as
+   another 8×8 grid editor.
+
+5. **Curve editor for `frequency_exponents`.** The
+   `ScalingParams::Scaled.frequency_exponents` array is one of the
+   harder-to-tune knobs in the encoder. A curve editor that drove
+   it directly (rather than via the current EQ × cell-overrides
+   approach) might be useful for research.
+
+6. **Component selector in the Quant tab.** When XYB is active, the
+   labels say "Y/X" / "Cb/Y-XYB" / "Cr/B" but the user might want
+   to focus on one component at a time. Could collapse/expand per
+   component.
+
+7. **Image upload wash via wasm.** We have zenresize compiled to
+   wasm in some sibling projects. Could add a "wash this upload"
+   button that calls a wasm export. Not done because file uploads
+   are user-driven and the warning is enough.
+
+## Asking around
+
+- **R2 codec-corpus**: `https://pub-7c5c57fd3e0842f0b147946928891d40.r2.dev`,
+  blobs at `/blobs/<sha[0:2]>/<sha[2:4]>/<sha>`, manifest at
+  `/manifest.jsonl`.
+- **zenjpeg encoder**: `../zenjpeg/`. The `__diagnostics` feature
+  produces the `Diagnostics` struct; see `zenjpeg/src/encode/
+  diagnostics.rs` for the shape.
+- **fast-ssim2** (SSIMULACRA 2): `~/work/zen/fast-ssim2/`.
+- **zensim** (our perceptual metric): `~/work/zen/zensim/`.
+
+## Style
+
+- Vanilla TS, no JS framework. State lives in module-level mutable
+  refs. The flow is small enough that a framework would be
+  ceremony.
+- Tailwind v4 via `@tailwindcss/vite`. `styles.css` is a single
+  `@import "tailwindcss"` + `@theme` block + a handful of
+  component-specific carve-outs (quant grid, EQ sliders, metric
+  readouts, encoding overlay, zoom inspector). Tailwind utility
+  classes everywhere else in the HTML.
+- One-line file headers explaining what the file is. No
+  paragraph-long docstrings.
+- No emoji in source. The "✓" and "—" in the UI are typographic
+  marks, not emoji.

--- a/zenjpeg-diagnostics-viewer/wasm/Cargo.toml
+++ b/zenjpeg-diagnostics-viewer/wasm/Cargo.toml
@@ -10,8 +10,9 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-zenjpeg = { path = "../../zenjpeg", features = ["__diagnostics", "decoder", "trellis"] }
+zenjpeg = { path = "../../zenjpeg", default-features = false, features = ["__diagnostics", "trellis"] }
 wasm-bindgen = "0.2"
+js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 serde_json = "1.0"

--- a/zenjpeg-diagnostics-viewer/wasm/Cargo.toml
+++ b/zenjpeg-diagnostics-viewer/wasm/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "zenjpeg-diagnostics-wasm"
+version = "0.1.0"
+edition = "2024"
+license = "AGPL-3.0-only OR LicenseRef-Imazen-Commercial"
+description = "WASM bindings for the unstable zenjpeg encode-diagnostics demo viewer."
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+zenjpeg = { path = "../../zenjpeg", features = ["__diagnostics", "decoder", "trellis"] }
+wasm-bindgen = "0.2"
+serde = { version = "1.0", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+serde_json = "1.0"
+enough = { version = "0.4", features = ["std"] }
+console_error_panic_hook = { version = "0.1", optional = true }
+
+[features]
+default = ["console_error_panic_hook"]

--- a/zenjpeg-diagnostics-viewer/wasm/Cargo.toml
+++ b/zenjpeg-diagnostics-viewer/wasm/Cargo.toml
@@ -11,6 +11,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 zenjpeg = { path = "../../zenjpeg", default-features = false, features = ["__diagnostics", "trellis"] }
+fast-ssim2 = { version = "0.8.0", default-features = false }
+zensim = { version = "0.2.7", default-features = false }
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/zenjpeg-diagnostics-viewer/wasm/src/lib.rs
+++ b/zenjpeg-diagnostics-viewer/wasm/src/lib.rs
@@ -1,0 +1,336 @@
+//! WASM bindings for zenjpeg's UNSTABLE `__diagnostics` capture.
+//!
+//! Exposes a single `encode_with_diagnostics(rgba_bytes, width, height,
+//! options)` entry that runs the encoder and returns both the JPEG byte
+//! payload and a serializable per-block diagnostics record. Used by the
+//! demo viewer in `../web/`.
+//!
+//! ## Output shape (TypeScript-friendly)
+//!
+//! The returned object has:
+//! - `bytes: Uint8Array` — the encoded JPEG bytes
+//! - `diagnostics: Diagnostics` — JSON-friendly diagnostics record
+//!
+//! See `Diagnostics` below for the full shape; field names match the
+//! Rust struct exactly so a TS consumer can re-derive types from the
+//! JSON Schema if needed.
+
+#![allow(clippy::missing_safety_doc)]
+
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use zenjpeg::encode::diagnostics as diag_src;
+use zenjpeg::encoder::{ChromaSubsampling, EncoderConfig, PixelLayout, XybSubsampling};
+
+/// Per-block diagnostic record, JS-friendly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockDiagnostics {
+    /// Forward-DCT coefficients in natural row-major order
+    /// (index `i = row*8 + col`). Length 64.
+    pub coef_pre_quant: Vec<f32>,
+    /// Quantized levels in JPEG zigzag order. Length 64.
+    pub coef_levels: Vec<i16>,
+    /// Per-block AQ multiplier (1.0 = neutral, <1.0 = finer, >1.0 = coarser).
+    pub aq_multiplier: f32,
+    /// Entropy bits attributed to this block (0 if not yet captured).
+    pub entropy_bits: u32,
+}
+
+/// Per-component diagnostic record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentDiagnostics {
+    /// JFIF component identifier (1=Y/X, 2=Cb/Y-XYB, 3=Cr/B-XYB).
+    pub component_id: u8,
+    /// (cols, rows) in 8x8 blocks.
+    pub block_grid: (u32, u32),
+    /// Base quantization table (natural row-major). Length 64.
+    pub quant_table_base: Vec<u16>,
+    /// Zero-bias offset table (natural row-major). Length 64.
+    pub zero_bias: Vec<f32>,
+    /// Per-block records, raster order
+    /// (index `r * cols + c` for `(r, c)` in the block grid).
+    pub blocks: Vec<BlockDiagnostics>,
+}
+
+/// Top-level diagnostic record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Diagnostics {
+    pub width: u32,
+    pub height: u32,
+    pub color_path: String,
+    pub sampling_factors: Vec<(u8, u8)>,
+    pub components: Vec<ComponentDiagnostics>,
+}
+
+fn to_js_diagnostics(src: diag_src::EncodeDiagnostics) -> Diagnostics {
+    Diagnostics {
+        width: src.image.width,
+        height: src.image.height,
+        color_path: match src.image.color_path {
+            diag_src::ColorPathTag::YCbCr => "YCbCr".into(),
+            diag_src::ColorPathTag::Xyb => "XYB".into(),
+            diag_src::ColorPathTag::Grayscale => "Grayscale".into(),
+        },
+        sampling_factors: src.image.sampling_factors,
+        components: src
+            .components
+            .into_iter()
+            .map(|c| ComponentDiagnostics {
+                component_id: c.component_id,
+                block_grid: c.block_grid,
+                quant_table_base: c.quant_table_base.to_vec(),
+                zero_bias: c.zero_bias.to_vec(),
+                blocks: c
+                    .blocks
+                    .into_iter()
+                    .map(|b| BlockDiagnostics {
+                        coef_pre_quant: b.coef_pre_quant.to_vec(),
+                        coef_levels: b.coef_levels.to_vec(),
+                        aq_multiplier: b.aq_multiplier,
+                        entropy_bits: b.entropy_bits,
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }
+}
+
+/// Options controlling the encode. Mirrors the most useful knobs from
+/// `EncoderConfig`. Field names use camelCase for TS-natural input.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct EncodeOptions {
+    /// jpegli quality (0-100). Default 85.
+    #[serde(default = "default_quality")]
+    pub quality: f32,
+    /// "ycbcr" or "xyb". Default "ycbcr".
+    #[serde(default = "default_color_path")]
+    pub color_path: String,
+    /// "none" (4:4:4), "halfHorizontal" (4:2:2), "quarter" (4:2:0),
+    /// "halfVertical" (4:4:0). Used when colorPath = "ycbcr".
+    /// Default "none".
+    #[serde(default = "default_subsampling")]
+    pub subsampling: String,
+    /// "full" or "bQuarter". Used when colorPath = "xyb". Default "full".
+    #[serde(default = "default_xyb_subsampling")]
+    pub xyb_subsampling: String,
+    /// Adaptive quantization on/off. Default true.
+    #[serde(default = "default_true")]
+    pub aq_enabled: bool,
+    /// Standalone trellis quantization on/off. Default false.
+    #[serde(default)]
+    pub trellis: bool,
+    /// Auto-optimize (hybrid AQ+trellis) on/off. Default false.
+    #[serde(default)]
+    pub auto_optimize: bool,
+    /// Deringing on/off. Default true.
+    #[serde(default = "default_true")]
+    pub deringing: bool,
+}
+
+fn default_quality() -> f32 {
+    85.0
+}
+fn default_color_path() -> String {
+    "ycbcr".into()
+}
+fn default_subsampling() -> String {
+    "none".into()
+}
+fn default_xyb_subsampling() -> String {
+    "full".into()
+}
+fn default_true() -> bool {
+    true
+}
+
+/// Output of `encodeWithDiagnostics`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EncodeResult {
+    /// JPEG bytes.
+    pub bytes: Vec<u8>,
+    /// Per-block diagnostics.
+    pub diagnostics: Diagnostics,
+}
+
+#[wasm_bindgen(start)]
+pub fn init() {
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}
+
+/// Encode an RGB or RGBA pixel buffer and return the resulting JPEG
+/// bytes plus a per-block diagnostics record.
+///
+/// `pixels` must be packed `[r, g, b]` triples (length = `width *
+/// height * 3`) — RGBA input should be flattened by the caller before
+/// passing in.
+///
+/// `options` is a JS object matching `EncodeOptions` (all fields
+/// optional; defaults documented inline). Pass `null` / `undefined`
+/// for defaults.
+#[wasm_bindgen(js_name = encodeWithDiagnostics)]
+pub fn encode_with_diagnostics(
+    pixels: &[u8],
+    width: u32,
+    height: u32,
+    options: JsValue,
+) -> Result<JsValue, JsValue> {
+    let opts: EncodeOptions = if options.is_null() || options.is_undefined() {
+        EncodeOptions {
+            quality: default_quality(),
+            color_path: default_color_path(),
+            subsampling: default_subsampling(),
+            xyb_subsampling: default_xyb_subsampling(),
+            aq_enabled: true,
+            trellis: false,
+            auto_optimize: false,
+            deringing: true,
+        }
+    } else {
+        serde_wasm_bindgen::from_value(options)
+            .map_err(|e| JsValue::from_str(&format!("invalid options: {e}")))?
+    };
+
+    let expected = (width as usize) * (height as usize) * 3;
+    if pixels.len() != expected {
+        return Err(JsValue::from_str(&format!(
+            "pixels length mismatch: expected {expected} ({width}*{height}*3), \
+             got {}",
+            pixels.len()
+        )));
+    }
+
+    let config = match opts.color_path.as_str() {
+        "ycbcr" => {
+            let sub = match opts.subsampling.as_str() {
+                "none" | "s444" | "4:4:4" => ChromaSubsampling::None,
+                "halfHorizontal" | "s422" | "4:2:2" => ChromaSubsampling::HalfHorizontal,
+                "quarter" | "s420" | "4:2:0" => ChromaSubsampling::Quarter,
+                "halfVertical" | "s440" | "4:4:0" => ChromaSubsampling::HalfVertical,
+                other => {
+                    return Err(JsValue::from_str(&format!(
+                        "unknown subsampling: {other}"
+                    )));
+                }
+            };
+            EncoderConfig::ycbcr(opts.quality, sub)
+        }
+        "xyb" => {
+            let xyb_sub = match opts.xyb_subsampling.as_str() {
+                "full" => XybSubsampling::Full,
+                "bQuarter" | "b_quarter" => XybSubsampling::BQuarter,
+                other => {
+                    return Err(JsValue::from_str(&format!(
+                        "unknown xyb subsampling: {other}"
+                    )));
+                }
+            };
+            EncoderConfig::xyb(opts.quality, xyb_sub)
+        }
+        other => {
+            return Err(JsValue::from_str(&format!(
+                "unknown color path: {other}"
+            )));
+        }
+    };
+
+    let mut config = config
+        .aq_enabled(opts.aq_enabled)
+        .deringing(opts.deringing)
+        .with_diagnostics(true);
+
+    #[cfg(feature = "trellis")]
+    {
+        if opts.auto_optimize {
+            config = config.auto_optimize(true);
+        } else if opts.trellis {
+            use zenjpeg::encode::trellis::TrellisConfig;
+            config = config.trellis(TrellisConfig::new());
+        }
+    }
+    // Suppress unused-warning when trellis isn't enabled.
+    let _ = (opts.trellis, opts.auto_optimize);
+
+    let request = config.request();
+    let mut encoder = request
+        .encode_from_bytes(width, height, PixelLayout::Rgb8Srgb)
+        .map_err(|e| JsValue::from_str(&format!("encoder build: {e}")))?;
+    encoder
+        .push_packed(pixels, enough::Unstoppable)
+        .map_err(|e| JsValue::from_str(&format!("push pixels: {e}")))?;
+    let (bytes, diag) = encoder
+        .finish_with_diagnostics()
+        .map_err(|e| JsValue::from_str(&format!("finish: {e}")))?;
+
+    let diag = diag.ok_or_else(|| {
+        JsValue::from_str("with_diagnostics(true) was set but encoder returned None")
+    })?;
+
+    let result = EncodeResult {
+        bytes,
+        diagnostics: to_js_diagnostics(diag),
+    };
+    serde_wasm_bindgen::to_value(&result)
+        .map_err(|e| JsValue::from_str(&format!("serialize result: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synthetic(w: u32, h: u32) -> Vec<u8> {
+        let mut buf = Vec::with_capacity((w * h * 3) as usize);
+        for y in 0..h {
+            for x in 0..w {
+                let fx = x as f32;
+                let fy = y as f32;
+                let r = (128.0 + 64.0 * (fx * 0.3).sin()).clamp(0.0, 255.0) as u8;
+                let g = (128.0 + 64.0 * (fy * 0.25).cos()).clamp(0.0, 255.0) as u8;
+                let b = (128.0 + 64.0 * ((fx + fy) * 0.15).sin()).clamp(0.0, 255.0) as u8;
+                buf.extend_from_slice(&[r, g, b]);
+            }
+        }
+        buf
+    }
+
+    /// Native side test: ensures the conversion path produces the same
+    /// shape as the Rust diagnostics. Doesn't go through wasm-bindgen
+    /// (that's covered by the web/Playwright suite).
+    #[test]
+    fn to_js_diagnostics_preserves_shape() {
+        let w = 32u32;
+        let h = 32u32;
+        let pixels = synthetic(w, h);
+        let config = EncoderConfig::ycbcr(85, ChromaSubsampling::Quarter)
+            .aq_enabled(true)
+            .with_diagnostics(true);
+        let mut enc = config
+            .request()
+            .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+            .expect("encoder");
+        enc.push_packed(&pixels, enough::Unstoppable).expect("push");
+        let (_bytes, diag) = enc.finish_with_diagnostics().expect("finish");
+        let diag = diag.expect("diag");
+        let js = to_js_diagnostics(diag);
+        assert_eq!(js.width, w);
+        assert_eq!(js.height, h);
+        assert_eq!(js.color_path, "YCbCr");
+        assert_eq!(js.components.len(), 3);
+        assert_eq!(js.components[0].block_grid, (4, 4));
+        assert_eq!(js.components[1].block_grid, (2, 2));
+        assert_eq!(js.components[2].block_grid, (2, 2));
+        assert_eq!(js.components[0].quant_table_base.len(), 64);
+        assert_eq!(js.components[0].zero_bias.len(), 64);
+        for comp in &js.components {
+            for block in &comp.blocks {
+                assert_eq!(block.coef_pre_quant.len(), 64);
+                assert_eq!(block.coef_levels.len(), 64);
+            }
+        }
+    }
+}

--- a/zenjpeg-diagnostics-viewer/wasm/src/lib.rs
+++ b/zenjpeg-diagnostics-viewer/wasm/src/lib.rs
@@ -98,11 +98,28 @@ fn to_js_diagnostics(src: diag_src::EncodeDiagnostics) -> Diagnostics {
     }
 }
 
-/// Options controlling the encode. Mirrors the most useful knobs from
-/// `EncoderConfig`. Field names use camelCase for TS-natural input.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+/// Options controlling the encode. Mirrors essentially every dial on
+/// `EncoderConfig` so the diagnostics viewer's UI can offer expert-mode
+/// access. Field names use camelCase for TS-natural input. All fields
+/// are optional with documented defaults.
+///
+/// ## Mode dispatch
+///
+/// `mode` selects which optimization to run:
+/// - `"baseline"` (default): no trellis, no auto-optimize. Honors
+///   `optimizeHuffman`, `progressive`, AQ, deringing, sharp_yuv,
+///   pre_blur, chroma_distance_scale, and any custom-table override.
+/// - `"trellis"`: standalone trellis with the explicit `trellis*`
+///   sub-config. Plays nicely with AQ.
+/// - `"hybrid"`: AQ-aware hybrid trellis (auto_optimize), reads the
+///   `hybrid*` sub-config. Always overrides standalone trellis.
+///
+/// Knobs not relevant to the chosen mode are silently ignored — the
+/// JS side greys them out with a red "ignored: <reason>" note.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EncodeOptions {
+    // ── Always-applied basics ───────────────────────────────────────
     /// jpegli quality (0-100). Default 85.
     #[serde(default = "default_quality")]
     pub quality: f32,
@@ -111,24 +128,151 @@ pub struct EncodeOptions {
     pub color_path: String,
     /// "none" (4:4:4), "halfHorizontal" (4:2:2), "quarter" (4:2:0),
     /// "halfVertical" (4:4:0). Used when colorPath = "ycbcr".
-    /// Default "none".
     #[serde(default = "default_subsampling")]
     pub subsampling: String,
-    /// "full" or "bQuarter". Used when colorPath = "xyb". Default "full".
+    /// "full" or "bQuarter". Used when colorPath = "xyb".
     #[serde(default = "default_xyb_subsampling")]
     pub xyb_subsampling: String,
     /// Adaptive quantization on/off. Default true.
     #[serde(default = "default_true")]
     pub aq_enabled: bool,
-    /// Standalone trellis quantization on/off. Default false.
-    #[serde(default)]
-    pub trellis: bool,
-    /// Auto-optimize (hybrid AQ+trellis) on/off. Default false.
-    #[serde(default)]
-    pub auto_optimize: bool,
     /// Deringing on/off. Default true.
     #[serde(default = "default_true")]
     pub deringing: bool,
+    /// Optimize Huffman tables (second-pass pixel sweep). Default true.
+    #[serde(default = "default_true")]
+    pub optimize_huffman: bool,
+    /// Progressive scan (multiple SOS markers, smaller for high-q
+    /// images). Default false (baseline).
+    #[serde(default)]
+    pub progressive: bool,
+    /// Sharp-YUV chroma downsampling (gamma-aware). Only meaningful
+    /// for YCbCr 4:2:2/4:2:0/4:4:0; ignored for 4:4:4 and XYB.
+    #[serde(default)]
+    pub sharp_yuv: bool,
+    /// Pre-encode Gaussian blur sigma (px). 0 disables.
+    #[serde(default)]
+    pub pre_blur: f32,
+    /// Multiplicative scale on chroma's perceptual distance budget.
+    /// 1.0 = default. >1 spends more bits on chroma; <1 less.
+    #[serde(default = "default_one")]
+    pub chroma_distance_scale: f32,
+    /// Restart-marker cadence in MCU rows. 0 disables restart markers.
+    #[serde(default)]
+    pub restart_mcu_rows: u16,
+
+    // ── Mode picker ─────────────────────────────────────────────────
+    /// "baseline" | "trellis" | "hybrid".
+    #[serde(default = "default_mode")]
+    pub mode: String,
+
+    // ── Standalone trellis sub-config (used when mode == "trellis") ─
+    /// Enable DC-coefficient trellis. Default false.
+    #[serde(default)]
+    pub trellis_dc_enabled: bool,
+    /// Lambda log-scale 1 (rate penalty). Default 14.75.
+    #[serde(default = "default_trellis_lambda1")]
+    pub trellis_lambda_log_scale1: f32,
+    /// Lambda log-scale 2 (distortion sensitivity). Default 16.5.
+    #[serde(default = "default_trellis_lambda2")]
+    pub trellis_lambda_log_scale2: f32,
+    /// "thorough" | "balanced" | "fast".
+    #[serde(default = "default_trellis_speed")]
+    pub trellis_speed_mode: String,
+    /// Vertical-DC-gradient weight in DC trellis. 0.0 disables.
+    #[serde(default)]
+    pub trellis_delta_dc_weight: f32,
+
+    // ── Hybrid sub-config (used when mode == "hybrid") ──────────────
+    /// Lambda gain per unit AQ strength. Default 2.0.
+    #[serde(default = "default_hybrid_aq_lambda_scale")]
+    pub hybrid_aq_lambda_scale: f32,
+    /// Base lambda log-scale 1. Default 14.75.
+    #[serde(default = "default_trellis_lambda1")]
+    pub hybrid_base_lambda_scale1: f32,
+    /// Base lambda log-scale 2. Default 16.5.
+    #[serde(default = "default_trellis_lambda2")]
+    pub hybrid_base_lambda_scale2: f32,
+    /// Enable DC-coefficient trellis in hybrid mode. Default false.
+    #[serde(default)]
+    pub hybrid_dc_enabled: bool,
+    /// AQ-strength exponent (1.0=linear, 2.0=squared, 0.5=sqrt).
+    #[serde(default = "default_one")]
+    pub hybrid_aq_exponent: f32,
+    /// Minimum AQ strength to start adjusting lambda.
+    #[serde(default)]
+    pub hybrid_aq_threshold: f32,
+    /// Quality-adaptive lambda dampening. Default true.
+    #[serde(default = "default_true")]
+    pub hybrid_quality_adaptive: bool,
+
+    // ── Custom quantization tables (overrides everything) ───────────
+    /// When set, replaces the source-derived quant tables with the
+    /// caller's f32 values. Other table fields (zero_bias_*) fall
+    /// back to jpegli defaults if not provided.
+    #[serde(default)]
+    pub custom_quant_tables: Option<CustomQuantTables>,
+}
+
+/// f32 quant tables + optional zero-bias overrides for a custom
+/// `EncodingTables`. Each component table is 64 floats in natural
+/// row-major order (DC at index 0, AC[7,7] at index 63).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomQuantTables {
+    /// Y / X (luma) quant table. Length 64.
+    pub y: Vec<f32>,
+    /// Cb / Y-XYB quant table. Length 64.
+    pub cb: Vec<f32>,
+    /// Cr / B-XYB quant table. Length 64.
+    pub cr: Vec<f32>,
+    /// Optional zero-bias multipliers per component (each length 64).
+    /// Higher values = more aggressive zeroing of small coefficients.
+    #[serde(default)]
+    pub y_zero_bias_mul: Option<Vec<f32>>,
+    #[serde(default)]
+    pub cb_zero_bias_mul: Option<Vec<f32>>,
+    #[serde(default)]
+    pub cr_zero_bias_mul: Option<Vec<f32>>,
+    /// Optional zero-bias DC offset, per component [Y, Cb, Cr]. Length 3.
+    #[serde(default)]
+    pub zero_bias_offset_dc: Option<[f32; 3]>,
+    /// Optional zero-bias AC offset, per component [Y, Cb, Cr]. Length 3.
+    #[serde(default)]
+    pub zero_bias_offset_ac: Option<[f32; 3]>,
+}
+
+impl Default for EncodeOptions {
+    fn default() -> Self {
+        Self {
+            quality: default_quality(),
+            color_path: default_color_path(),
+            subsampling: default_subsampling(),
+            xyb_subsampling: default_xyb_subsampling(),
+            aq_enabled: true,
+            deringing: true,
+            optimize_huffman: true,
+            progressive: false,
+            sharp_yuv: false,
+            pre_blur: 0.0,
+            chroma_distance_scale: 1.0,
+            restart_mcu_rows: 0,
+            mode: default_mode(),
+            trellis_dc_enabled: false,
+            trellis_lambda_log_scale1: default_trellis_lambda1(),
+            trellis_lambda_log_scale2: default_trellis_lambda2(),
+            trellis_speed_mode: default_trellis_speed(),
+            trellis_delta_dc_weight: 0.0,
+            hybrid_aq_lambda_scale: default_hybrid_aq_lambda_scale(),
+            hybrid_base_lambda_scale1: default_trellis_lambda1(),
+            hybrid_base_lambda_scale2: default_trellis_lambda2(),
+            hybrid_dc_enabled: false,
+            hybrid_aq_exponent: 1.0,
+            hybrid_aq_threshold: 0.0,
+            hybrid_quality_adaptive: true,
+            custom_quant_tables: None,
+        }
+    }
 }
 
 fn default_quality() -> f32 {
@@ -145,6 +289,24 @@ fn default_xyb_subsampling() -> String {
 }
 fn default_true() -> bool {
     true
+}
+fn default_one() -> f32 {
+    1.0
+}
+fn default_mode() -> String {
+    "baseline".into()
+}
+fn default_trellis_lambda1() -> f32 {
+    14.75
+}
+fn default_trellis_lambda2() -> f32 {
+    16.5
+}
+fn default_trellis_speed() -> String {
+    "balanced".into()
+}
+fn default_hybrid_aq_lambda_scale() -> f32 {
+    2.0
 }
 
 // Note: `EncodeResult` is built up on the JS side as
@@ -178,16 +340,7 @@ pub fn encode_with_diagnostics(
     options: JsValue,
 ) -> Result<JsValue, JsValue> {
     let opts: EncodeOptions = if options.is_null() || options.is_undefined() {
-        EncodeOptions {
-            quality: default_quality(),
-            color_path: default_color_path(),
-            subsampling: default_subsampling(),
-            xyb_subsampling: default_xyb_subsampling(),
-            aq_enabled: true,
-            trellis: false,
-            auto_optimize: false,
-            deringing: true,
-        }
+        EncodeOptions::default()
     } else {
         serde_wasm_bindgen::from_value(options)
             .map_err(|e| JsValue::from_str(&format!("invalid options: {e}")))?
@@ -236,20 +389,113 @@ pub fn encode_with_diagnostics(
         }
     };
 
-    // Trellis + auto-optimize are always available because the wasm
-    // crate enables zenjpeg's `trellis` feature unconditionally
-    // (see Cargo.toml). The cfg gate that was here previously was
-    // checking the `trellis` feature on *this* crate, which doesn't
-    // exist — leading to dead code under any cfg evaluation.
+    use zenjpeg::encode::encoder_types::ProgressiveScanMode;
+    use zenjpeg::encode::trellis::{HybridConfig, TrellisConfig, TrellisSpeedMode};
+    use zenjpeg::encode::tuning::{EncodingTables, ScalingParams};
+    use zenjpeg::encoder::QuantTableConfig;
+
+    // Always-applied dials. Knobs that don't apply to the chosen
+    // (color path × subsampling × mode) combination get silently
+    // ignored — the JS side flags them as "ignored: …" in the UI.
+    let scan_mode = if opts.progressive {
+        ProgressiveScanMode::Progressive
+    } else {
+        ProgressiveScanMode::Baseline
+    };
     let mut config = config
         .aq_enabled(opts.aq_enabled)
         .deringing(opts.deringing)
+        .optimize_huffman(opts.optimize_huffman)
+        .scan_mode(scan_mode)
+        .sharp_yuv(opts.sharp_yuv)
+        .pre_blur(opts.pre_blur)
+        .chroma_distance_scale(opts.chroma_distance_scale)
+        .restart_mcu_rows(opts.restart_mcu_rows)
         .with_diagnostics(true);
-    if opts.auto_optimize {
-        config = config.auto_optimize(true);
-    } else if opts.trellis {
-        use zenjpeg::encode::trellis::TrellisConfig;
-        config = config.trellis(TrellisConfig::new());
+
+    // Custom quant tables override `quant_table_config` entirely.
+    // PerComponent uses generic c0/c1/c2 fields (Y/Cb/Cr in YCbCr mode).
+    //
+    // CRITICAL: when the caller passes a custom table, we set
+    // `scaling: ScalingParams::Exact` so the f32 values are used
+    // directly as final quant values. With the default
+    // `ScalingParams::Scaled`, the table would be re-multiplied by
+    // distance_to_scale × global_scale at encode time — a "Q-scale =
+    // 0.5" edit on the JS side would compound, exploding to
+    // unreasonable values.
+    if let Some(tables) = opts.custom_quant_tables.as_ref() {
+        let is_xyb = matches!(opts.color_path.as_str(), "xyb");
+        let mut t = if is_xyb {
+            EncodingTables::default_xyb()
+        } else {
+            EncodingTables::default_ycbcr()
+        };
+        if tables.y.len() == 64 {
+            t.quant.c0.copy_from_slice(&tables.y);
+        }
+        if tables.cb.len() == 64 {
+            t.quant.c1.copy_from_slice(&tables.cb);
+        }
+        if tables.cr.len() == 64 {
+            t.quant.c2.copy_from_slice(&tables.cr);
+        }
+        if let Some(v) = tables.y_zero_bias_mul.as_ref() {
+            if v.len() == 64 {
+                t.zero_bias_mul.c0.copy_from_slice(v);
+            }
+        }
+        if let Some(v) = tables.cb_zero_bias_mul.as_ref() {
+            if v.len() == 64 {
+                t.zero_bias_mul.c1.copy_from_slice(v);
+            }
+        }
+        if let Some(v) = tables.cr_zero_bias_mul.as_ref() {
+            if v.len() == 64 {
+                t.zero_bias_mul.c2.copy_from_slice(v);
+            }
+        }
+        if let Some(dc) = tables.zero_bias_offset_dc {
+            t.zero_bias_offset_dc = dc;
+        }
+        if let Some(ac) = tables.zero_bias_offset_ac {
+            t.zero_bias_offset_ac = ac;
+        }
+        // The caller is editing final tables, not pre-scale base
+        // values — switch to Exact so the values pass through.
+        t.scaling = ScalingParams::exact();
+        config = config.quant_table_config(QuantTableConfig::Custom(Box::new(t)));
+    }
+
+    // Mode picker: hybrid > trellis > baseline.
+    match opts.mode.as_str() {
+        "hybrid" => {
+            let mut h = HybridConfig::default();
+            h.enabled = true;
+            h.aq_lambda_scale = opts.hybrid_aq_lambda_scale;
+            h.base_lambda_scale1 = opts.hybrid_base_lambda_scale1;
+            h.base_lambda_scale2 = opts.hybrid_base_lambda_scale2;
+            h.dc_enabled = opts.hybrid_dc_enabled;
+            h.aq_exponent = opts.hybrid_aq_exponent;
+            h.aq_threshold = opts.hybrid_aq_threshold;
+            h.quality_adaptive = opts.hybrid_quality_adaptive;
+            config = config.hybrid_config(h);
+        }
+        "trellis" => {
+            let speed = match opts.trellis_speed_mode.as_str() {
+                "thorough" => TrellisSpeedMode::Thorough,
+                "fast" => TrellisSpeedMode::Level(8),
+                _ => TrellisSpeedMode::Adaptive,
+            };
+            let mut t = TrellisConfig::new();
+            t.dc_enabled = opts.trellis_dc_enabled;
+            t.lambda_log_scale1 = opts.trellis_lambda_log_scale1;
+            t.lambda_log_scale2 = opts.trellis_lambda_log_scale2;
+            t.speed_mode = speed;
+            t.delta_dc_weight = opts.trellis_delta_dc_weight;
+            config = config.trellis(t);
+        }
+        // "baseline" or unknown — no trellis/hybrid wiring.
+        _ => {}
     }
 
     let request = config.request();
@@ -277,6 +523,103 @@ pub fn encode_with_diagnostics(
     js_sys::Reflect::set(&out, &JsValue::from_str("diagnostics"), &js_diag)
         .map_err(|_| JsValue::from_str("failed to set diagnostics on result"))?;
     Ok(out.into())
+}
+
+/// Compute SSIMULACRA 2 between two sRGB-encoded RGB byte buffers.
+///
+/// Both `source` and `distorted` must be packed `[r, g, b]` triples
+/// with the same dimensions (length = `width * height * 3`). Returns
+/// the f64 SSIMULACRA 2 score (higher = more similar; ~80+ "good",
+/// 100 = identical, can go negative for severe distortions).
+///
+/// On any input mismatch or computation failure, returns a JS error.
+#[wasm_bindgen(js_name = computeSsimulacra2)]
+pub fn compute_ssimulacra2_rgb(
+    source: &[u8],
+    distorted: &[u8],
+    width: u32,
+    height: u32,
+) -> Result<f64, JsValue> {
+    let expected = (width as usize) * (height as usize) * 3;
+    if source.len() != expected {
+        return Err(JsValue::from_str(&format!(
+            "source pixels length mismatch: expected {expected} ({width}*{height}*3), got {}",
+            source.len()
+        )));
+    }
+    if distorted.len() != expected {
+        return Err(JsValue::from_str(&format!(
+            "distorted pixels length mismatch: expected {expected} ({width}*{height}*3), got {}",
+            distorted.len()
+        )));
+    }
+    if width == 0 || height == 0 {
+        return Err(JsValue::from_str("width and height must be > 0"));
+    }
+    let lin_src = rgb_bytes_to_linear(source, width as usize, height as usize);
+    let lin_dst = rgb_bytes_to_linear(distorted, width as usize, height as usize);
+    fast_ssim2::compute_ssimulacra2(lin_src, lin_dst)
+        .map_err(|e| JsValue::from_str(&format!("ssimulacra2: {e}")))
+}
+
+/// Compute zensim score between two sRGB-encoded RGB byte buffers.
+///
+/// Same input shape as [`compute_ssimulacra2_rgb`]. Returns the f64
+/// zensim score (0-100; 100 = identical). Uses the latest profile.
+#[wasm_bindgen(js_name = computeZensim)]
+pub fn compute_zensim_rgb(
+    source: &[u8],
+    distorted: &[u8],
+    width: u32,
+    height: u32,
+) -> Result<f64, JsValue> {
+    let expected = (width as usize) * (height as usize) * 3;
+    if source.len() != expected || distorted.len() != expected {
+        return Err(JsValue::from_str(&format!(
+            "rgb length mismatch: expected {expected} (={width}*{height}*3), \
+             got source={} distorted={}",
+            source.len(),
+            distorted.len()
+        )));
+    }
+    if width == 0 || height == 0 {
+        return Err(JsValue::from_str("width and height must be > 0"));
+    }
+    let w = width as usize;
+    let h = height as usize;
+    let n = w * h;
+    let src_rgb = pack_rgb_triples(source, n);
+    let dst_rgb = pack_rgb_triples(distorted, n);
+    let z = zensim::Zensim::new(zensim::ZensimProfile::latest());
+    let src = zensim::RgbSlice::new(&src_rgb, w, h);
+    let dst = zensim::RgbSlice::new(&dst_rgb, w, h);
+    z.compute(&src, &dst)
+        .map(|r| r.score())
+        .map_err(|e| JsValue::from_str(&format!("zensim: {e}")))
+}
+
+fn pack_rgb_triples(rgb: &[u8], n: usize) -> Vec<[u8; 3]> {
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        out.push([rgb[i * 3], rgb[i * 3 + 1], rgb[i * 3 + 2]]);
+    }
+    out
+}
+
+fn rgb_bytes_to_linear(rgb: &[u8], w: usize, h: usize) -> fast_ssim2::LinearRgbImage {
+    let n = w * h;
+    let mut data: Vec<[f32; 3]> = Vec::with_capacity(n);
+    for i in 0..n {
+        let r = rgb[i * 3];
+        let g = rgb[i * 3 + 1];
+        let b = rgb[i * 3 + 2];
+        data.push([
+            fast_ssim2::srgb_u8_to_linear(r),
+            fast_ssim2::srgb_u8_to_linear(g),
+            fast_ssim2::srgb_u8_to_linear(b),
+        ]);
+    }
+    fast_ssim2::LinearRgbImage::new(data, w, h)
 }
 
 #[cfg(test)]

--- a/zenjpeg-diagnostics-viewer/wasm/src/lib.rs
+++ b/zenjpeg-diagnostics-viewer/wasm/src/lib.rs
@@ -147,15 +147,12 @@ fn default_true() -> bool {
     true
 }
 
-/// Output of `encodeWithDiagnostics`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct EncodeResult {
-    /// JPEG bytes.
-    pub bytes: Vec<u8>,
-    /// Per-block diagnostics.
-    pub diagnostics: Diagnostics,
-}
+// Note: `EncodeResult` is built up on the JS side as
+// `{ bytes: Uint8Array, diagnostics: Diagnostics }`. We can't go through
+// serde_wasm_bindgen for the whole struct because it serializes
+// `Vec<u8>` as a plain JS Array<number>, which produces invalid bytes
+// when fed to `new Blob([...])`. We hand-pack the result with
+// `js_sys::Uint8Array` to keep the byte path zero-copy.
 
 #[wasm_bindgen(start)]
 pub fn init() {
@@ -271,12 +268,16 @@ pub fn encode_with_diagnostics(
         JsValue::from_str("with_diagnostics(true) was set but encoder returned None")
     })?;
 
-    let result = EncodeResult {
-        bytes,
-        diagnostics: to_js_diagnostics(diag),
-    };
-    serde_wasm_bindgen::to_value(&result)
-        .map_err(|e| JsValue::from_str(&format!("serialize result: {e}")))
+    let js_bytes = js_sys::Uint8Array::new_with_length(bytes.len() as u32);
+    js_bytes.copy_from(&bytes);
+    let js_diag = serde_wasm_bindgen::to_value(&to_js_diagnostics(diag))
+        .map_err(|e| JsValue::from_str(&format!("serialize diagnostics: {e}")))?;
+    let out = js_sys::Object::new();
+    js_sys::Reflect::set(&out, &JsValue::from_str("bytes"), &js_bytes)
+        .map_err(|_| JsValue::from_str("failed to set bytes on result"))?;
+    js_sys::Reflect::set(&out, &JsValue::from_str("diagnostics"), &js_diag)
+        .map_err(|_| JsValue::from_str("failed to set diagnostics on result"))?;
+    Ok(out.into())
 }
 
 #[cfg(test)]
@@ -302,6 +303,7 @@ mod tests {
     /// shape as the Rust diagnostics. Doesn't go through wasm-bindgen
     /// (that's covered by the web/Playwright suite).
     #[test]
+    #[allow(unused_variables)]
     fn to_js_diagnostics_preserves_shape() {
         let w = 32u32;
         let h = 32u32;

--- a/zenjpeg-diagnostics-viewer/wasm/src/lib.rs
+++ b/zenjpeg-diagnostics-viewer/wasm/src/lib.rs
@@ -236,22 +236,21 @@ pub fn encode_with_diagnostics(
         }
     };
 
+    // Trellis + auto-optimize are always available because the wasm
+    // crate enables zenjpeg's `trellis` feature unconditionally
+    // (see Cargo.toml). The cfg gate that was here previously was
+    // checking the `trellis` feature on *this* crate, which doesn't
+    // exist — leading to dead code under any cfg evaluation.
     let mut config = config
         .aq_enabled(opts.aq_enabled)
         .deringing(opts.deringing)
         .with_diagnostics(true);
-
-    #[cfg(feature = "trellis")]
-    {
-        if opts.auto_optimize {
-            config = config.auto_optimize(true);
-        } else if opts.trellis {
-            use zenjpeg::encode::trellis::TrellisConfig;
-            config = config.trellis(TrellisConfig::new());
-        }
+    if opts.auto_optimize {
+        config = config.auto_optimize(true);
+    } else if opts.trellis {
+        use zenjpeg::encode::trellis::TrellisConfig;
+        config = config.trellis(TrellisConfig::new());
     }
-    // Suppress unused-warning when trellis isn't enabled.
-    let _ = (opts.trellis, opts.auto_optimize);
 
     let request = config.request();
     let mut encoder = request

--- a/zenjpeg-diagnostics-viewer/web/.deploy-trigger
+++ b/zenjpeg-diagnostics-viewer/web/.deploy-trigger
@@ -1,0 +1,1 @@
+# trigger deploy

--- a/zenjpeg-diagnostics-viewer/web/index.html
+++ b/zenjpeg-diagnostics-viewer/web/index.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>zenjpeg diagnostics viewer</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>zenjpeg diagnostics viewer</h1>
+      <p class="status" id="status" data-testid="status">Initializing…</p>
+    </header>
+
+    <section class="controls" aria-label="Encode controls">
+      <label>
+        Quality
+        <input
+          type="range"
+          id="quality"
+          min="1"
+          max="100"
+          step="1"
+          value="85"
+          data-testid="quality-slider"
+        />
+        <output id="quality-out" data-testid="quality-out">85</output>
+      </label>
+
+      <label>
+        Color path
+        <select id="color-path" data-testid="color-path-select">
+          <option value="ycbcr" selected>YCbCr</option>
+          <option value="xyb">XYB</option>
+        </select>
+      </label>
+
+      <label data-controls-for="ycbcr" id="subsampling-label">
+        Subsampling
+        <select id="subsampling" data-testid="subsampling-select">
+          <option value="none" selected>4:4:4 (none)</option>
+          <option value="halfHorizontal">4:2:2 (half horizontal)</option>
+          <option value="quarter">4:2:0 (quarter)</option>
+          <option value="halfVertical">4:4:0 (half vertical)</option>
+        </select>
+      </label>
+
+      <label data-controls-for="xyb" id="xyb-subsampling-label" hidden>
+        XYB B
+        <select id="xyb-subsampling" data-testid="xyb-subsampling-select">
+          <option value="full" selected>Full</option>
+          <option value="bQuarter">B Quarter</option>
+        </select>
+      </label>
+
+      <label>
+        <input
+          type="checkbox"
+          id="aq-enabled"
+          checked
+          data-testid="aq-checkbox"
+        />
+        AQ
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          id="trellis"
+          data-testid="trellis-checkbox"
+        />
+        Trellis
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          id="auto-optimize"
+          data-testid="auto-optimize-checkbox"
+        />
+        Auto-optimize (hybrid)
+      </label>
+
+      <label class="file-pick">
+        <input type="file" id="image-input" accept="image/*" data-testid="image-input" />
+        <span>Load image</span>
+      </label>
+      <button id="reset" type="button" data-testid="reset-button">
+        Reset to synthetic
+      </button>
+      <button id="encode" type="button" data-testid="encode-button">Encode</button>
+    </section>
+
+    <main>
+      <section class="triptych" aria-label="Source / encoded / delta">
+        <figure>
+          <figcaption>Source</figcaption>
+          <canvas id="source-canvas" data-testid="source-canvas"></canvas>
+        </figure>
+        <figure>
+          <figcaption>Encoded</figcaption>
+          <canvas id="encoded-canvas" data-testid="encoded-canvas"></canvas>
+        </figure>
+        <figure>
+          <figcaption>|delta| (×8)</figcaption>
+          <canvas id="delta-canvas" data-testid="delta-canvas"></canvas>
+        </figure>
+      </section>
+
+      <section class="aq-row" aria-label="AQ field">
+        <h2>AQ multiplier per Y block</h2>
+        <canvas id="aq-canvas" data-testid="aq-canvas"></canvas>
+        <p class="legend">
+          Smaller AQ multiplier → finer quantization (more bits spent).
+          Hover to see per-block value.
+        </p>
+      </section>
+
+      <section class="component-grid" aria-label="Per-component editors">
+        <article class="component" data-component="0" id="component-0">
+          <header>
+            <h2>Component 0 (Y/X)</h2>
+            <p class="grid-info" data-testid="comp-0-grid-info"></p>
+          </header>
+          <div class="component-body">
+            <div class="quant-editor">
+              <h3>Quant table (base × h_eq × v_eq)</h3>
+              <div class="quant-grid" data-testid="comp-0-quant-grid"></div>
+              <div class="eq-row">
+                <span class="eq-label">h_eq</span>
+                <div
+                  class="eq-sliders horizontal"
+                  data-testid="comp-0-h-eq"
+                ></div>
+              </div>
+              <div class="eq-col">
+                <span class="eq-label">v_eq</span>
+                <div
+                  class="eq-sliders vertical"
+                  data-testid="comp-0-v-eq"
+                ></div>
+              </div>
+              <button
+                type="button"
+                data-testid="comp-0-reset-eq"
+                class="reset-eq"
+              >
+                Reset EQ
+              </button>
+            </div>
+            <div class="utilization">
+              <h3>Coefficient utilization</h3>
+              <canvas
+                data-testid="comp-0-utilization"
+                class="utilization-canvas"
+              ></canvas>
+              <p class="legend">
+                Mean |coef_pre_quant| / effective_quant per coefficient
+                position (natural order; DC top-left).
+              </p>
+            </div>
+            <div class="estimate">
+              <h3>Byte budget</h3>
+              <p>
+                <span data-testid="comp-0-zero-rate">--</span>%
+                of coefs zero out at this table.
+              </p>
+              <p class="legend">
+                Re-applying the user-adjusted table to this component's
+                pre-quant coefficients. Updates live as you drag.
+              </p>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/zenjpeg-diagnostics-viewer/web/index.html
+++ b/zenjpeg-diagnostics-viewer/web/index.html
@@ -6,172 +6,991 @@
     <title>zenjpeg diagnostics viewer</title>
     <link rel="stylesheet" href="/src/styles.css" />
   </head>
-  <body>
-    <header>
-      <h1>zenjpeg diagnostics viewer</h1>
-      <p class="status" id="status" data-testid="status">Initializing…</p>
+  <body class="min-h-screen text-text">
+    <header class="px-6 py-3 border-b border-line flex items-baseline gap-6">
+      <h1 class="text-base font-semibold m-0">zenjpeg diagnostics viewer</h1>
+      <p class="m-0 text-xs text-muted font-mono" id="status" data-testid="status">
+        Initializing…
+      </p>
+      <div class="ml-auto flex items-center gap-3">
+        <label class="flex items-center gap-2 text-xs text-muted">
+          <input
+            type="checkbox"
+            id="auto-encode"
+            checked
+            data-testid="auto-encode-toggle"
+          />
+          <span>Auto-encode (debounced)</span>
+        </label>
+        <button
+          id="encode"
+          type="button"
+          data-testid="encode-button"
+          class="px-3 py-1.5 text-xs font-semibold rounded bg-accent text-bg hover:brightness-110"
+        >
+          Encode now
+        </button>
+        <button
+          id="cancel"
+          type="button"
+          data-testid="cancel-button"
+          class="px-3 py-1.5 text-xs font-semibold rounded bg-panel-2 text-text border border-line hover:bg-panel"
+          disabled
+        >
+          Cancel
+        </button>
+      </div>
     </header>
 
-    <section class="controls" aria-label="Encode controls">
-      <label>
-        Quality
-        <input
-          type="range"
-          id="quality"
-          min="1"
-          max="100"
-          step="1"
-          value="85"
-          data-testid="quality-slider"
-        />
-        <output id="quality-out" data-testid="quality-out">85</output>
-      </label>
-
-      <label>
-        Color path
-        <select id="color-path" data-testid="color-path-select">
-          <option value="ycbcr" selected>YCbCr</option>
-          <option value="xyb">XYB</option>
+    <!-- Image source bar -->
+    <section class="px-6 py-2 border-b border-line bg-panel flex flex-wrap gap-4 items-center text-sm">
+      <label class="flex items-center gap-2 text-muted">
+        <span class="text-xs uppercase tracking-wider">Image</span>
+        <select id="image-pick" data-testid="image-pick" class="min-w-[280px]">
+          <option value="__synthetic__" selected>Synthetic 64×64</option>
         </select>
       </label>
-
-      <label data-controls-for="ycbcr" id="subsampling-label">
-        Subsampling
-        <select id="subsampling" data-testid="subsampling-select">
-          <option value="none" selected>4:4:4 (none)</option>
-          <option value="halfHorizontal">4:2:2 (half horizontal)</option>
-          <option value="quarter">4:2:0 (quarter)</option>
-          <option value="halfVertical">4:4:0 (half vertical)</option>
-        </select>
-      </label>
-
-      <label data-controls-for="xyb" id="xyb-subsampling-label" hidden>
-        XYB B
-        <select id="xyb-subsampling" data-testid="xyb-subsampling-select">
-          <option value="full" selected>Full</option>
-          <option value="bQuarter">B Quarter</option>
-        </select>
-      </label>
-
-      <label>
+      <label class="flex items-center gap-2 text-muted relative">
         <input
-          type="checkbox"
-          id="aq-enabled"
-          checked
-          data-testid="aq-checkbox"
+          type="file"
+          id="image-input"
+          accept="image/*"
+          data-testid="image-input"
+          class="absolute w-0 h-0 opacity-0"
         />
-        AQ
+        <span class="px-2.5 py-1 rounded bg-panel-2 border border-line cursor-pointer hover:bg-bg">
+          Or upload…
+        </span>
       </label>
-      <label>
-        <input
-          type="checkbox"
-          id="trellis"
-          data-testid="trellis-checkbox"
-        />
-        Trellis
-      </label>
-      <label>
-        <input
-          type="checkbox"
-          id="auto-optimize"
-          data-testid="auto-optimize-checkbox"
-        />
-        Auto-optimize (hybrid)
-      </label>
-
-      <label class="file-pick">
-        <input type="file" id="image-input" accept="image/*" data-testid="image-input" />
-        <span>Load image</span>
-      </label>
-      <button id="reset" type="button" data-testid="reset-button">
+      <button
+        id="reset"
+        type="button"
+        data-testid="reset-button"
+        class="px-3 py-1.5 text-xs font-semibold rounded bg-panel-2 text-text border border-line hover:bg-bg"
+      >
         Reset to synthetic
       </button>
-      <button id="encode" type="button" data-testid="encode-button">Encode</button>
+      <span id="image-info" class="ml-auto text-xs text-muted font-mono">
+        — × —
+      </span>
     </section>
 
-    <main>
-      <section class="triptych" aria-label="Source / encoded / delta">
-        <figure>
+    <!-- BIG RESULTS PANEL -->
+    <section
+      class="px-6 py-4 bg-panel border-b border-line flex flex-wrap gap-3 items-stretch relative"
+      aria-label="Encode results"
+      id="results-panel"
+    >
+      <!-- Encoding overlay: shown during in-flight encode -->
+      <div
+        id="encode-overlay"
+        data-testid="encode-overlay"
+        class="encode-overlay"
+        hidden
+      >
+        <div class="encode-overlay-inner">
+          <span class="encode-overlay-spinner" aria-hidden="true"></span>
+          <span class="encode-overlay-label">ENCODING</span>
+          <span class="encode-overlay-detail" id="encode-overlay-detail">…</span>
+        </div>
+      </div>
+      <div class="metric-readout" data-testid="metric-bytes">
+        <span class="label">Bytes</span>
+        <span class="value" id="m-bytes">—</span>
+        <span class="unit" id="m-bpp">—</span>
+      </div>
+      <div class="metric-readout" data-testid="metric-mode">
+        <span class="label">Mode</span>
+        <span class="value text-2xl!" id="m-mode" style="font-size: 22px">—</span>
+        <span class="unit" id="m-mode-detail">—</span>
+      </div>
+      <div class="metric-readout" data-testid="metric-ssim2">
+        <span class="label">SSIMULACRA 2</span>
+        <span class="value" id="m-ssim2">—</span>
+        <span class="unit">100 = identical</span>
+      </div>
+      <div class="metric-readout" data-testid="metric-zensim">
+        <span class="label">zensim</span>
+        <span class="value" id="m-zensim">—</span>
+        <span class="unit">100 = identical</span>
+      </div>
+      <div class="metric-readout" data-testid="metric-pareto">
+        <span class="label">Δ vs reference</span>
+        <span class="value" id="m-pareto">—</span>
+        <span class="unit">+ above ref curve · − below</span>
+      </div>
+      <div class="metric-readout" data-testid="metric-time">
+        <span class="label">Encode</span>
+        <span class="value" id="m-time">—</span>
+        <span class="unit">ms</span>
+      </div>
+    </section>
+
+    <!-- Image triptych — click any canvas to open the zoom inspector -->
+    <section
+      class="px-6 py-4 grid grid-cols-3 gap-4 border-b border-line"
+      aria-label="Source / encoded / delta"
+    >
+      <figure class="m-0 flex flex-col">
+        <figcaption class="text-xs text-muted font-mono mb-1 flex justify-between items-center">
+          <span>Source</span>
+          <span class="text-[10px] opacity-60">click to zoom</span>
+        </figcaption>
+        <canvas
+          id="source-canvas"
+          data-testid="source-canvas"
+          class="w-full h-auto bg-black border border-line rounded cursor-zoom-in"
+          data-zoom-source="source"
+        ></canvas>
+      </figure>
+      <figure class="m-0 flex flex-col">
+        <figcaption class="text-xs text-muted font-mono mb-1 flex justify-between items-center">
+          <span>Encoded</span>
+          <span class="text-[10px] opacity-60">click to zoom</span>
+        </figcaption>
+        <canvas
+          id="encoded-canvas"
+          data-testid="encoded-canvas"
+          class="w-full h-auto bg-black border border-line rounded cursor-zoom-in"
+          data-zoom-source="encoded"
+        ></canvas>
+      </figure>
+      <figure class="m-0 flex flex-col">
+        <figcaption class="text-xs text-muted font-mono mb-1 flex justify-between items-center">
+          <span>|delta| (×8)</span>
+          <span class="text-[10px] opacity-60">click to zoom</span>
+        </figcaption>
+        <canvas
+          id="delta-canvas"
+          data-testid="delta-canvas"
+          class="w-full h-auto bg-black border border-line rounded cursor-zoom-in"
+          data-zoom-source="delta"
+        ></canvas>
+      </figure>
+    </section>
+
+    <!-- Zoom inspector modal -->
+    <div
+      id="zoom-modal"
+      class="zoom-modal"
+      data-testid="zoom-modal"
+      hidden
+      role="dialog"
+      aria-modal="true"
+      aria-label="Pixel zoom inspector"
+    >
+      <div class="zoom-modal-bar">
+        <span class="zoom-modal-title">Pixel zoom inspector</span>
+        <span class="zoom-modal-coords" id="zoom-coords">—</span>
+        <span class="zoom-modal-scale" id="zoom-scale">×4</span>
+        <span class="zoom-modal-hint">drag to pan · wheel to zoom · 1-9 to set scale · esc to close</span>
+        <button type="button" id="zoom-close" data-testid="zoom-close" class="zoom-modal-close">
+          ✕
+        </button>
+      </div>
+      <div class="zoom-modal-grid">
+        <figure class="zoom-pane">
           <figcaption>Source</figcaption>
-          <canvas id="source-canvas" data-testid="source-canvas"></canvas>
+          <canvas id="zoom-source" data-testid="zoom-source"></canvas>
         </figure>
-        <figure>
+        <figure class="zoom-pane">
           <figcaption>Encoded</figcaption>
-          <canvas id="encoded-canvas" data-testid="encoded-canvas"></canvas>
+          <canvas id="zoom-encoded" data-testid="zoom-encoded"></canvas>
         </figure>
-        <figure>
+        <figure class="zoom-pane">
           <figcaption>|delta| (×8)</figcaption>
-          <canvas id="delta-canvas" data-testid="delta-canvas"></canvas>
+          <canvas id="zoom-delta" data-testid="zoom-delta"></canvas>
         </figure>
-      </section>
+      </div>
+    </div>
 
-      <section class="aq-row" aria-label="AQ field">
-        <h2>AQ multiplier per Y block</h2>
-        <canvas id="aq-canvas" data-testid="aq-canvas"></canvas>
-        <p class="legend">
+    <!-- AQ + RD row -->
+    <section
+      class="px-6 py-4 grid grid-cols-1 lg:grid-cols-2 gap-6 border-b border-line"
+    >
+      <div class="bg-panel border border-line rounded p-3">
+        <h2 class="text-sm m-0 mb-2 text-accent font-semibold">
+          AQ multiplier per Y/X block
+        </h2>
+        <div class="flex gap-3 items-start">
+          <canvas
+            id="aq-canvas"
+            data-testid="aq-canvas"
+            class="bg-black rounded max-w-[480px] w-full h-auto"
+          ></canvas>
+          <dl
+            class="m-0 grid grid-cols-[auto_auto] gap-x-3 gap-y-1 text-xs font-mono"
+            id="aq-stats"
+          >
+            <dt class="text-muted">min</dt>
+            <dd class="m-0" id="aq-min">—</dd>
+            <dt class="text-muted">max</dt>
+            <dd class="m-0" id="aq-max">—</dd>
+            <dt class="text-muted">mean</dt>
+            <dd class="m-0" id="aq-mean">—</dd>
+            <dt class="text-muted">channel</dt>
+            <dd class="m-0" id="aq-channel">—</dd>
+          </dl>
+        </div>
+        <p class="m-0 mt-2 text-xs text-muted">
           Smaller AQ multiplier → finer quantization (more bits spent).
-          Hover to see per-block value.
+          Map is computed on the AQ source channel (Y for YCbCr, Y-XYB
+          for XYB) and applied to the lead component (Y or X).
         </p>
-      </section>
+      </div>
+      <div class="bg-panel border border-line rounded p-3">
+        <h2 class="text-sm m-0 mb-2 text-accent font-semibold">
+          Reference RD curve
+        </h2>
+        <canvas
+          id="rd-canvas"
+          data-testid="rd-canvas"
+          width="640"
+          height="280"
+          class="bg-black rounded w-full h-auto"
+        ></canvas>
+        <p class="m-0 mt-2 text-xs text-muted">
+          White polyline = reference encode (default tables, AQ on,
+          4:2:0, q=1..100). Blue dot = current encode.
+          <strong>This is a single-config q-sweep, not a true
+          rate-distortion pareto envelope</strong> — a real pareto
+          would also vary subsampling, mode, and other knobs to find
+          the upper-left frontier. The Δ vs reference number says how
+          far the current encode lands above (positive) or below
+          (negative) the reference at its byte count.
+        </p>
+      </div>
+    </section>
 
-      <section class="component-grid" aria-label="Per-component editors">
-        <article class="component" data-component="0" id="component-0">
-          <header>
-            <h2>Component 0 (Y/X)</h2>
-            <p class="grid-info" data-testid="comp-0-grid-info"></p>
-          </header>
-          <div class="component-body">
-            <div class="quant-editor">
-              <h3>Quant table (base × h_eq × v_eq)</h3>
-              <div class="quant-grid" data-testid="comp-0-quant-grid"></div>
-              <div class="eq-row">
-                <span class="eq-label">h_eq</span>
-                <div
-                  class="eq-sliders horizontal"
-                  data-testid="comp-0-h-eq"
-                ></div>
-              </div>
-              <div class="eq-col">
-                <span class="eq-label">v_eq</span>
-                <div
-                  class="eq-sliders vertical"
-                  data-testid="comp-0-v-eq"
-                ></div>
-              </div>
-              <button
-                type="button"
-                data-testid="comp-0-reset-eq"
-                class="reset-eq"
-              >
-                Reset EQ
-              </button>
+    <!-- Controls panel (tabs) -->
+    <nav
+      class="tabs flex gap-1 px-6 bg-bg border-b border-line overflow-x-auto"
+      role="tablist"
+      aria-label="Encoder controls"
+    >
+      <button
+        role="tab"
+        type="button"
+        class="tab text-xs font-medium px-4 py-2.5 whitespace-nowrap"
+        data-tab="quality"
+        aria-selected="true"
+        data-testid="tab-quality"
+      >
+        Quality &amp; Chroma
+      </button>
+      <button
+        role="tab"
+        type="button"
+        class="tab text-xs font-medium px-4 py-2.5 whitespace-nowrap"
+        data-tab="aq"
+        aria-selected="false"
+        data-testid="tab-aq"
+      >
+        AQ &amp; Mode
+      </button>
+      <button
+        role="tab"
+        type="button"
+        class="tab text-xs font-medium px-4 py-2.5 whitespace-nowrap"
+        data-tab="trellis"
+        aria-selected="false"
+        data-testid="tab-trellis"
+      >
+        Trellis
+      </button>
+      <button
+        role="tab"
+        type="button"
+        class="tab text-xs font-medium px-4 py-2.5 whitespace-nowrap"
+        data-tab="hybrid"
+        aria-selected="false"
+        data-testid="tab-hybrid"
+      >
+        Hybrid
+      </button>
+      <button
+        role="tab"
+        type="button"
+        class="tab text-xs font-medium px-4 py-2.5 whitespace-nowrap"
+        data-tab="quant"
+        aria-selected="false"
+        data-testid="tab-quant"
+      >
+        Quant tables
+      </button>
+      <button
+        role="tab"
+        type="button"
+        class="tab text-xs font-medium px-4 py-2.5 whitespace-nowrap"
+        data-tab="misc"
+        aria-selected="false"
+        data-testid="tab-misc"
+      >
+        Misc
+      </button>
+    </nav>
+
+    <section class="bg-panel border-b border-line" id="tab-panels">
+      <article
+        class="tab-panel flex flex-wrap gap-x-6 gap-y-3 px-6 py-4"
+        data-tab="quality"
+        aria-hidden="false"
+        data-testid="panel-quality"
+      >
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted min-w-[180px]">
+          <span class="uppercase tracking-wider text-[10px]">Quality</span>
+          <span class="flex items-center gap-2">
+            <input
+              type="range"
+              id="quality"
+              min="0"
+              max="100"
+              step="1"
+              value="85"
+              data-testid="quality-slider"
+              class="flex-1"
+            />
+            <output id="quality-out" data-testid="quality-out" class="w-8 text-right text-text">85</output>
+          </span>
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">Color path</span>
+          <select id="color-path" data-testid="color-path-select">
+            <option value="ycbcr" selected>YCbCr</option>
+            <option value="xyb">XYB</option>
+          </select>
+        </label>
+        <label
+          class="ctrl flex flex-col gap-1 text-xs text-muted"
+          data-controls-for="ycbcr"
+          id="subsampling-label"
+        >
+          <span class="uppercase tracking-wider text-[10px]">Subsampling</span>
+          <select id="subsampling" data-testid="subsampling-select">
+            <option value="none" selected>4:4:4 (none)</option>
+            <option value="halfHorizontal">4:2:2 (half horizontal)</option>
+            <option value="quarter">4:2:0 (quarter)</option>
+            <option value="halfVertical">4:4:0 (half vertical)</option>
+          </select>
+        </label>
+        <label
+          class="ctrl flex flex-col gap-1 text-xs text-muted"
+          data-controls-for="xyb"
+          id="xyb-subsampling-label"
+          hidden
+        >
+          <span class="uppercase tracking-wider text-[10px]">XYB B chroma</span>
+          <select id="xyb-subsampling" data-testid="xyb-subsampling-select">
+            <option value="full" selected>Full</option>
+            <option value="bQuarter">B Quarter</option>
+          </select>
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">
+            Sharp YUV
+            <span class="ignored-note ml-2" data-when="sharp-yuv-ignored"></span>
+          </span>
+          <span class="flex items-center gap-2">
+            <input type="checkbox" id="sharp-yuv" data-testid="sharp-yuv-checkbox" />
+            <span class="text-text">Gamma-aware downsample</span>
+          </span>
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">Pre-blur σ (px)</span>
+          <input
+            type="number"
+            id="pre-blur"
+            min="0"
+            max="3"
+            step="0.05"
+            value="0"
+            data-testid="pre-blur"
+            class="w-24"
+          />
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">Chroma distance scale</span>
+          <input
+            type="number"
+            id="chroma-dist-scale"
+            min="0.1"
+            max="10"
+            step="0.05"
+            value="1"
+            data-testid="chroma-dist-scale"
+            class="w-24"
+          />
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">Progressive scan</span>
+          <span class="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="progressive"
+              data-testid="progressive-checkbox"
+              checked
+            />
+            <span class="text-text">Multi-pass scans (smaller files at high q)</span>
+          </span>
+        </label>
+      </article>
+
+      <article
+        class="tab-panel flex flex-wrap gap-x-6 gap-y-3 px-6 py-4"
+        data-tab="aq"
+        aria-hidden="true"
+        data-testid="panel-aq"
+        hidden
+      >
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">Adaptive quantization</span>
+          <span class="flex items-center gap-2">
+            <input type="checkbox" id="aq-enabled" checked data-testid="aq-checkbox" />
+            <span class="text-text">Enable AQ</span>
+          </span>
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">Deringing</span>
+          <span class="flex items-center gap-2">
+            <input type="checkbox" id="deringing" checked data-testid="deringing-checkbox" />
+            <span class="text-text">Enable</span>
+          </span>
+        </label>
+        <fieldset
+          class="border border-line rounded px-3 py-2 flex flex-col gap-1 m-0"
+          data-testid="mode-radio-group"
+        >
+          <legend class="px-1 text-[10px] uppercase tracking-wider text-muted">
+            Encoder mode
+          </legend>
+          <label class="flex items-center gap-2 text-xs text-text">
+            <input type="radio" name="mode" value="baseline" checked data-testid="mode-baseline" />
+            Adaptive Quantization
+            <span class="text-muted text-[10px]">(per-block AQ multiplier; no trellis RD)</span>
+          </label>
+          <label class="flex items-center gap-2 text-xs text-text">
+            <input type="radio" name="mode" value="trellis" data-testid="mode-trellis" />
+            Trellis <span class="text-muted text-[10px]">(explicit RD optimization)</span>
+          </label>
+          <label class="flex items-center gap-2 text-xs text-text">
+            <input type="radio" name="mode" value="hybrid" data-testid="mode-hybrid" />
+            Hybrid <span class="text-muted text-[10px]">(AQ-aware trellis)</span>
+          </label>
+        </fieldset>
+      </article>
+
+      <article
+        class="tab-panel flex flex-wrap gap-x-6 gap-y-3 px-6 py-4"
+        data-tab="trellis"
+        aria-hidden="true"
+        data-testid="panel-trellis"
+        hidden
+      >
+        <p class="ignored-note basis-full" data-when="trellis-ignored">
+          Trellis applies only when <strong>Mode = Trellis</strong>.
+          Pick it on the AQ &amp; Mode tab.
+        </p>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">DC trellis</span>
+          <span class="flex items-center gap-2">
+            <input type="checkbox" id="trellis-dc" data-testid="trellis-dc-checkbox" />
+            <span class="text-text">Enable DC trellis</span>
+          </span>
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">λ log-scale 1 (rate)</span>
+          <input
+            type="number"
+            id="trellis-lambda1"
+            min="0"
+            max="40"
+            step="0.05"
+            value="14.75"
+            data-testid="trellis-lambda1"
+            class="w-24"
+          />
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">λ log-scale 2 (distortion)</span>
+          <input
+            type="number"
+            id="trellis-lambda2"
+            min="0"
+            max="40"
+            step="0.05"
+            value="16.5"
+            data-testid="trellis-lambda2"
+            class="w-24"
+          />
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">Speed</span>
+          <select id="trellis-speed" data-testid="trellis-speed-select">
+            <option value="thorough">Thorough</option>
+            <option value="balanced" selected>Balanced (adaptive)</option>
+            <option value="fast">Fast (level 8)</option>
+          </select>
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">ΔDC weight</span>
+          <input
+            type="number"
+            id="trellis-delta-dc"
+            min="0"
+            max="10"
+            step="0.05"
+            value="0"
+            data-testid="trellis-delta-dc"
+            class="w-24"
+          />
+        </label>
+      </article>
+
+      <article
+        class="tab-panel flex flex-wrap gap-x-6 gap-y-3 px-6 py-4"
+        data-tab="hybrid"
+        aria-hidden="true"
+        data-testid="panel-hybrid"
+        hidden
+      >
+        <p class="ignored-note basis-full" data-when="hybrid-ignored">
+          Hybrid applies only when <strong>Mode = Hybrid</strong>.
+          Pick it on the AQ &amp; Mode tab.
+        </p>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">AQ → λ scale</span>
+          <input
+            type="number"
+            id="hybrid-aq-lambda-scale"
+            min="0"
+            max="10"
+            step="0.05"
+            value="2"
+            data-testid="hybrid-aq-lambda-scale"
+            class="w-24"
+          />
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">Base λ scale 1</span>
+          <input
+            type="number"
+            id="hybrid-base-lambda1"
+            min="0"
+            max="40"
+            step="0.05"
+            value="14.75"
+            data-testid="hybrid-base-lambda1"
+            class="w-24"
+          />
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">Base λ scale 2</span>
+          <input
+            type="number"
+            id="hybrid-base-lambda2"
+            min="0"
+            max="40"
+            step="0.05"
+            value="16.5"
+            data-testid="hybrid-base-lambda2"
+            class="w-24"
+          />
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">DC trellis (hybrid)</span>
+          <span class="flex items-center gap-2">
+            <input type="checkbox" id="hybrid-dc" data-testid="hybrid-dc-checkbox" />
+            <span class="text-text">Enable</span>
+          </span>
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">AQ exponent</span>
+          <input
+            type="number"
+            id="hybrid-aq-exp"
+            min="0"
+            max="3"
+            step="0.05"
+            value="1"
+            data-testid="hybrid-aq-exp"
+            class="w-24"
+          />
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">AQ threshold</span>
+          <input
+            type="number"
+            id="hybrid-aq-threshold"
+            min="0"
+            max="3"
+            step="0.05"
+            value="0"
+            data-testid="hybrid-aq-threshold"
+            class="w-24"
+          />
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">Quality-adaptive λ</span>
+          <span class="flex items-center gap-2">
+            <input type="checkbox" id="hybrid-q-adapt" checked data-testid="hybrid-q-adapt-checkbox" />
+            <span class="text-text">Enable</span>
+          </span>
+        </label>
+      </article>
+
+      <article
+        class="tab-panel flex flex-col gap-3 px-6 py-4"
+        data-tab="quant"
+        aria-hidden="true"
+        data-testid="panel-quant"
+        hidden
+      >
+        <div class="flex flex-col gap-1">
+          <p class="text-xs text-muted m-0">
+            Per-component <strong>f32</strong> quant tables (encoder
+            uses these as final values when custom tables are present
+            — <code>ScalingParams::Exact</code>). The 8-band sliders
+            (h_eq, v_eq) drive a separable multiplier; curve presets
+            jump to common shapes; click any cell to edit the float
+            directly. Values are sent as
+            <code>customQuantTables</code>.
+          </p>
+          <p
+            class="text-xs m-0"
+            id="quant-mode-banner"
+            data-testid="quant-mode-banner"
+          ></p>
+        </div>
+        <div class="flex flex-wrap gap-x-6 gap-y-3 items-end">
+          <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+            <span class="uppercase tracking-wider text-[10px]">
+              Q-scale (uniform) <output id="curve-qscale-out">1.00</output>
+            </span>
+            <input
+              type="range"
+              id="curve-qscale"
+              min="0.25"
+              max="4"
+              step="0.05"
+              value="1"
+              data-testid="curve-qscale"
+            />
+          </label>
+          <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+            <span class="uppercase tracking-wider text-[10px]">
+              Frequency tilt (HF emphasis) <output id="curve-tilt-out">+0.00</output>
+            </span>
+            <input
+              type="range"
+              id="curve-tilt"
+              min="-1"
+              max="1"
+              step="0.02"
+              value="0"
+              data-testid="curve-tilt"
+            />
+          </label>
+          <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+            <span class="uppercase tracking-wider text-[10px]">
+              H/V emphasis (H − V) <output id="curve-hv-out">+0.00</output>
+            </span>
+            <input
+              type="range"
+              id="curve-hv"
+              min="-1"
+              max="1"
+              step="0.02"
+              value="0"
+              data-testid="curve-hv"
+            />
+          </label>
+          <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+            <span class="uppercase tracking-wider text-[10px]">Preset</span>
+            <select id="curve-preset" data-testid="curve-preset">
+              <option value="jfif" selected>JFIF default</option>
+              <option value="hf-boost">HF-boost</option>
+              <option value="lf-keep">LF-keep</option>
+              <option value="flat">Flat</option>
+            </select>
+          </label>
+          <button
+            id="curve-reset"
+            type="button"
+            data-testid="curve-reset-all"
+            class="px-3 py-1.5 text-xs font-semibold rounded bg-panel-2 text-text border border-line hover:bg-bg"
+          >
+            Reset all components
+          </button>
+        </div>
+
+        <!-- Zero-bias controls (separate from quant tables — these are
+             the per-frequency dead-zone parameters and the per-component
+             DC/AC offsets that control rounding behavior near zero). -->
+        <details class="border border-line rounded p-3 bg-panel-2" open>
+          <summary class="text-xs font-semibold text-accent cursor-pointer">
+            Zero-bias (dead-zone) parameters
+          </summary>
+          <p class="text-xs text-muted mt-2 mb-2">
+            Coefficient with abs value below
+            <code>zero_bias_mul[k] · quant[k]</code> snaps to zero.
+            Higher mul = more aggressive zeroing. DC/AC offsets shift
+            the dead-zone center.
+          </p>
+          <div class="grid grid-cols-3 gap-3">
+            <div class="flex flex-col gap-2">
+              <span class="text-[10px] uppercase tracking-wider text-muted">Y / X</span>
+              <label class="text-xs text-muted flex flex-col gap-1">
+                Global mul
+                <span class="flex items-center gap-2">
+                  <input
+                    type="range"
+                    id="zb-mul-0"
+                    min="0.0"
+                    max="3.0"
+                    step="0.05"
+                    value="1"
+                    data-testid="zb-mul-0"
+                    class="flex-1"
+                  />
+                  <output id="zb-mul-0-out" class="text-text">1.00</output>
+                </span>
+              </label>
+              <label class="text-xs text-muted flex items-center gap-2">
+                DC offset
+                <input
+                  type="number"
+                  id="zb-dc-0"
+                  min="-1"
+                  max="1"
+                  step="0.01"
+                  value="0"
+                  data-testid="zb-dc-0"
+                  class="w-20"
+                />
+              </label>
+              <label class="text-xs text-muted flex items-center gap-2">
+                AC offset
+                <input
+                  type="number"
+                  id="zb-ac-0"
+                  min="-1"
+                  max="1"
+                  step="0.01"
+                  value="0"
+                  data-testid="zb-ac-0"
+                  class="w-20"
+                />
+              </label>
             </div>
-            <div class="utilization">
-              <h3>Coefficient utilization</h3>
-              <canvas
-                data-testid="comp-0-utilization"
-                class="utilization-canvas"
-              ></canvas>
-              <p class="legend">
-                Mean |coef_pre_quant| / effective_quant per coefficient
-                position (natural order; DC top-left).
-              </p>
+            <div class="flex flex-col gap-2">
+              <span class="text-[10px] uppercase tracking-wider text-muted">Cb / Y-XYB</span>
+              <label class="text-xs text-muted flex flex-col gap-1">
+                Global mul
+                <span class="flex items-center gap-2">
+                  <input
+                    type="range"
+                    id="zb-mul-1"
+                    min="0.0"
+                    max="3.0"
+                    step="0.05"
+                    value="1"
+                    data-testid="zb-mul-1"
+                    class="flex-1"
+                  />
+                  <output id="zb-mul-1-out" class="text-text">1.00</output>
+                </span>
+              </label>
+              <label class="text-xs text-muted flex items-center gap-2">
+                DC offset
+                <input
+                  type="number"
+                  id="zb-dc-1"
+                  min="-1"
+                  max="1"
+                  step="0.01"
+                  value="0"
+                  data-testid="zb-dc-1"
+                  class="w-20"
+                />
+              </label>
+              <label class="text-xs text-muted flex items-center gap-2">
+                AC offset
+                <input
+                  type="number"
+                  id="zb-ac-1"
+                  min="-1"
+                  max="1"
+                  step="0.01"
+                  value="0"
+                  data-testid="zb-ac-1"
+                  class="w-20"
+                />
+              </label>
             </div>
-            <div class="estimate">
-              <h3>Byte budget</h3>
-              <p>
-                <span data-testid="comp-0-zero-rate">--</span>%
-                of coefs zero out at this table.
-              </p>
-              <p class="legend">
-                Re-applying the user-adjusted table to this component's
-                pre-quant coefficients. Updates live as you drag.
-              </p>
+            <div class="flex flex-col gap-2">
+              <span class="text-[10px] uppercase tracking-wider text-muted">Cr / B</span>
+              <label class="text-xs text-muted flex flex-col gap-1">
+                Global mul
+                <span class="flex items-center gap-2">
+                  <input
+                    type="range"
+                    id="zb-mul-2"
+                    min="0.0"
+                    max="3.0"
+                    step="0.05"
+                    value="1"
+                    data-testid="zb-mul-2"
+                    class="flex-1"
+                  />
+                  <output id="zb-mul-2-out" class="text-text">1.00</output>
+                </span>
+              </label>
+              <label class="text-xs text-muted flex items-center gap-2">
+                DC offset
+                <input
+                  type="number"
+                  id="zb-dc-2"
+                  min="-1"
+                  max="1"
+                  step="0.01"
+                  value="0"
+                  data-testid="zb-dc-2"
+                  class="w-20"
+                />
+              </label>
+              <label class="text-xs text-muted flex items-center gap-2">
+                AC offset
+                <input
+                  type="number"
+                  id="zb-ac-2"
+                  min="-1"
+                  max="1"
+                  step="0.01"
+                  value="0"
+                  data-testid="zb-ac-2"
+                  class="w-20"
+                />
+              </label>
             </div>
           </div>
-        </article>
-      </section>
-    </main>
+          <button
+            id="zb-reset"
+            type="button"
+            data-testid="zb-reset"
+            class="mt-2 px-3 py-1 text-xs rounded bg-panel border border-line text-muted hover:text-text"
+          >
+            Reset zero-bias to defaults
+          </button>
+        </details>
+
+        <!-- Per-component editors -->
+        <div class="component-grid flex flex-col gap-4">
+          <article
+            class="component bg-panel-2 border border-line rounded p-3"
+            data-component="0"
+            id="component-0"
+          >
+            <header class="flex items-baseline gap-3 mb-2">
+              <h2 class="text-sm m-0 text-accent font-semibold">
+                Component 0 (Y/X)
+              </h2>
+              <p
+                class="m-0 text-xs text-muted font-mono"
+                data-testid="comp-0-grid-info"
+              ></p>
+            </header>
+            <div
+              class="grid gap-6 items-start"
+              style="grid-template-columns: minmax(280px, 1fr) minmax(220px, 1fr) minmax(200px, 1fr)"
+            >
+              <div class="grid grid-cols-[auto_auto] gap-1 items-center">
+                <h3 class="col-span-2 text-xs m-0 text-text font-semibold">
+                  Quant table (base × h_eq × v_eq, click to edit)
+                </h3>
+                <div class="quant-grid" data-testid="comp-0-quant-grid"></div>
+                <div class="flex flex-col items-center gap-1">
+                  <span class="text-[11px] text-muted font-mono">v_eq</span>
+                  <div class="eq-sliders vertical" data-testid="comp-0-v-eq"></div>
+                </div>
+                <div class="flex items-center gap-1 col-start-1">
+                  <span class="text-[11px] text-muted font-mono">h_eq</span>
+                  <div class="eq-sliders horizontal" data-testid="comp-0-h-eq"></div>
+                </div>
+                <button
+                  type="button"
+                  data-testid="comp-0-reset-eq"
+                  class="col-start-1 mt-1 px-2 py-1 text-[11px] rounded border border-line bg-panel hover:bg-bg justify-self-start"
+                >
+                  Reset EQ
+                </button>
+              </div>
+              <div>
+                <h3 class="text-xs m-0 mb-1 text-text font-semibold">
+                  Coefficient utilization
+                </h3>
+                <canvas
+                  data-testid="comp-0-utilization"
+                  class="block w-[200px] h-[200px] bg-black rounded"
+                ></canvas>
+                <p class="m-0 mt-1 text-xs text-muted">
+                  Mean |coef_pre_quant| / effective_quant per coefficient
+                  position (natural order; DC top-left).
+                </p>
+              </div>
+              <div>
+                <h3 class="text-xs m-0 mb-1 text-text font-semibold">
+                  Byte budget
+                </h3>
+                <p class="m-0 text-sm font-mono">
+                  <span data-testid="comp-0-zero-rate">--</span>%
+                  <span class="text-muted">of coefs zero out</span>
+                </p>
+                <p class="m-0 mt-2 text-xs text-muted">
+                  Re-applying the user-adjusted table to this
+                  component's pre-quant coefficients. Updates live as
+                  you drag.
+                </p>
+              </div>
+            </div>
+          </article>
+        </div>
+      </article>
+
+      <article
+        class="tab-panel flex flex-wrap gap-x-6 gap-y-3 px-6 py-4"
+        data-tab="misc"
+        aria-hidden="true"
+        data-testid="panel-misc"
+        hidden
+      >
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">Optimize Huffman tables</span>
+          <span class="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="optimize-huffman"
+              checked
+              data-testid="optimize-huffman-checkbox"
+            />
+            <span class="text-text">Enable</span>
+          </span>
+        </label>
+        <label class="ctrl flex flex-col gap-1 text-xs text-muted">
+          <span class="uppercase tracking-wider text-[10px]">Restart MCU rows</span>
+          <input
+            type="number"
+            id="restart-mcu-rows"
+            min="0"
+            max="65535"
+            step="1"
+            value="0"
+            data-testid="restart-mcu-rows"
+            class="w-24"
+          />
+          <span class="text-[10px] text-muted">0 disables restart markers</span>
+        </label>
+      </article>
+    </section>
 
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/zenjpeg-diagnostics-viewer/web/package-lock.json
+++ b/zenjpeg-diagnostics-viewer/web/package-lock.json
@@ -1,0 +1,1066 @@
+{
+  "name": "zenjpeg-diagnostics-viewer",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zenjpeg-diagnostics-viewer",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.48.0",
+        "typescript": "^5.6.0",
+        "vite": "^5.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    }
+  }
+}

--- a/zenjpeg-diagnostics-viewer/web/package-lock.json
+++ b/zenjpeg-diagnostics-viewer/web/package-lock.json
@@ -9,8 +9,23 @@
       "version": "0.1.0",
       "devDependencies": {
         "@playwright/test": "^1.48.0",
+        "@tailwindcss/vite": "^4.2.4",
+        "sharp": "^0.34.5",
+        "tailwindcss": "^4.2.4",
+        "tsx": "^4.19.0",
         "typescript": "^5.6.0",
         "vite": "^5.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -302,6 +317,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -319,6 +351,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -334,6 +383,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -402,6 +468,546 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@playwright/test": {
@@ -770,12 +1376,308 @@
         "win32"
       ]
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
+      "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
+        "tailwindcss": "4.2.4"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -829,6 +1731,307 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/nanoid": {
@@ -918,6 +2121,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
@@ -963,6 +2176,64 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -971,6 +2242,503 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/typescript": {
@@ -993,6 +2761,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/zenjpeg-diagnostics-viewer/web/package.json
+++ b/zenjpeg-diagnostics-viewer/web/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "zenjpeg-diagnostics-viewer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 3173",
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0",
+    "typescript": "^5.6.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/zenjpeg-diagnostics-viewer/web/package.json
+++ b/zenjpeg-diagnostics-viewer/web/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "fetch-images": "tsx scripts/fetch-images.ts",
+    "predev": "npm run fetch-images",
+    "prebuild": "npm run fetch-images",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --port 3173",
@@ -11,6 +14,10 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.48.0",
+    "@tailwindcss/vite": "^4.2.4",
+    "sharp": "^0.34.5",
+    "tailwindcss": "^4.2.4",
+    "tsx": "^4.19.0",
     "typescript": "^5.6.0",
     "vite": "^5.4.0"
   }

--- a/zenjpeg-diagnostics-viewer/web/playwright.config.ts
+++ b/zenjpeg-diagnostics-viewer/web/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://localhost:3173",
+    trace: "retain-on-failure",
+  },
+  // Per-test timeout: WASM compile + first encode in headless chromium
+  // can take 20+ seconds in WSL2 / GitHub Actions runners. 90s gives
+  // headroom; the suite still completes in well under five minutes.
+  timeout: 90_000,
+  expect: {
+    timeout: 45_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    // Build then preview — gives us the wasm-bundled output served as
+    // ESM, exactly like a real deployment. Preview is faster than dev
+    // for CI and avoids HMR noise. We reuse any existing dev preview
+    // (so a manually-started `vite preview --port 3173` is fine);
+    // outside CI this avoids the build cost on every test invocation.
+    command: "npx vite build && npx vite preview --port 3173 --strictPort",
+    url: "http://localhost:3173",
+    reuseExistingServer: true,
+    timeout: 180_000,
+  },
+});

--- a/zenjpeg-diagnostics-viewer/web/scripts/fetch-images.ts
+++ b/zenjpeg-diagnostics-viewer/web/scripts/fetch-images.ts
@@ -1,0 +1,336 @@
+// Build-time image fetch + wash hook.
+//
+// Downloads the diagnostics-viewer demo corpus from a Cloudflare R2 (or
+// any HTTP) endpoint into `public/images/`, then writes a
+// `manifest.json` the runtime reads at boot.
+//
+// Two URL conventions per entry:
+//   1. Content-addressed: entry has `sha256`. Path is
+//      `<base>/blobs/<sha[0:2]>/<sha[2:4]>/<sha>`.
+//   2. Path-addressed: entry has `file`. Path is `<base>/<file>`.
+//
+// Wash step (CRITICAL for diagnostics integrity):
+//   When `wasJpeg: true`, the source image is decoded and 8×
+//   downsampled with sharp's lanczos3 kernel before being re-encoded
+//   as PNG. This eliminates any 8×8 DCT block artifacts inherited
+//   from a JPEG → PNG conversion in the source corpus, so the encoded
+//   side of the diagnostics is measuring our encoder, not someone
+//   else's. Lanczos3 is the right kernel here — Mitchell-Netravali
+//   is gentler but leaves more residual ringing; lanczos3 is sharper
+//   with controlled overshoot. See:
+//     ~/work/claudehints/topics/rust-defaults.md  ("principled kernel")
+//
+// The post-wash file is named `<sha>-w8.png` so the original blob can
+// also be cached separately if desired (the runtime never needs the
+// raw blob — it always reads the washed PNG via the manifest).
+//
+// Configuration env:
+//   DIAGNOSTICS_VIEWER_IMAGE_BASE
+//     base URL prefix (no trailing slash). Defaults to the source
+//     manifest's `defaultBase`, then a baked-in codec-corpus URL.
+//   DIAGNOSTICS_VIEWER_IMAGE_LIST
+//     path to the source manifest. Defaults to ./scripts/image-list.json.
+//   DIAGNOSTICS_VIEWER_OFFLINE
+//     "1" to skip network entirely; reuse existing local files.
+//
+// Run as `npm run prebuild` or `tsx scripts/fetch-images.ts`. The
+// only runtime deps are sharp (for the wash step) and Node's
+// built-in fetch.
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import sharp from "sharp";
+
+interface SourceEntry {
+  id: string;
+  label: string;
+  /** Optional content-addressed sha256 hex. */
+  sha256?: string;
+  /** File extension to use for the raw cached copy. */
+  ext?: string;
+  /** Plain relative URL fragment (alternative to `sha256`). */
+  file?: string;
+  /** When true, decode + 8× lanczos3 downscale + re-encode as PNG.
+   *  Use for sources that may have come from JPEG (the codec-corpus
+   *  doesn't track provenance, so its `corpus/png-24-32` PNGs are
+   *  conservatively flagged). */
+  wasJpeg?: boolean;
+}
+
+interface SourceManifest {
+  defaultBase?: string;
+  images: SourceEntry[];
+}
+
+interface RuntimeEntry {
+  id: string;
+  label: string;
+  url: string;
+  /** Post-wash dimensions, included in the manifest so the runtime
+   *  can size its UI without decoding. */
+  width: number;
+  height: number;
+  /** True when the served file is the post-wash PNG (vs the raw
+   *  blob). The runtime uses this for status-line annotation. */
+  washed: boolean;
+}
+
+const FALLBACK_DEFAULT_BASE =
+  "https://pub-7c5c57fd3e0842f0b147946928891d40.r2.dev";
+
+const here = dirname(new URL(import.meta.url).pathname);
+const webRoot = resolve(here, "..");
+const targetDir = resolve(webRoot, "public", "images");
+const manifestSrc = resolve(
+  process.env.DIAGNOSTICS_VIEWER_IMAGE_LIST ??
+    resolve(here, "image-list.json"),
+);
+const manifestOut = resolve(targetDir, "manifest.json");
+const offline = process.env.DIAGNOSTICS_VIEWER_OFFLINE === "1";
+
+function readSource(): SourceManifest {
+  if (!existsSync(manifestSrc)) {
+    console.warn(
+      `[fetch-images] no source manifest at ${manifestSrc}; nothing to fetch`,
+    );
+    return { images: [] };
+  }
+  const raw = readFileSync(manifestSrc, "utf8");
+  try {
+    const data = JSON.parse(raw) as SourceManifest;
+    if (!Array.isArray(data.images)) {
+      console.warn("[fetch-images] manifest source missing `images` array");
+      return { images: [] };
+    }
+    return data;
+  } catch (e) {
+    console.warn(`[fetch-images] failed to parse ${manifestSrc}:`, e);
+    return { images: [] };
+  }
+}
+
+function sha256Hex(buf: Uint8Array): string {
+  const h = createHash("sha256");
+  h.update(buf);
+  return h.digest("hex");
+}
+
+interface BlobAddr {
+  /** URL path component, joined onto base with a slash. */
+  pathFragment: string;
+  /** Raw-blob filename. */
+  rawName: string;
+  /** Final served filename (raw or post-wash, depending on wasJpeg). */
+  servedName: string;
+}
+
+function deriveAddr(entry: SourceEntry): BlobAddr | null {
+  if (entry.sha256) {
+    const sha = entry.sha256.toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(sha)) {
+      console.warn(`[fetch-images] invalid sha256 for ${entry.id}: ${sha}`);
+      return null;
+    }
+    const ext = entry.ext ?? "bin";
+    const rawName = `${sha}.${ext}`;
+    const servedName = entry.wasJpeg ? `${sha}-w8.png` : rawName;
+    return {
+      pathFragment: `blobs/${sha.slice(0, 2)}/${sha.slice(2, 4)}/${sha}`,
+      rawName,
+      servedName,
+    };
+  }
+  if (entry.file) {
+    const sansExt = entry.file.replace(/\.[^./]+$/, "");
+    const rawName = entry.file;
+    const servedName = entry.wasJpeg ? `${sansExt}-w8.png` : entry.file;
+    return {
+      pathFragment: entry.file,
+      rawName,
+      servedName,
+    };
+  }
+  console.warn(
+    `[fetch-images] entry ${entry.id} has neither sha256 nor file; skipping`,
+  );
+  return null;
+}
+
+async function washToPng(
+  rawPath: string,
+  outPath: string,
+): Promise<{ width: number; height: number }> {
+  // 8× downscale via sharp lanczos3, written as PNG. sharp accepts
+  // the source format directly (PNG/JPEG/WebP/AVIF/etc.) and the
+  // resize() default kernel is lanczos3. The PNG output is lossless
+  // (compressionLevel default 6 is fine — these are <2MB demo blobs).
+  const meta = await sharp(rawPath).metadata();
+  const w0 = meta.width ?? 0;
+  const h0 = meta.height ?? 0;
+  if (w0 === 0 || h0 === 0) {
+    throw new Error(`sharp could not read dimensions of ${rawPath}`);
+  }
+  const w = Math.max(8, Math.floor(w0 / 8));
+  const h = Math.max(8, Math.floor(h0 / 8));
+  await sharp(rawPath)
+    .resize(w, h, { kernel: "lanczos3" })
+    .png({ compressionLevel: 9, palette: false })
+    .toFile(outPath);
+  return { width: w, height: h };
+}
+
+async function dimsOnly(path: string): Promise<{ width: number; height: number }> {
+  const meta = await sharp(path).metadata();
+  return { width: meta.width ?? 0, height: meta.height ?? 0 };
+}
+
+async function fetchOne(
+  entry: SourceEntry,
+  baseUrl: string,
+): Promise<RuntimeEntry | null> {
+  const addr = deriveAddr(entry);
+  if (!addr) return null;
+  const rawDest = resolve(targetDir, addr.rawName);
+  const servedDest = resolve(targetDir, addr.servedName);
+  const wasJpeg = !!entry.wasJpeg;
+
+  // Decide whether we need to download. The served file (washed or
+  // raw) is what the runtime consumes. For wash entries we keep the
+  // raw blob too so we can re-wash with a new kernel without
+  // re-downloading.
+  if (offline) {
+    if (!existsSync(servedDest)) {
+      console.warn(
+        `[fetch-images] offline + missing served file: ${addr.servedName}`,
+      );
+      return null;
+    }
+    const dims = await dimsOnly(servedDest);
+    return {
+      id: entry.id,
+      label: entry.label,
+      url: `./images/${addr.servedName}`,
+      width: dims.width,
+      height: dims.height,
+      washed: wasJpeg,
+    };
+  }
+  if (!baseUrl) {
+    if (existsSync(servedDest)) {
+      const dims = await dimsOnly(servedDest);
+      return {
+        id: entry.id,
+        label: entry.label,
+        url: `./images/${addr.servedName}`,
+        width: dims.width,
+        height: dims.height,
+        washed: wasJpeg,
+      };
+    }
+    console.warn(
+      `[fetch-images] no base URL and no local copy for ${entry.id}; skipping`,
+    );
+    return null;
+  }
+
+  // Reuse cached raw blob when sha matches (or no hash declared and
+  // we already have it on disk).
+  let needsDownload = true;
+  if (existsSync(rawDest)) {
+    if (!entry.sha256) {
+      needsDownload = false;
+    } else {
+      const have = readFileSync(rawDest);
+      if (sha256Hex(have) === entry.sha256.toLowerCase()) {
+        needsDownload = false;
+      } else {
+        console.log(
+          `[fetch-images] sha256 mismatch on cached ${addr.rawName}, re-downloading`,
+        );
+      }
+    }
+  }
+  if (needsDownload) {
+    const url = `${baseUrl}/${addr.pathFragment}`;
+    console.log(`[fetch-images] GET ${url}`);
+    const resp = await fetch(url);
+    if (!resp.ok) {
+      console.warn(`[fetch-images] ${url} → ${resp.status} ${resp.statusText}`);
+      return null;
+    }
+    const buf = new Uint8Array(await resp.arrayBuffer());
+    if (entry.sha256 && sha256Hex(buf) !== entry.sha256.toLowerCase()) {
+      console.warn(`[fetch-images] sha256 mismatch on download from ${url}`);
+      return null;
+    }
+    mkdirSync(dirname(rawDest), { recursive: true });
+    writeFileSync(rawDest, buf);
+  }
+
+  // Wash if needed (and the wash output isn't already on disk and fresh).
+  let dims: { width: number; height: number };
+  if (wasJpeg) {
+    const rawStat = needsDownload || !existsSync(servedDest);
+    if (rawStat) {
+      console.log(
+        `[fetch-images] washing ${addr.rawName} → ${addr.servedName} (8× lanczos3 → PNG)`,
+      );
+      dims = await washToPng(rawDest, servedDest);
+    } else {
+      dims = await dimsOnly(servedDest);
+    }
+  } else {
+    dims = await dimsOnly(rawDest);
+  }
+  return {
+    id: entry.id,
+    label: entry.label,
+    url: `./images/${addr.servedName}`,
+    width: dims.width,
+    height: dims.height,
+    washed: wasJpeg,
+  };
+}
+
+async function main(): Promise<void> {
+  mkdirSync(targetDir, { recursive: true });
+  const source = readSource();
+  if (source.images.length === 0) {
+    writeFileSync(manifestOut, JSON.stringify({ images: [] }, null, 2) + "\n");
+    console.log(`[fetch-images] wrote empty manifest at ${manifestOut}`);
+    return;
+  }
+  const baseUrl = (
+    process.env.DIAGNOSTICS_VIEWER_IMAGE_BASE ??
+    source.defaultBase ??
+    FALLBACK_DEFAULT_BASE
+  ).replace(/\/+$/, "");
+  console.log(`[fetch-images] base URL: ${baseUrl || "(none — offline)"}`);
+  const runtime: RuntimeEntry[] = [];
+  for (const entry of source.images) {
+    try {
+      const got = await fetchOne(entry, baseUrl);
+      if (got) runtime.push(got);
+    } catch (e) {
+      console.warn(`[fetch-images] error on ${entry.id}:`, e);
+    }
+  }
+  writeFileSync(
+    manifestOut,
+    JSON.stringify({ images: runtime }, null, 2) + "\n",
+  );
+  console.log(
+    `[fetch-images] wrote runtime manifest with ${runtime.length}/${source.images.length} entries at ${manifestOut}`,
+  );
+}
+
+main().catch((e) => {
+  console.error("[fetch-images] fatal:", e);
+  process.exitCode = 1;
+});

--- a/zenjpeg-diagnostics-viewer/web/scripts/image-list.json
+++ b/zenjpeg-diagnostics-viewer/web/scripts/image-list.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "Demo picker images, sourced from the imazen codec-corpus R2 bucket. PNG-only — JPEG/WebP demos cause generation-loss confusion (encoding a lossy source through a lossy codec hides where the artifacts actually came from). The codec-corpus's `corpus/png-24-32` label doesn't track provenance, so any of these may be PNG conversions of original JPEGs. We mark them all with `wasJpeg: true` and scripts/fetch-images.ts applies an 8× lanczos3 downscale at BUILD TIME via sharp (no browser-side resampling). The washed PNG is named <sha>-w8.png and the runtime reads it directly. 8× decimation eliminates the original 8×8 DCT block artifacts and ringing. Override per-entry by setting wasJpeg: false (e.g. for synthetic / RAW-derived sources where you trust the PNG is pixel-clean).",
+  "defaultBase": "https://pub-7c5c57fd3e0842f0b147946928891d40.r2.dev",
+  "images": [
+    {
+      "id": "png-4k-square",
+      "label": "Photo (PNG, 4219×4548 → 527×568 after 8× wash)",
+      "sha256": "0ca1248e164f04ae6fd9e24f45d232f89533c8dfba3eeadc64778a2e5f4519f3",
+      "ext": "png",
+      "wasJpeg": true
+    },
+    {
+      "id": "png-5k-square",
+      "label": "Photo (PNG, 4951×5014 → 619×627 after 8× wash)",
+      "sha256": "25a3473eddc8dcc8a20ce6a9880bb6cfee0f80e04a826cca07cae253afcf8f27",
+      "ext": "png",
+      "wasJpeg": true
+    },
+    {
+      "id": "png-4k-landscape",
+      "label": "Photo (PNG, 4000×2700 → 500×337 after 8× wash)",
+      "sha256": "403685d7adabe161b02529db9eb16c055f1820c9536014560abfe0e556b0e983",
+      "ext": "png",
+      "wasJpeg": true
+    },
+    {
+      "id": "png-2k-landscape",
+      "label": "Photo (PNG, 2038×2244 → 254×280 after 8× wash)",
+      "sha256": "0e6234204dd0d0fbc9b673a0250457d728ee27b4485cb7facb719d391da99bd4",
+      "ext": "png",
+      "wasJpeg": true
+    },
+    {
+      "id": "png-2k-square",
+      "label": "Photo (PNG, 2652×2582 → 332×322 after 8× wash)",
+      "sha256": "33c8ca08a529e40d6fe46842a2f6a2705911f275a94e4816cf47079ff6c52b50",
+      "ext": "png",
+      "wasJpeg": true
+    },
+    {
+      "id": "png-1700",
+      "label": "Photo (PNG, 1700×1133 → 212×142 after 8× wash)",
+      "sha256": "37c09d8426302e30f373c1b499d5a8e852cd3242538b4e53ca0c727bfcda2066",
+      "ext": "png",
+      "wasJpeg": true
+    }
+  ]
+}

--- a/zenjpeg-diagnostics-viewer/web/src/encode-worker.ts
+++ b/zenjpeg-diagnostics-viewer/web/src/encode-worker.ts
@@ -1,0 +1,162 @@
+// Web Worker: runs the wasm encode pipeline off the main thread.
+//
+// Protocol (postMessage in both directions):
+//
+//   Main → Worker:
+//     { kind: "encode",
+//       reqId: number,            // unique per request
+//       pixels: Uint8Array,       // packed RGB, length = w*h*3
+//       width: number,
+//       height: number,
+//       options: EncodeOptions }
+//
+//   Worker → Main:
+//     { kind: "ready" }                                      // after wasm init
+//     { kind: "result", reqId, bytes, diagnostics, ssim2, zensim, durationMs }
+//     { kind: "error",  reqId, message }
+//
+// The worker imports the wasm-pack module directly. Because Vite is
+// configured with `worker.format: "es"`, the worker module is loaded
+// as ES with native dynamic imports.
+//
+// Cancellation model: the worker doesn't currently honor mid-encode
+// cancellation (would require SharedArrayBuffer + COOP/COEP). Instead,
+// the main thread tracks the `latest reqId` and discards results that
+// don't match — see main.ts for the discard logic.
+
+import init, {
+  computeSsimulacra2,
+  computeZensim,
+  encodeWithDiagnostics,
+} from "../wasm-pkg/zenjpeg_diagnostics_wasm.js";
+import type { Diagnostics, EncodeOptions } from "./types";
+
+interface EncodeReq {
+  kind: "encode";
+  reqId: number;
+  pixels: Uint8Array;
+  width: number;
+  height: number;
+  options: EncodeOptions;
+  /** Decoded RGB of the *source* (not the JPEG output) for metric
+   *  scoring. Caller already has it on the main thread; passing it
+   *  in saves us from re-decoding inside the worker. */
+  sourceRgb: Uint8Array;
+  /** Whether to compute SSIMULACRA 2 + zensim after encode. Skipped
+   *  for the pareto-curve sweep where only bytes + score are needed
+   *  and we score in batch. */
+  scoreMetrics: boolean;
+}
+
+interface EncodeResultMsg {
+  kind: "result";
+  reqId: number;
+  bytes: Uint8Array;
+  diagnostics: Diagnostics;
+  ssim2: number | null;
+  zensim: number | null;
+  durationMs: number;
+}
+
+interface ErrorMsg {
+  kind: "error";
+  reqId: number;
+  message: string;
+}
+
+interface ReadyMsg {
+  kind: "ready";
+}
+
+let initPromise: Promise<unknown> | null = null;
+
+async function ensureInit(): Promise<void> {
+  if (!initPromise) {
+    initPromise = init();
+  }
+  await initPromise;
+}
+
+function postReady(): void {
+  const msg: ReadyMsg = { kind: "ready" };
+  (self as unknown as Worker).postMessage(msg);
+}
+
+function postError(reqId: number, message: string): void {
+  const msg: ErrorMsg = { kind: "error", reqId, message };
+  (self as unknown as Worker).postMessage(msg);
+}
+
+async function decodeJpegInWorker(
+  bytes: Uint8Array,
+  w: number,
+  h: number,
+): Promise<Uint8Array | null> {
+  // Workers have OffscreenCanvas + createImageBitmap, but image
+  // decoding via these is browser-implemented and we don't actually
+  // need the decoded bytes inside the worker — metric scoring uses
+  // the encoded JPEG decoded on the main thread (where we already
+  // have to draw it to a canvas anyway). Return null so the worker
+  // doesn't re-decode.
+  void bytes;
+  void w;
+  void h;
+  return null;
+}
+
+self.addEventListener("message", async (ev: MessageEvent) => {
+  const data = ev.data as EncodeReq;
+  if (!data || data.kind !== "encode") return;
+  const { reqId, pixels, width, height, options, sourceRgb, scoreMetrics } = data;
+  const t0 = performance.now();
+  try {
+    await ensureInit();
+    const result = (await encodeWithDiagnostics(
+      pixels,
+      width,
+      height,
+      options,
+    )) as { bytes: Uint8Array; diagnostics: Diagnostics };
+
+    let ssim2: number | null = null;
+    let zensim: number | null = null;
+    if (scoreMetrics) {
+      // We need the *decoded* JPEG bytes for scoring. The main thread
+      // does that decode (via <img>), but for the worker we can't
+      // easily get HTMLImageElement. Defer scoring to main thread.
+      // (See main.ts — it calls computeSsimulacra2 / computeZensim
+      //  on its own once the JPEG is decoded.)
+      void sourceRgb;
+      void decodeJpegInWorker;
+    }
+
+    const t1 = performance.now();
+    const msg: EncodeResultMsg = {
+      kind: "result",
+      reqId,
+      bytes: result.bytes,
+      diagnostics: result.diagnostics,
+      ssim2,
+      zensim,
+      durationMs: t1 - t0,
+    };
+    (self as unknown as Worker).postMessage(msg, [
+      result.bytes.buffer as ArrayBuffer,
+    ]);
+  } catch (e) {
+    postError(reqId, (e as Error)?.message ?? String(e));
+  }
+});
+
+// Bootstrap.
+ensureInit()
+  .then(() => postReady())
+  .catch((e) => postError(-1, (e as Error)?.message ?? String(e)));
+
+/// Score helpers for main-thread use after JPEG decode. Exporting these
+/// here so the main thread can call them via a separate worker
+/// instance (cheap because wasm init is cached). Not strictly needed —
+/// we re-export the wasm module's score fns from main.ts directly
+/// (kept synchronous in the main thread since metric compute is fast).
+export type { EncodeReq, EncodeResultMsg, ErrorMsg, ReadyMsg };
+export { computeSsimulacra2, computeZensim };

--- a/zenjpeg-diagnostics-viewer/web/src/heatmap.ts
+++ b/zenjpeg-diagnostics-viewer/web/src/heatmap.ts
@@ -1,0 +1,101 @@
+// Tiny dependency-free heatmap renderer. Maps a 2D scalar field onto a
+// canvas with a viridis-ish gradient and pixelated upscaling.
+
+export interface HeatmapOptions {
+  /** Width in cells (input data is row-major, length = w*h). */
+  cols: number;
+  rows: number;
+  /** Output canvas pixel size. */
+  pixelSize: number;
+  /** Optional explicit min/max; otherwise auto. */
+  min?: number;
+  max?: number;
+  /** Optional value formatter for accessible per-cell title. */
+  format?: (v: number) => string;
+}
+
+const STOPS: Array<[number, [number, number, number]]> = [
+  [0.0, [13, 8, 135]], // dark purple
+  [0.25, [84, 2, 163]],
+  [0.5, [156, 23, 158]],
+  [0.75, [225, 100, 98]],
+  [1.0, [253, 231, 37]], // bright yellow
+];
+
+function lerp(a: number, b: number, t: number) {
+  return a + (b - a) * t;
+}
+
+function viridis(t: number): [number, number, number] {
+  if (t <= 0) return STOPS[0]![1];
+  if (t >= 1) return STOPS[STOPS.length - 1]![1];
+  for (let i = 0; i < STOPS.length - 1; i++) {
+    const a = STOPS[i]!;
+    const b = STOPS[i + 1]!;
+    if (t >= a[0] && t <= b[0]) {
+      const tt = (t - a[0]) / (b[0] - a[0]);
+      return [
+        Math.round(lerp(a[1][0], b[1][0], tt)),
+        Math.round(lerp(a[1][1], b[1][1], tt)),
+        Math.round(lerp(a[1][2], b[1][2], tt)),
+      ];
+    }
+  }
+  return STOPS[STOPS.length - 1]![1];
+}
+
+export function drawHeatmap(
+  canvas: HTMLCanvasElement,
+  data: ArrayLike<number>,
+  opts: HeatmapOptions,
+): void {
+  const { cols, rows, pixelSize } = opts;
+  if (data.length !== cols * rows) {
+    throw new Error(
+      `heatmap data length ${data.length} ≠ cols×rows ${cols * rows}`,
+    );
+  }
+
+  let min = opts.min;
+  let max = opts.max;
+  if (min === undefined || max === undefined) {
+    let lo = Infinity;
+    let hi = -Infinity;
+    for (let i = 0; i < data.length; i++) {
+      const v = data[i]!;
+      if (Number.isFinite(v)) {
+        if (v < lo) lo = v;
+        if (v > hi) hi = v;
+      }
+    }
+    min ??= lo;
+    max ??= hi;
+  }
+  const span = max - min;
+
+  canvas.width = cols * pixelSize;
+  canvas.height = rows * pixelSize;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("canvas 2d context unavailable");
+  // Use ImageData for crisp per-cell colors.
+  const img = ctx.createImageData(cols * pixelSize, rows * pixelSize);
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const v = data[r * cols + c]!;
+      const t = span > 0 ? (v - min) / span : 0;
+      const [rr, gg, bb] = viridis(t);
+      for (let py = 0; py < pixelSize; py++) {
+        for (let px = 0; px < pixelSize; px++) {
+          const ox = c * pixelSize + px;
+          const oy = r * pixelSize + py;
+          const idx = (oy * cols * pixelSize + ox) * 4;
+          img.data[idx] = rr;
+          img.data[idx + 1] = gg;
+          img.data[idx + 2] = bb;
+          img.data[idx + 3] = 255;
+        }
+      }
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+}

--- a/zenjpeg-diagnostics-viewer/web/src/image-list.json
+++ b/zenjpeg-diagnostics-viewer/web/src/image-list.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "Demo picker images, sourced from the imazen codec-corpus R2 bucket. PNG-only — JPEG/WebP demos cause generation-loss confusion (encoding a lossy source through a lossy codec hides where the artifacts actually came from). The codec-corpus's `corpus/png-24-32` label doesn't track provenance, so any of these may be PNG conversions of original JPEGs. We mark them all with `wasJpeg: true` and scripts/fetch-images.ts applies an 8× lanczos3 downscale at BUILD TIME via sharp (no browser-side resampling). The washed PNG is named <sha>-w8.png and the runtime reads it directly. 8× decimation eliminates the original 8×8 DCT block artifacts and ringing. Override per-entry by setting wasJpeg: false (e.g. for synthetic / RAW-derived sources where you trust the PNG is pixel-clean).",
+  "defaultBase": "https://pub-7c5c57fd3e0842f0b147946928891d40.r2.dev",
+  "images": [
+    {
+      "id": "png-4k-square",
+      "label": "Photo (PNG, 4219×4548 → 527×568 after 8× wash)",
+      "sha256": "0ca1248e164f04ae6fd9e24f45d232f89533c8dfba3eeadc64778a2e5f4519f3",
+      "ext": "png",
+      "wasJpeg": true
+    },
+    {
+      "id": "png-5k-square",
+      "label": "Photo (PNG, 4951×5014 → 619×627 after 8× wash)",
+      "sha256": "25a3473eddc8dcc8a20ce6a9880bb6cfee0f80e04a826cca07cae253afcf8f27",
+      "ext": "png",
+      "wasJpeg": true
+    },
+    {
+      "id": "png-4k-landscape",
+      "label": "Photo (PNG, 4000×2700 → 500×337 after 8× wash)",
+      "sha256": "403685d7adabe161b02529db9eb16c055f1820c9536014560abfe0e556b0e983",
+      "ext": "png",
+      "wasJpeg": true
+    },
+    {
+      "id": "png-2k-landscape",
+      "label": "Photo (PNG, 2038×2244 → 254×280 after 8× wash)",
+      "sha256": "0e6234204dd0d0fbc9b673a0250457d728ee27b4485cb7facb719d391da99bd4",
+      "ext": "png",
+      "wasJpeg": true
+    },
+    {
+      "id": "png-2k-square",
+      "label": "Photo (PNG, 2652×2582 → 332×322 after 8× wash)",
+      "sha256": "33c8ca08a529e40d6fe46842a2f6a2705911f275a94e4816cf47079ff6c52b50",
+      "ext": "png",
+      "wasJpeg": true
+    },
+    {
+      "id": "png-1700",
+      "label": "Photo (PNG, 1700×1133 → 212×142 after 8× wash)",
+      "sha256": "37c09d8426302e30f373c1b499d5a8e852cd3242538b4e53ca0c727bfcda2066",
+      "ext": "png",
+      "wasJpeg": true
+    }
+  ]
+}

--- a/zenjpeg-diagnostics-viewer/web/src/main.ts
+++ b/zenjpeg-diagnostics-viewer/web/src/main.ts
@@ -1,33 +1,82 @@
-// Entry point for the zenjpeg encode-diagnostics demo viewer.
+// Diagnostics viewer entry point.
 //
-// Flow:
-//   1. Load the wasm-pack module.
-//   2. Render synthetic source pattern (or load user file).
-//   3. Call encodeWithDiagnostics with the current control state.
-//   4. Decode the encoded bytes via the browser's <img> for display.
-//   5. Render diagnostics: AQ map, per-component utilization heatmap,
-//      live re-quant on EQ slider drag.
+// Architecture:
+// - Wasm runs in a Web Worker. Main thread stays responsive.
+// - Each encode is tagged with a unique `reqId`. When a result arrives
+//   from the worker, we discard it if it isn't the latest request.
+//   That's our "cancellation" — we don't actually preempt the worker
+//   (would require SharedArrayBuffer + COOP/COEP) but stale results
+//   are dropped, which is the UX we want for slider-driven re-encodes.
+// - Auto-encode toggle + 250 ms debounce: any control change schedules
+//   a re-encode after the slider settles.
+// - Per-component EQ sliders + cell overrides persist across encodes.
+//   They serialize into `customQuantTables` whenever any value diverges
+//   from the source-derived defaults.
 //
-// All UI state lives in module-level mutable refs; this is a small
-// vanilla TS app — no framework, no virtual DOM.
+// The metric scoring (SSIMULACRA 2 + zensim) runs on the main thread
+// after the encoded JPEG is decoded back to RGBA — saves us from
+// shipping the source pixels into the worker just for scoring.
 
-import init, { encodeWithDiagnostics } from "../wasm-pkg/zenjpeg_diagnostics_wasm.js";
+import init, {
+  computeSsimulacra2,
+  computeZensim,
+} from "../wasm-pkg/zenjpeg_diagnostics_wasm.js";
 import { drawHeatmap } from "./heatmap";
 import { syntheticPattern } from "./synthetic";
+import bundledImageList from "./image-list.json";
 import type {
   ComponentDiagnostics,
+  CustomQuantTables,
   Diagnostics,
+  EncodeMode,
   EncodeOptions,
-  EncodeResult,
+  TrellisSpeed,
 } from "./types";
+import type {
+  EncodeReq,
+  EncodeResultMsg,
+  ErrorMsg,
+  ReadyMsg,
+} from "./encode-worker";
 
+// ─── DOM helpers ──────────────────────────────────────────────────
 const $ = <T extends HTMLElement>(sel: string): T => {
   const el = document.querySelector(sel);
   if (!el) throw new Error(`element not found: ${sel}`);
   return el as T;
 };
 
+// Status / actions
 const status = $<HTMLParagraphElement>("#status");
+const autoEncodeIn = $<HTMLInputElement>("#auto-encode");
+const encodeBtn = $<HTMLButtonElement>("#encode");
+const cancelBtn = $<HTMLButtonElement>("#cancel");
+// Image bar
+const fileIn = $<HTMLInputElement>("#image-input");
+const imagePickSel = $<HTMLSelectElement>("#image-pick");
+const imageInfoEl = $<HTMLElement>("#image-info");
+const resetBtn = $<HTMLButtonElement>("#reset");
+// Big readout
+const mBytes = $<HTMLElement>("#m-bytes");
+const mBpp = $<HTMLElement>("#m-bpp");
+const mMode = $<HTMLElement>("#m-mode");
+const mModeDetail = $<HTMLElement>("#m-mode-detail");
+const mSsim2 = $<HTMLElement>("#m-ssim2");
+const mZensim = $<HTMLElement>("#m-zensim");
+const mPareto = $<HTMLElement>("#m-pareto");
+const mTime = $<HTMLElement>("#m-time");
+// Canvases
+const sourceCanvas = $<HTMLCanvasElement>("#source-canvas");
+const encodedCanvas = $<HTMLCanvasElement>("#encoded-canvas");
+const deltaCanvas = $<HTMLCanvasElement>("#delta-canvas");
+const aqCanvas = $<HTMLCanvasElement>("#aq-canvas");
+const rdCanvas = $<HTMLCanvasElement>("#rd-canvas");
+// AQ stats
+const aqMinEl = $<HTMLElement>("#aq-min");
+const aqMaxEl = $<HTMLElement>("#aq-max");
+const aqMeanEl = $<HTMLElement>("#aq-mean");
+const aqChannelEl = $<HTMLElement>("#aq-channel");
+// Encoder controls
 const qualityIn = $<HTMLInputElement>("#quality");
 const qualityOut = $<HTMLOutputElement>("#quality-out");
 const colorPathSel = $<HTMLSelectElement>("#color-path");
@@ -36,43 +85,252 @@ const xybSubSel = $<HTMLSelectElement>("#xyb-subsampling");
 const subLabel = $<HTMLLabelElement>("#subsampling-label");
 const xybLabel = $<HTMLLabelElement>("#xyb-subsampling-label");
 const aqIn = $<HTMLInputElement>("#aq-enabled");
-const trellisIn = $<HTMLInputElement>("#trellis");
-const autoOptIn = $<HTMLInputElement>("#auto-optimize");
-const fileIn = $<HTMLInputElement>("#image-input");
-const resetBtn = $<HTMLButtonElement>("#reset");
-const encodeBtn = $<HTMLButtonElement>("#encode");
-const sourceCanvas = $<HTMLCanvasElement>("#source-canvas");
-const encodedCanvas = $<HTMLCanvasElement>("#encoded-canvas");
-const deltaCanvas = $<HTMLCanvasElement>("#delta-canvas");
-const aqCanvas = $<HTMLCanvasElement>("#aq-canvas");
+const deringingIn = $<HTMLInputElement>("#deringing");
+const sharpYuvIn = $<HTMLInputElement>("#sharp-yuv");
+const preBlurIn = $<HTMLInputElement>("#pre-blur");
+const chromaDistIn = $<HTMLInputElement>("#chroma-dist-scale");
+const optimizeHuffmanIn = $<HTMLInputElement>("#optimize-huffman");
+const progressiveIn = $<HTMLInputElement>("#progressive");
+const restartMcuRowsIn = $<HTMLInputElement>("#restart-mcu-rows");
+// Trellis
+const trellisDcIn = $<HTMLInputElement>("#trellis-dc");
+const trellisLambda1In = $<HTMLInputElement>("#trellis-lambda1");
+const trellisLambda2In = $<HTMLInputElement>("#trellis-lambda2");
+const trellisSpeedSel = $<HTMLSelectElement>("#trellis-speed");
+const trellisDeltaDcIn = $<HTMLInputElement>("#trellis-delta-dc");
+// Hybrid
+const hybridAqLambdaIn = $<HTMLInputElement>("#hybrid-aq-lambda-scale");
+const hybridBaseLambda1In = $<HTMLInputElement>("#hybrid-base-lambda1");
+const hybridBaseLambda2In = $<HTMLInputElement>("#hybrid-base-lambda2");
+const hybridDcIn = $<HTMLInputElement>("#hybrid-dc");
+const hybridAqExpIn = $<HTMLInputElement>("#hybrid-aq-exp");
+const hybridAqThresholdIn = $<HTMLInputElement>("#hybrid-aq-threshold");
+const hybridQAdaptIn = $<HTMLInputElement>("#hybrid-q-adapt");
+// Curve controls
+const curveQscaleIn = $<HTMLInputElement>("#curve-qscale");
+const curveQscaleOut = $<HTMLOutputElement>("#curve-qscale-out");
+const curveTiltIn = $<HTMLInputElement>("#curve-tilt");
+const curveTiltOut = $<HTMLOutputElement>("#curve-tilt-out");
+const curveHvIn = $<HTMLInputElement>("#curve-hv");
+const curveHvOut = $<HTMLOutputElement>("#curve-hv-out");
+const curvePresetSel = $<HTMLSelectElement>("#curve-preset");
+const curveResetBtn = $<HTMLButtonElement>("#curve-reset");
+
 const compRoot = $<HTMLElement>("#component-0").parentElement!;
 
+// ─── State ────────────────────────────────────────────────────────
 interface ImageState {
   width: number;
   height: number;
-  /** Source RGBA, length = width*height*4. */
   rgba: Uint8ClampedArray;
+  /** Stable per-image key for caches (pareto). */
+  key: string;
 }
 
 interface ComponentEqState {
-  /** Length 8, multiplier per horizontal-frequency column. */
   hEq: number[];
-  /** Length 8, multiplier per vertical-frequency row. */
   vEq: number[];
+  cellOverrides: Map<number, number>;
+}
+
+interface BaseSnapshot {
+  /** Per-component f32 base tables (length 64, natural row-major). */
+  tables: [Float32Array, Float32Array, Float32Array];
+  /** Encode opts the snapshot was captured under. Stale if any of
+   *  these change. */
+  quality: number;
+  colorPath: string;
+  subsampling: string;
+  xybSubsampling: string;
+}
+
+interface ZeroBiasState {
+  /** Global multiplier on zero_bias_mul[k] for all 64 cells. */
+  globalMul: [number, number, number];
+  /** Per-component DC offset. */
+  offsetDc: [number, number, number];
+  /** Per-component AC offset. */
+  offsetAc: [number, number, number];
+}
+
+interface ParetoPoint {
+  bytes: number;
+  score: number;
+  q: number;
+}
+
+interface ParetoQueue {
+  /** Quality values still to encode, in evaluation order. */
+  qs: number[];
+  /** Points landed so far (unsorted; we sort on every redraw). */
+  points: ParetoPoint[];
+  /** Total q values in the original sweep (for progress %). */
+  total: number;
+  /** Set true when the queue is exhausted. */
+  complete: boolean;
+}
+
+interface LastEncode {
+  bytes: number;
+  ssim2: number;
+  zensim: number;
+  durationMs: number;
+  mode: EncodeMode;
+  width: number;
+  height: number;
 }
 
 let currentImage: ImageState = synthetic();
 let currentDiagnostics: Diagnostics | null = null;
+let lastEncode: LastEncode | null = null;
 const eqStates = new Map<number, ComponentEqState>();
+let baseSnapshot: BaseSnapshot | null = null;
+// Cached ImageData per pane for the zoom inspector. Updated on each
+// successful encode (in runEncode). Lets the zoom modal redraw at
+// arbitrary scales/centers without re-extracting from the on-screen
+// canvases (which getImageData() works for, but is slower at large
+// scales and noisy when source/encoded/delta have different sizes).
+let zoomImageData: {
+  source: ImageData | null;
+  encoded: ImageData | null;
+  delta: ImageData | null;
+} = { source: null, encoded: null, delta: null };
+const zeroBias: ZeroBiasState = {
+  globalMul: [1.0, 1.0, 1.0],
+  offsetDc: [0.0, 0.0, 0.0],
+  offsetAc: [0.0, 0.0, 0.0],
+};
+const paretoCache = new Map<string, ParetoPoint[]>();
+const paretoQueues = new Map<string, ParetoQueue>();
+let activeTab = "quality";
 
+interface ImageManifestEntry {
+  id: string;
+  label: string;
+  /** Local cached relative URL when prebuild ran. The build-time
+   *  fetch-images.ts script applies an 8× lanczos3 wash to entries
+   *  flagged wasJpeg, writes the result as a PNG named `<sha>-w8.png`,
+   *  and points this URL at the washed copy. The browser does NO
+   *  resampling at any point — pixels are taken straight from this
+   *  URL into the encoder. */
+  localUrl: string | null;
+  /** Direct R2 URL (raw blob — only used as a fallback when the
+   *  local cache is missing AND CORS happens to be configured). */
+  remoteUrl: string;
+}
+let imageManifest: ImageManifestEntry[] = [];
+
+// Source list typed as the bundled JSON shape.
+interface BundledImageList {
+  defaultBase?: string;
+  images: Array<{
+    id: string;
+    label: string;
+    sha256?: string;
+    ext?: string;
+    file?: string;
+    wasJpeg?: boolean;
+  }>;
+}
+const bundled = bundledImageList as BundledImageList;
+const FALLBACK_BASE = "https://pub-7c5c57fd3e0842f0b147946928891d40.r2.dev";
+
+function entryToUrls(
+  entry: BundledImageList["images"][number],
+  base: string,
+): { localUrl: string | null; remoteUrl: string; localName: string } | null {
+  if (entry.sha256) {
+    const sha = entry.sha256.toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(sha)) return null;
+    const ext = entry.ext ?? "bin";
+    const localName = `${sha}.${ext}`;
+    return {
+      localUrl: `./images/${localName}`,
+      remoteUrl: `${base}/blobs/${sha.slice(0, 2)}/${sha.slice(2, 4)}/${sha}`,
+      localName,
+    };
+  }
+  if (entry.file) {
+    return {
+      localUrl: `./images/${entry.file}`,
+      remoteUrl: `${base}/${entry.file}`,
+      localName: entry.file,
+    };
+  }
+  return null;
+}
+
+// ─── Worker setup ─────────────────────────────────────────────────
+const worker = new Worker(new URL("./encode-worker.ts", import.meta.url), {
+  type: "module",
+});
+let workerReady: Promise<void> = new Promise((resolve) => {
+  const onReady = (ev: MessageEvent) => {
+    const m = ev.data as ReadyMsg | EncodeResultMsg | ErrorMsg;
+    if (m.kind === "ready") {
+      worker.removeEventListener("message", onReady);
+      resolve();
+    }
+  };
+  worker.addEventListener("message", onReady);
+});
+
+let nextReqId = 1;
+let inflightReqId = 0;
+let latestReqId = 0;
+const pendingResolvers = new Map<
+  number,
+  {
+    resolve: (r: { bytes: Uint8Array; diagnostics: Diagnostics; durationMs: number }) => void;
+    reject: (e: Error) => void;
+  }
+>();
+worker.addEventListener("message", (ev: MessageEvent) => {
+  const m = ev.data as EncodeResultMsg | ErrorMsg | ReadyMsg;
+  if (m.kind === "result") {
+    const slot = pendingResolvers.get(m.reqId);
+    pendingResolvers.delete(m.reqId);
+    if (slot)
+      slot.resolve({
+        bytes: m.bytes,
+        diagnostics: m.diagnostics,
+        durationMs: m.durationMs,
+      });
+  } else if (m.kind === "error") {
+    const slot = pendingResolvers.get(m.reqId);
+    pendingResolvers.delete(m.reqId);
+    if (slot) slot.reject(new Error(m.message));
+  }
+});
+
+function workerEncode(
+  pixels: Uint8Array,
+  width: number,
+  height: number,
+  options: EncodeOptions,
+  reqId: number,
+): Promise<{ bytes: Uint8Array; diagnostics: Diagnostics; durationMs: number }> {
+  return new Promise((resolve, reject) => {
+    pendingResolvers.set(reqId, { resolve, reject });
+    const msg: EncodeReq = {
+      kind: "encode",
+      reqId,
+      pixels,
+      width,
+      height,
+      options,
+      sourceRgb: pixels,
+      scoreMetrics: false,
+    };
+    worker.postMessage(msg, [pixels.buffer]);
+  });
+}
+
+// ─── Image helpers ────────────────────────────────────────────────
 function synthetic(): ImageState {
   const w = 64;
   const h = 64;
-  return {
-    width: w,
-    height: h,
-    rgba: syntheticPattern(w, h),
-  };
+  return { width: w, height: h, rgba: syntheticPattern(w, h), key: "__synthetic__" };
 }
 
 function drawRGBA(
@@ -116,20 +374,14 @@ function deltaImage(src: ImageData, dec: ImageData, gain = 8): ImageData {
   const out = new ImageData(w, h);
   for (let i = 0; i < w * h * 4; i += 4) {
     out.data[i] = Math.min(255, Math.abs(src.data[i]! - dec.data[i]!) * gain);
-    out.data[i + 1] = Math.min(
-      255,
-      Math.abs(src.data[i + 1]! - dec.data[i + 1]!) * gain,
-    );
-    out.data[i + 2] = Math.min(
-      255,
-      Math.abs(src.data[i + 2]! - dec.data[i + 2]!) * gain,
-    );
+    out.data[i + 1] = Math.min(255, Math.abs(src.data[i + 1]! - dec.data[i + 1]!) * gain);
+    out.data[i + 2] = Math.min(255, Math.abs(src.data[i + 2]! - dec.data[i + 2]!) * gain);
     out.data[i + 3] = 255;
   }
   return out;
 }
 
-function rgbaToPackedRgb(rgba: Uint8ClampedArray): Uint8Array {
+function rgbaToPackedRgb(rgba: Uint8ClampedArray | Uint8Array): Uint8Array {
   const n = rgba.length / 4;
   const out = new Uint8Array(n * 3);
   for (let i = 0, j = 0; i < rgba.length; i += 4, j += 3) {
@@ -140,47 +392,209 @@ function rgbaToPackedRgb(rgba: Uint8ClampedArray): Uint8Array {
   return out;
 }
 
-function currentOptions(): EncodeOptions {
-  return {
+// ─── Options assembly ─────────────────────────────────────────────
+function getMode(): EncodeMode {
+  const checked = document.querySelector<HTMLInputElement>('input[name="mode"]:checked');
+  return (checked?.value as EncodeMode | undefined) ?? "baseline";
+}
+
+/** Reset the cached base snapshot when any non-EQ encoder option changes
+ *  that would alter the encoder-derived defaults. The snapshot will be
+ *  re-captured on the next encode that runs *without* custom tables. */
+function invalidateBaseSnapshotIfStale(): boolean {
+  if (!baseSnapshot) return false;
+  const optsMatch =
+    baseSnapshot.quality === parseInt(qualityIn.value, 10) &&
+    baseSnapshot.colorPath === colorPathSel.value &&
+    baseSnapshot.subsampling === subSel.value &&
+    baseSnapshot.xybSubsampling === xybSubSel.value;
+  if (!optsMatch) {
+    baseSnapshot = null;
+    return true;
+  }
+  return false;
+}
+
+/** Pull a snapshot of the encoder's source-derived f32 base tables.
+ *  Called from runEncode after a successful no-custom-tables encode.
+ *  The diagnostics report u16 tables (DQT-format) so we round-trip
+ *  through f32, but we cache here so subsequent custom edits are
+ *  multipliers on a STABLE base — not the previous customized one. */
+function captureBaseSnapshot(diag: Diagnostics): void {
+  const tables: [Float32Array, Float32Array, Float32Array] = [
+    new Float32Array(64),
+    new Float32Array(64),
+    new Float32Array(64),
+  ];
+  for (let cidx = 0; cidx < 3; cidx++) {
+    const comp = diag.components[cidx];
+    const t = tables[cidx]!;
+    if (!comp) {
+      t.fill(16);
+      continue;
+    }
+    const base = comp.quantTableBase as Uint16Array | number[];
+    for (let i = 0; i < 64; i++) t[i] = base[i]! as number;
+  }
+  baseSnapshot = {
+    tables,
     quality: parseInt(qualityIn.value, 10),
-    colorPath: colorPathSel.value as "ycbcr" | "xyb",
-    subsampling: subSel.value as EncodeOptions["subsampling"],
-    xybSubsampling: xybSubSel.value as EncodeOptions["xybSubsampling"],
-    aqEnabled: aqIn.checked,
-    trellis: trellisIn.checked,
-    autoOptimize: autoOptIn.checked,
-    deringing: true,
+    colorPath: colorPathSel.value,
+    subsampling: subSel.value,
+    xybSubsampling: xybSubSel.value,
   };
 }
 
-function eqStateFor(componentIdx: number, comp: ComponentDiagnostics): ComponentEqState {
-  let s = eqStates.get(componentIdx);
-  if (!s) {
-    s = { hEq: Array(8).fill(1), vEq: Array(8).fill(1) };
-    eqStates.set(componentIdx, s);
-  }
-  void comp; // keep signature stable for future per-component init
-  return s;
-}
-
-function effectiveQuant(comp: ComponentDiagnostics, eq: ComponentEqState): Float32Array {
+/** Build the f32 effective table for a component, using the cached
+ *  base snapshot (NOT the live diagnostics, which may already reflect
+ *  the previous custom-tables encode). */
+function effectiveTableF32(componentIdx: number): Float32Array {
+  const snap = baseSnapshot;
   const out = new Float32Array(64);
+  if (!snap) {
+    // No snapshot yet — fall back to live diag if available.
+    const diag = currentDiagnostics;
+    const comp = diag?.components[componentIdx];
+    const base = comp?.quantTableBase as Uint16Array | number[] | undefined;
+    if (base) {
+      for (let i = 0; i < 64; i++) out[i] = base[i]! as number;
+    } else {
+      out.fill(16);
+    }
+    return out;
+  }
+  const base = snap.tables[componentIdx];
+  if (!base) {
+    out.fill(16);
+    return out;
+  }
+  out.set(base);
+  const eq = eqStates.get(componentIdx);
+  if (!eq) return out;
   for (let v = 0; v < 8; v++) {
     for (let u = 0; u < 8; u++) {
-      const idx = v * 8 + u;
-      const base = comp.quantTableBase[idx]! as number;
-      out[idx] = base * eq.hEq[u]! * eq.vEq[v]!;
+      const i = v * 8 + u;
+      let factor = eq.hEq[u]! * eq.vEq[v]!;
+      const ovr = eq.cellOverrides.get(i);
+      if (ovr !== undefined) factor *= ovr;
+      out[i] = Math.max(1, base[i]! * factor);
     }
   }
   return out;
 }
 
-/**
- * For each natural-order coefficient position, compute the mean
- * |coef_pre_quant| / effective_quant across all blocks. Values >> 1 mean
- * the coefficient has lots of headroom (table overshoots); << 1 means
- * the position is mostly quantized to zero.
- */
+function buildCustomQuantTables(): CustomQuantTables | null {
+  if (!baseSnapshot) return null;
+  let anyDiff = false;
+  const tables: number[][] = [];
+  for (let cidx = 0; cidx < 3; cidx++) {
+    const out = Array.from(effectiveTableF32(cidx));
+    tables.push(out);
+    const base = baseSnapshot.tables[cidx]!;
+    for (let i = 0; i < 64; i++) {
+      if (Math.abs(out[i]! - base[i]!) > 1e-3) {
+        anyDiff = true;
+        break;
+      }
+    }
+    if (anyDiff) break;
+  }
+  // Zero-bias deviations from defaults also count as "user has edits".
+  const zbDirty =
+    zeroBias.globalMul.some((m) => Math.abs(m - 1.0) > 1e-3) ||
+    zeroBias.offsetDc.some((d) => Math.abs(d) > 1e-4) ||
+    zeroBias.offsetAc.some((d) => Math.abs(d) > 1e-4);
+  if (!anyDiff && !zbDirty) return null;
+  // Build zero-bias multiplier tables: each component has 64 cells; the
+  // global mul applies to all of them. Default zero_bias_mul values
+  // come from the encoder's per-mode defaults — we don't have those on
+  // the JS side, so we approximate as 1.0×globalMul, leaving the
+  // encoder to apply the rest of its baseline shape. (For finer
+  // control we'd need to surface zero_bias_mul defaults via diagnostics.)
+  const zbMul = (cidx: number): number[] | undefined => {
+    const m = zeroBias.globalMul[cidx]!;
+    if (Math.abs(m - 1.0) < 1e-3) return undefined;
+    return new Array<number>(64).fill(m);
+  };
+  return {
+    y: tables[0]!,
+    cb: tables[1]!,
+    cr: tables[2]!,
+    yZeroBiasMul: zbMul(0),
+    cbZeroBiasMul: zbMul(1),
+    crZeroBiasMul: zbMul(2),
+    zeroBiasOffsetDc: [
+      zeroBias.offsetDc[0]!,
+      zeroBias.offsetDc[1]!,
+      zeroBias.offsetDc[2]!,
+    ],
+    zeroBiasOffsetAc: [
+      zeroBias.offsetAc[0]!,
+      zeroBias.offsetAc[1]!,
+      zeroBias.offsetAc[2]!,
+    ],
+  };
+}
+
+function currentOptions(): EncodeOptions {
+  const opts: EncodeOptions = {
+    quality: parseInt(qualityIn.value, 10),
+    colorPath: colorPathSel.value as "ycbcr" | "xyb",
+    subsampling: subSel.value as EncodeOptions["subsampling"],
+    xybSubsampling: xybSubSel.value as EncodeOptions["xybSubsampling"],
+    aqEnabled: aqIn.checked,
+    deringing: deringingIn.checked,
+    optimizeHuffman: optimizeHuffmanIn.checked,
+    progressive: progressiveIn.checked,
+    sharpYuv: sharpYuvIn.checked,
+    preBlur: parseFloat(preBlurIn.value) || 0,
+    chromaDistanceScale: parseFloat(chromaDistIn.value) || 1,
+    restartMcuRows: parseInt(restartMcuRowsIn.value, 10) || 0,
+    mode: getMode(),
+    trellisDcEnabled: trellisDcIn.checked,
+    trellisLambdaLogScale1: parseFloat(trellisLambda1In.value) || 14.75,
+    trellisLambdaLogScale2: parseFloat(trellisLambda2In.value) || 16.5,
+    trellisSpeedMode: trellisSpeedSel.value as TrellisSpeed,
+    trellisDeltaDcWeight: parseFloat(trellisDeltaDcIn.value) || 0,
+    hybridAqLambdaScale: parseFloat(hybridAqLambdaIn.value) || 2,
+    hybridBaseLambdaScale1: parseFloat(hybridBaseLambda1In.value) || 14.75,
+    hybridBaseLambdaScale2: parseFloat(hybridBaseLambda2In.value) || 16.5,
+    hybridDcEnabled: hybridDcIn.checked,
+    hybridAqExponent: parseFloat(hybridAqExpIn.value) || 1,
+    hybridAqThreshold: parseFloat(hybridAqThresholdIn.value) || 0,
+    hybridQualityAdaptive: hybridQAdaptIn.checked,
+  };
+  const custom = buildCustomQuantTables();
+  if (custom) opts.customQuantTables = custom;
+  return opts;
+}
+
+// ─── EQ + quant grid ──────────────────────────────────────────────
+function eqStateFor(componentIdx: number): ComponentEqState {
+  let s = eqStates.get(componentIdx);
+  if (!s) {
+    s = {
+      hEq: Array(8).fill(1),
+      vEq: Array(8).fill(1),
+      cellOverrides: new Map(),
+    };
+    eqStates.set(componentIdx, s);
+  }
+  return s;
+}
+
+function effectiveQuant(
+  _comp: ComponentDiagnostics,
+  _eq: ComponentEqState,
+  componentIdx: number,
+): Float32Array {
+  // Always use the snapshot-derived table — same f32 numbers we send
+  // to the encoder via customQuantTables. Reading the live diagnostics
+  // would reflect the previous custom-tables encode and compound any
+  // multiplier edit (Q-scale, EQ, etc).
+  return effectiveTableF32(componentIdx);
+}
+
 function utilizationField(
   comp: ComponentDiagnostics,
   q: Float32Array,
@@ -193,7 +607,7 @@ function utilizationField(
     for (let i = 0; i < 64; i++) {
       const qv = q[i]!;
       if (qv <= 0) continue;
-      const ratio = Math.abs(c[i]! as number) / qv;
+      const ratio = Math.abs((c[i]! as number)) / qv;
       accum[i]! += ratio;
       totalCoef++;
       if (ratio < 0.5) zeroCoef++;
@@ -204,26 +618,76 @@ function utilizationField(
   if (n > 0) {
     for (let i = 0; i < 64; i++) field[i] = accum[i]! / n;
   }
-  return {
-    field,
-    zeroRate: totalCoef > 0 ? (zeroCoef / totalCoef) * 100 : 0,
-  };
+  return { field, zeroRate: totalCoef > 0 ? (zeroCoef / totalCoef) * 100 : 0 };
+}
+
+function bindCellEditor(
+  cell: HTMLElement,
+  componentIdx: number,
+  cellIdx: number,
+  baseVal: number,
+  effVal: number,
+  onChange: () => void,
+): void {
+  cell.addEventListener("click", () => {
+    const eq = eqStateFor(componentIdx);
+    const input = window.prompt(
+      `Cell (${cellIdx % 8},${Math.floor(cellIdx / 8)}) — base=${baseVal}, ` +
+        `current effective=${effVal.toFixed(2)}. Enter new f32 effective:`,
+      effVal.toFixed(3),
+    );
+    if (input === null) return;
+    const parsed = parseFloat(input);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      status.textContent = `Invalid value (must be ≥ 1): ${input}`;
+      return;
+    }
+    const hv = (eq.hEq[cellIdx % 8]! * eq.vEq[Math.floor(cellIdx / 8)]!) || 1;
+    const mult = parsed / (baseVal * hv);
+    if (Math.abs(mult - 1) < 1e-4) {
+      eq.cellOverrides.delete(cellIdx);
+    } else {
+      eq.cellOverrides.set(cellIdx, mult);
+    }
+    onChange();
+    scheduleAutoEncode();
+  });
 }
 
 function buildQuantGrid(
   el: HTMLElement,
   comp: ComponentDiagnostics,
+  componentIdx: number,
   eq: ComponentEqState,
+  onChange: () => void,
 ): void {
   el.replaceChildren();
-  const eff = effectiveQuant(comp, eq);
+  const eff = effectiveQuant(comp, eq, componentIdx);
+  const baseSnap = baseSnapshot?.tables[componentIdx] ?? null;
   for (let v = 0; v < 8; v++) {
     for (let u = 0; u < 8; u++) {
       const cell = document.createElement("div");
       const idx = v * 8 + u;
       const val = eff[idx]!;
-      cell.textContent = val < 100 ? val.toFixed(0) : Math.round(val).toString();
-      cell.title = `(${u},${v}) base=${comp.quantTableBase[idx]} effective=${val.toFixed(1)}`;
+      // Show actual f32 precision: 3 sig figs for small values,
+      // 2 decimals up to 99.99, 1 decimal up to 999.9, then integer.
+      // The encoder consumes these as f32 so show what we'll send.
+      const formatted =
+        val < 10
+          ? val.toFixed(2)
+          : val < 100
+          ? val.toFixed(2)
+          : val < 1000
+          ? val.toFixed(1)
+          : Math.round(val).toString();
+      cell.textContent = formatted;
+      const baseVal = baseSnap ? baseSnap[idx]! : ((comp.quantTableBase as Uint16Array | number[])[idx]! as number);
+      cell.title = `(${u},${v}) base=${baseVal.toFixed(2)} → effective=${val.toFixed(3)} (f32, click to edit)`;
+      if (eq.cellOverrides.has(idx) || Math.abs(val - baseVal) > 1e-3) {
+        cell.style.color = "var(--color-accent)";
+        cell.style.fontWeight = "600";
+      }
+      bindCellEditor(cell, componentIdx, idx, baseVal, val, onChange);
       el.appendChild(cell);
     }
   }
@@ -246,13 +710,13 @@ function buildEqSliders(
     h.step = "0.05";
     h.value = String(eq.hEq[i]!);
     h.dataset.testid = `comp-${componentIdx}-h-eq-${i}`;
-    h.title = `h_eq[${i}]: column ${i} multiplier`;
+    h.title = `h_eq[${i}]`;
     h.addEventListener("input", () => {
       eq.hEq[i] = parseFloat(h.value);
       onChange();
+      scheduleAutoEncode();
     });
     hEl.appendChild(h);
-
     const vv = document.createElement("input");
     vv.type = "range";
     vv.min = "0.5";
@@ -260,37 +724,28 @@ function buildEqSliders(
     vv.step = "0.05";
     vv.value = String(eq.vEq[i]!);
     vv.dataset.testid = `comp-${componentIdx}-v-eq-${i}`;
-    vv.title = `v_eq[${i}]: row ${i} multiplier`;
+    vv.title = `v_eq[${i}]`;
     vv.addEventListener("input", () => {
       eq.vEq[i] = parseFloat(vv.value);
       onChange();
+      scheduleAutoEncode();
     });
     vEl.appendChild(vv);
   }
 }
 
-function renderComponent(
-  componentIdx: number,
-  diag: Diagnostics,
-): void {
+function renderComponent(componentIdx: number, diag: Diagnostics): void {
   const comp = diag.components[componentIdx];
   if (!comp) return;
-  let article = document.querySelector<HTMLElement>(
-    `[data-component="${componentIdx}"]`,
-  );
+  let article = document.querySelector<HTMLElement>(`[data-component="${componentIdx}"]`);
   if (!article) {
-    // Clone component-0's structure for additional components.
     const tmpl = document.querySelector<HTMLElement>('[data-component="0"]');
     if (!tmpl) throw new Error("template article missing");
     article = tmpl.cloneNode(true) as HTMLElement;
     article.dataset.component = String(componentIdx);
     article.id = `component-${componentIdx}`;
-    // Patch test-ids.
     article.querySelectorAll<HTMLElement>("[data-testid^='comp-0-']").forEach((el) => {
-      el.dataset.testid = el.dataset.testid!.replace(
-        "comp-0-",
-        `comp-${componentIdx}-`,
-      );
+      el.dataset.testid = el.dataset.testid!.replace("comp-0-", `comp-${componentIdx}-`);
     });
     const headerH2 = article.querySelector<HTMLHeadingElement>("h2");
     if (headerH2) {
@@ -310,7 +765,7 @@ function renderComponent(
   const [cols, rows] = comp.blockGrid;
   gridInfo.textContent = `${cols}×${rows} blocks (${cols * rows} total)`;
 
-  const eq = eqStateFor(componentIdx, comp);
+  const eq = eqStateFor(componentIdx);
   const quantGridEl = article.querySelector<HTMLElement>(
     `[data-testid="comp-${componentIdx}-quant-grid"]`,
   )!;
@@ -326,22 +781,25 @@ function renderComponent(
   const zeroRateEl = article.querySelector<HTMLElement>(
     `[data-testid="comp-${componentIdx}-zero-rate"]`,
   )!;
-  const resetBtn = article.querySelector<HTMLButtonElement>(
+  const compResetBtn = article.querySelector<HTMLButtonElement>(
     `[data-testid="comp-${componentIdx}-reset-eq"]`,
   )!;
 
   const refresh = () => {
-    buildQuantGrid(quantGridEl, comp, eq);
-    const q = effectiveQuant(comp, eq);
+    buildQuantGrid(quantGridEl, comp, componentIdx, eq, refresh);
+    const q = effectiveQuant(comp, eq, componentIdx);
     const { field, zeroRate } = utilizationField(comp, q);
     drawHeatmap(utilCanvas, field, { cols: 8, rows: 8, pixelSize: 25 });
     zeroRateEl.textContent = zeroRate.toFixed(1);
   };
 
   buildEqSliders(componentIdx, hEqEl, vEqEl, eq, refresh);
-  resetBtn.addEventListener("click", () => {
+  const freshReset = compResetBtn.cloneNode(true) as HTMLButtonElement;
+  compResetBtn.replaceWith(freshReset);
+  freshReset.addEventListener("click", () => {
     eq.hEq.fill(1);
     eq.vEq.fill(1);
+    eq.cellOverrides.clear();
     article!
       .querySelectorAll<HTMLInputElement>(
         `[data-testid^="comp-${componentIdx}-h-eq-"], [data-testid^="comp-${componentIdx}-v-eq-"]`,
@@ -350,57 +808,462 @@ function renderComponent(
         el.value = "1";
       });
     refresh();
+    scheduleAutoEncode();
   });
   refresh();
 }
 
 function componentLabel(colorPath: string, idx: number): string {
-  if (colorPath === "XYB") {
-    return ["X", "Y (XYB)", "B"][idx] ?? `c${idx}`;
-  }
+  if (colorPath === "XYB") return ["X", "Y (XYB)", "B"][idx] ?? `c${idx}`;
   if (colorPath === "Grayscale") return "Y";
   return ["Y", "Cb", "Cr"][idx] ?? `c${idx}`;
 }
 
+// ─── AQ field rendering ───────────────────────────────────────────
 function renderAqField(diag: Diagnostics): void {
+  // AQ multiplier is always written to component 0 (Y in YCbCr,
+  // X in XYB); the *source* channel for AQ analysis is c1 (Y-XYB)
+  // in XYB mode and c0 (Y) in YCbCr mode. Both produce per-block
+  // multipliers we display here.
   const yComp = diag.components[0];
-  if (!yComp) return;
+  if (!yComp) {
+    aqMinEl.textContent = "—";
+    aqMaxEl.textContent = "—";
+    aqMeanEl.textContent = "—";
+    aqChannelEl.textContent = "—";
+    return;
+  }
   const [cols, rows] = yComp.blockGrid;
   const data = new Float32Array(cols * rows);
+  let mn = Infinity;
+  let mx = -Infinity;
+  let sum = 0;
   for (let i = 0; i < yComp.blocks.length; i++) {
-    data[i] = yComp.blocks[i]!.aqMultiplier;
+    const v = yComp.blocks[i]!.aqMultiplier;
+    data[i] = v;
+    if (v < mn) mn = v;
+    if (v > mx) mx = v;
+    sum += v;
   }
+  const mean = yComp.blocks.length > 0 ? sum / yComp.blocks.length : 0;
   drawHeatmap(aqCanvas, data, {
     cols,
     rows,
     pixelSize: Math.max(8, Math.min(40, Math.floor(480 / cols))),
   });
+  aqMinEl.textContent = mn === Infinity ? "—" : mn.toFixed(3);
+  aqMaxEl.textContent = mx === -Infinity ? "—" : mx.toFixed(3);
+  aqMeanEl.textContent = mean.toFixed(3);
+  aqChannelEl.textContent =
+    diag.colorPath === "XYB"
+      ? "X (driven by Y-XYB)"
+      : diag.colorPath === "Grayscale"
+      ? "Y"
+      : "Y";
+}
+
+// ─── Curve presets ────────────────────────────────────────────────
+function applyCurvePreset(preset: string, qscale: number, tilt: number, hv: number): void {
+  const comps = currentDiagnostics?.components.length ?? 1;
+  for (let cidx = 0; cidx < comps; cidx++) {
+    const eq = eqStateFor(cidx);
+    eq.cellOverrides.clear();
+    for (let i = 0; i < 8; i++) {
+      const fband = i / 7;
+      const tiltFactor = Math.exp(-tilt * (fband - 0.5));
+      const hFactor = Math.exp(-hv * (fband - 0.5));
+      const vFactor = Math.exp(hv * (fband - 0.5));
+      let h = qscale * tiltFactor * hFactor;
+      let v = qscale * tiltFactor * vFactor;
+      switch (preset) {
+        case "hf-boost":
+          h *= 1 - 0.4 * fband;
+          v *= 1 - 0.4 * fband;
+          break;
+        case "lf-keep":
+          h *= 0.85 + 0.3 * fband;
+          v *= 0.85 + 0.3 * fband;
+          break;
+        case "flat":
+          h = qscale;
+          v = qscale;
+          break;
+      }
+      eq.hEq[i] = clamp(h, 0.5, 2);
+      eq.vEq[i] = clamp(v, 0.5, 2);
+    }
+  }
+}
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+// ─── Metrics ──────────────────────────────────────────────────────
+function ssim2(src: ImageData, dec: ImageData): number {
+  if (src.width !== dec.width || src.height !== dec.height) return 0;
+  try {
+    return computeSsimulacra2(
+      rgbaToPackedRgb(src.data),
+      rgbaToPackedRgb(dec.data),
+      src.width,
+      src.height,
+    );
+  } catch (e) {
+    console.warn("ssim2 failed", e);
+    return 0;
+  }
+}
+function zensim(src: ImageData, dec: ImageData): number {
+  if (src.width !== dec.width || src.height !== dec.height) return 0;
+  try {
+    return computeZensim(
+      rgbaToPackedRgb(src.data),
+      rgbaToPackedRgb(dec.data),
+      src.width,
+      src.height,
+    );
+  } catch (e) {
+    console.warn("zensim failed", e);
+    return 0;
+  }
+}
+
+// ─── Pareto baseline ──────────────────────────────────────────────
+// 100-point integer sweep (q=1..100) computed *progressively*. Running
+// all 100 encodes back-to-back would block the worker queue and starve
+// user-driven encodes for several seconds. Instead we drive the queue
+// from runEncode's `finally` hook: every time the user encode settles,
+// we kick off ONE pareto step in the worker. That naturally yields
+// priority to user encodes — pareto fills in during idle time.
+//
+// As each point lands the RD canvas is repainted with the current set,
+// so the curve grows in front of the user. The full 1..100 sweep
+// resolves over ~tens of seconds for a 1 MP image.
+
+const PARETO_QS = Array.from({ length: 100 }, (_, i) => i + 1); // 1..100
+
+function buildParetoFromPoints(raw: ParetoPoint[]): ParetoPoint[] {
+  const sorted = raw.slice().sort((a, b) => a.bytes - b.bytes);
+  const pareto: ParetoPoint[] = [];
+  let bestScore = -Infinity;
+  for (const p of sorted) {
+    if (p.score >= bestScore) {
+      pareto.push(p);
+      bestScore = p.score;
+    }
+  }
+  return pareto;
+}
+
+function ensureParetoQueue(image: ImageState): ParetoQueue {
+  const existing = paretoQueues.get(image.key);
+  if (existing) return existing;
+  const cached = paretoCache.get(image.key);
+  if (cached) {
+    const q: ParetoQueue = {
+      qs: [],
+      points: cached.slice(),
+      total: cached.length,
+      complete: true,
+    };
+    paretoQueues.set(image.key, q);
+    return q;
+  }
+  const q: ParetoQueue = {
+    qs: PARETO_QS.slice(),
+    points: [],
+    total: PARETO_QS.length,
+    complete: false,
+  };
+  paretoQueues.set(image.key, q);
+  return q;
+}
+
+let paretoStepInflight = false;
+
+async function stepPareto(): Promise<void> {
+  // Single-step worker: only one pareto encode in flight at a time,
+  // and only while no user encode is pending. Recurses after each step.
+  if (paretoStepInflight) return;
+  if (inflightReqId !== 0) return;
+  const image = currentImage;
+  const queue = ensureParetoQueue(image);
+  if (queue.complete) return;
+  if (queue.qs.length === 0) {
+    queue.complete = true;
+    paretoCache.set(image.key, buildParetoFromPoints(queue.points));
+    return;
+  }
+  paretoStepInflight = true;
+  const q = queue.qs.shift()!;
+  try {
+    const reqId = nextReqId++;
+    const packed = rgbaToPackedRgb(image.rgba);
+    const opts: EncodeOptions = {
+      quality: q,
+      colorPath: "ycbcr",
+      subsampling: "quarter",
+      aqEnabled: true,
+      deringing: true,
+      optimizeHuffman: true,
+      mode: "baseline",
+    };
+    const r = await workerEncode(packed, image.width, image.height, opts, reqId);
+    if (image.key !== currentImage.key) {
+      // Image changed during the step — drop result.
+      return;
+    }
+    const decoded = await decodeJpeg(r.bytes);
+    const srcImageData = new ImageData(image.rgba.slice(), image.width, image.height);
+    const score = ssim2(srcImageData, decoded);
+    queue.points.push({ bytes: r.bytes.byteLength, score, q });
+    // Repaint with the current filled-in subset.
+    drawRdCanvas(buildParetoFromPoints(queue.points), currentLastEncodePoint());
+    updateParetoDelta();
+  } catch (e) {
+    console.warn(`pareto q=${q} failed:`, e);
+  } finally {
+    paretoStepInflight = false;
+    // If the user isn't encoding, immediately schedule the next pareto
+    // step on the next microtask (yields to runEncode if it's queued).
+    if (inflightReqId === 0 && !queue.complete) {
+      queueMicrotask(() => void stepPareto());
+    }
+  }
+}
+
+function currentLastEncodePoint(): { bytes: number; score: number } | null {
+  return lastEncode ? { bytes: lastEncode.bytes, score: lastEncode.ssim2 } : null;
+}
+
+function updateParetoDelta(): void {
+  const queue = paretoQueues.get(currentImage.key);
+  const cur = currentLastEncodePoint();
+  if (!cur) return;
+  // Use the currently-filled subset to compute Δ-pareto. Refines as
+  // more points arrive.
+  const points =
+    queue && queue.points.length >= 2
+      ? buildParetoFromPoints(queue.points)
+      : paretoCache.get(currentImage.key) ?? [];
+  if (points.length < 2) return;
+  const d = paretoDelta(points, cur);
+  mPareto.textContent = (d >= 0 ? "+" : "") + d.toFixed(2);
+  mPareto.parentElement?.setAttribute(
+    "data-tone",
+    d >= 0 ? "good" : d > -3 ? "warn" : "bad",
+  );
+}
+
+function drawRdCanvas(
+  pareto: ParetoPoint[],
+  current: { bytes: number; score: number } | null,
+): void {
+  const queue = paretoQueues.get(currentImage.key);
+  const filled = queue ? queue.points.length : pareto.length;
+  const total = queue ? queue.total : pareto.length;
+  const ctx = rdCanvas.getContext("2d");
+  if (!ctx) return;
+  const W = rdCanvas.width;
+  const H = rdCanvas.height;
+  ctx.fillStyle = "#0e1117";
+  ctx.fillRect(0, 0, W, H);
+  if (pareto.length === 0) {
+    ctx.fillStyle = "#8b949e";
+    ctx.font = "13px ui-monospace, SFMono-Regular, Menlo, monospace";
+    ctx.fillText(
+      filled === 0
+        ? "Computing reference RD curve in the background…"
+        : `Building reference RD: ${filled}/${total}`,
+      20,
+      H / 2,
+    );
+    return;
+  }
+  const allBytes = pareto.map((p) => p.bytes);
+  const allScores = pareto.map((p) => p.score);
+  if (current) {
+    allBytes.push(current.bytes);
+    allScores.push(current.score);
+  }
+  const minB = Math.min(...allBytes) * 0.9;
+  const maxB = Math.max(...allBytes) * 1.1;
+  const minS = Math.min(...allScores) - 2;
+  const maxS = Math.max(...allScores) + 2;
+  const padL = 50;
+  const padR = 12;
+  const padT = 12;
+  const padB = 32;
+  const xFor = (b: number) =>
+    padL +
+    ((Math.log10(b) - Math.log10(minB)) / (Math.log10(maxB) - Math.log10(minB))) *
+      (W - padL - padR);
+  const yFor = (s: number) => padT + (1 - (s - minS) / (maxS - minS)) * (H - padT - padB);
+  ctx.strokeStyle = "#30363d";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(padL, padT);
+  ctx.lineTo(padL, H - padB);
+  ctx.lineTo(W - padR, H - padB);
+  ctx.stroke();
+  ctx.fillStyle = "#8b949e";
+  ctx.font = "11px ui-monospace, SFMono-Regular, Menlo, monospace";
+  ctx.fillText("bytes (log)", W - 80, H - 10);
+  ctx.save();
+  ctx.translate(14, padT + 60);
+  ctx.rotate(-Math.PI / 2);
+  ctx.fillText("ssimulacra2", 0, 0);
+  ctx.restore();
+  ctx.strokeStyle = "#c9d1d9";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  for (let i = 0; i < pareto.length; i++) {
+    const p = pareto[i]!;
+    const x = xFor(p.bytes);
+    const y = yFor(p.score);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+  ctx.fillStyle = "#c9d1d9";
+  for (const p of pareto) {
+    ctx.beginPath();
+    ctx.arc(xFor(p.bytes), yFor(p.score), 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  if (current) {
+    ctx.fillStyle = "#58a6ff";
+    ctx.beginPath();
+    ctx.arc(xFor(current.bytes), yFor(current.score), 6, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = "#000";
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+  }
+  // Progress label (top-right).
+  const isComplete = queue?.complete === true;
+  ctx.fillStyle = isComplete ? "#56d364" : "#f0883e";
+  ctx.font = "11px ui-monospace, SFMono-Regular, Menlo, monospace";
+  const progressText = isComplete
+    ? `ref RD ${filled}/${total} ✓`
+    : `ref RD ${filled}/${total}`;
+  const tw = ctx.measureText(progressText).width;
+  ctx.fillText(progressText, W - padR - tw, padT + 12);
+}
+
+function paretoDelta(
+  pareto: ParetoPoint[],
+  cur: { bytes: number; score: number },
+): number {
+  if (pareto.length < 2) return 0;
+  const lb = Math.log10(cur.bytes);
+  let prev = pareto[0]!;
+  for (let i = 1; i < pareto.length; i++) {
+    const p = pareto[i]!;
+    const a = Math.log10(prev.bytes);
+    const b = Math.log10(p.bytes);
+    if (lb >= a && lb <= b) {
+      const t = (lb - a) / Math.max(1e-9, b - a);
+      const interp = prev.score + (p.score - prev.score) * t;
+      return cur.score - interp;
+    }
+    prev = p;
+  }
+  if (lb < Math.log10(pareto[0]!.bytes)) return cur.score - pareto[0]!.score;
+  return cur.score - pareto[pareto.length - 1]!.score;
+}
+
+// ─── Big-readout updater ──────────────────────────────────────────
+function updateReadout(): void {
+  if (!lastEncode) {
+    mBytes.textContent = "—";
+    mBpp.textContent = "—";
+    mMode.textContent = "—";
+    mModeDetail.textContent = "—";
+    mSsim2.textContent = "—";
+    mZensim.textContent = "—";
+    mPareto.textContent = "—";
+    mTime.textContent = "—";
+    return;
+  }
+  const px = lastEncode.width * lastEncode.height;
+  mBytes.textContent = formatBytes(lastEncode.bytes);
+  mBpp.textContent = px > 0 ? `${((lastEncode.bytes * 8) / px).toFixed(2)} bpp` : "—";
+  mMode.textContent = lastEncode.mode.toUpperCase();
+  mModeDetail.textContent = "";
+  mSsim2.textContent = lastEncode.ssim2.toFixed(2);
+  mSsim2.parentElement?.setAttribute("data-tone", scoreTone(lastEncode.ssim2));
+  mZensim.textContent = lastEncode.zensim.toFixed(2);
+  mZensim.parentElement?.setAttribute("data-tone", scoreTone(lastEncode.zensim));
+  mTime.textContent = lastEncode.durationMs.toFixed(0);
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n}`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}K`;
+  return `${(n / 1024 / 1024).toFixed(2)}M`;
+}
+function scoreTone(s: number): string {
+  if (s >= 80) return "good";
+  if (s >= 60) return "warn";
+  return "bad";
+}
+
+// ─── Encode pipeline ──────────────────────────────────────────────
+let debounceTimer: number | null = null;
+const DEBOUNCE_MS = 250;
+
+function scheduleAutoEncode(): void {
+  if (!autoEncodeIn.checked) return;
+  if (debounceTimer !== null) window.clearTimeout(debounceTimer);
+  debounceTimer = window.setTimeout(() => {
+    debounceTimer = null;
+    void runEncode();
+  }, DEBOUNCE_MS);
+}
+
+function setEncodingIndicator(on: boolean, detail = ""): void {
+  const overlay = document.getElementById("encode-overlay");
+  const detailEl = document.getElementById("encode-overlay-detail");
+  if (overlay) overlay.hidden = !on;
+  if (detailEl) detailEl.textContent = detail;
+  document.body.dataset.encoding = on ? "true" : "false";
 }
 
 async function runEncode(): Promise<void> {
-  if (!currentImage) return;
-  document.body.dataset.encodePhase = "start";
-  status.textContent = "Encoding…";
+  const reqId = nextReqId++;
+  latestReqId = reqId;
+  inflightReqId = reqId;
   encodeBtn.disabled = true;
+  cancelBtn.disabled = false;
+  status.textContent = "Encoding…";
+  document.body.dataset.encodePhase = "start";
+  setEncodingIndicator(
+    true,
+    `req#${reqId} · ${currentImage.width}×${currentImage.height} · q=${qualityIn.value} · ${getMode()}`,
+  );
   try {
+    await workerReady;
     const packed = rgbaToPackedRgb(currentImage.rgba);
     const opts = currentOptions();
     document.body.dataset.encodePhase = "calling-wasm";
-    const result = (await encodeWithDiagnostics(
+    const result = await workerEncode(
       packed,
       currentImage.width,
       currentImage.height,
       opts,
-    )) as EncodeResult;
+      reqId,
+    );
     document.body.dataset.encodePhase = "wasm-returned";
-
+    if (reqId !== latestReqId) {
+      // Stale result — drop.
+      return;
+    }
     drawRGBA(sourceCanvas, currentImage.rgba, currentImage.width, currentImage.height);
-
     const decoded = await decodeJpeg(result.bytes);
     encodedCanvas.width = decoded.width;
     encodedCanvas.height = decoded.height;
     encodedCanvas.getContext("2d")!.putImageData(decoded, 0, 0);
-
     const sourceImageData = new ImageData(
       currentImage.rgba.slice(),
       currentImage.width,
@@ -411,10 +1274,27 @@ async function runEncode(): Promise<void> {
     deltaCanvas.height = delta.height;
     deltaCanvas.getContext("2d")!.putImageData(delta, 0, 0);
 
+    // Cache for the zoom inspector.
+    zoomImageData = {
+      source: sourceImageData,
+      encoded: decoded,
+      delta,
+    };
+    if (zoomState.open) {
+      // Refresh the open inspector with the new pixels (slider drag
+      // is auto-encoding — the user expects to watch deltas evolve
+      // at the same zoom).
+      drawZoomFrame();
+    }
+
     currentDiagnostics = result.diagnostics;
-    eqStates.clear();
+    // If this encode ran without custom tables, the diagnostics' base
+    // tables are the encoder's source-derived defaults — capture them
+    // so subsequent edits are multipliers on a stable base.
+    if (!opts.customQuantTables) {
+      captureBaseSnapshot(result.diagnostics);
+    }
     renderAqField(result.diagnostics);
-    // Remove additional component articles we may have appended.
     compRoot
       .querySelectorAll<HTMLElement>("[data-component]")
       .forEach((el) => {
@@ -423,21 +1303,65 @@ async function runEncode(): Promise<void> {
     for (let i = 0; i < result.diagnostics.components.length; i++) {
       renderComponent(i, result.diagnostics);
     }
-    status.textContent = `Encoded ${result.bytes.byteLength} bytes (${result.diagnostics.components.length} components, ${
-      result.diagnostics.components[0]?.blocks.length ?? 0
-    } Y blocks)`;
+
+    const ssim2Score = ssim2(sourceImageData, decoded);
+    const zensimScore = zensim(sourceImageData, decoded);
+    lastEncode = {
+      bytes: result.bytes.byteLength,
+      ssim2: ssim2Score,
+      zensim: zensimScore,
+      durationMs: result.durationMs,
+      mode: opts.mode ?? "baseline",
+      width: currentImage.width,
+      height: currentImage.height,
+    };
+
+    // Pareto delta — refresh asynchronously.
+    void refreshRdPanel();
+
+    updateReadout();
+    const customMark = opts.customQuantTables ? " · custom Q" : "";
+    status.textContent = `Encoded ${result.bytes.byteLength} B in ${result.durationMs.toFixed(0)} ms${customMark}`;
     document.body.dataset.encodeState = "done";
   } catch (e) {
-    console.error(e);
-    status.textContent = `Error: ${(e as Error).message}`;
-    document.body.dataset.encodeState = "error";
+    if (reqId === latestReqId) {
+      console.error(e);
+      status.textContent = `Error: ${(e as Error).message}`;
+      document.body.dataset.encodeState = "error";
+    }
   } finally {
-    encodeBtn.disabled = false;
+    if (inflightReqId === reqId) {
+      inflightReqId = 0;
+      encodeBtn.disabled = false;
+      cancelBtn.disabled = true;
+      setEncodingIndicator(false);
+      // Kick the next pareto step now that the user encode has settled.
+      // stepPareto() guards against concurrent stepping and yields if
+      // the user kicks another encode while it's running.
+      queueMicrotask(() => void stepPareto());
+    }
   }
 }
 
+function refreshRdPanel(): void {
+  // Draw whatever pareto data is currently available — full from cache
+  // if the sweep is complete, partial from the active queue otherwise.
+  const queue = ensureParetoQueue(currentImage);
+  const points = queue.complete
+    ? paretoCache.get(currentImage.key) ?? buildParetoFromPoints(queue.points)
+    : buildParetoFromPoints(queue.points);
+  drawRdCanvas(points, currentLastEncodePoint());
+  updateParetoDelta();
+}
+
+// ─── Image loading ────────────────────────────────────────────────
 async function loadFile(file: File): Promise<void> {
   const url = URL.createObjectURL(file);
+  // No browser-side wash for uploads either. If the user uploads a
+  // JPEG / WebP / AVIF, the diagnostics will reflect "encoder + prior
+  // codec artifacts" not "encoder alone" — that's the user's
+  // responsibility. We surface a warning so it's not a silent footgun.
+  const lossy = !/\b(?:image\/png|image\/x-png)\b/i.test(file.type);
   try {
     const img = await new Promise<HTMLImageElement>((res, rej) => {
       const i = new Image();
@@ -445,24 +1369,240 @@ async function loadFile(file: File): Promise<void> {
       i.onerror = rej;
       i.src = url;
     });
-    const w = img.naturalWidth;
-    const h = img.naturalHeight;
-    const c = document.createElement("canvas");
-    c.width = w;
-    c.height = h;
-    const cx = c.getContext("2d");
-    if (!cx) throw new Error("canvas 2d unavailable");
-    cx.drawImage(img, 0, 0);
-    const data = cx.getImageData(0, 0, w, h);
-    currentImage = { width: w, height: h, rgba: data.data };
+    const decoded = decodeImageToCanvas(img);
+    currentImage = {
+      width: decoded.width,
+      height: decoded.height,
+      rgba: decoded.rgba,
+      key: `upload:${file.name}:${decoded.width}x${decoded.height}`,
+    };
+    const lossyWarn = lossy
+      ? " ⚠ lossy source — pre-process for clean diagnostics"
+      : "";
+    imageInfoEl.textContent =
+      `${decoded.width} × ${decoded.height} (uploaded ${file.type})${lossyWarn}`;
   } finally {
     URL.revokeObjectURL(url);
   }
 }
 
+async function fetchAsImage(url: string): Promise<HTMLImageElement> {
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`fetch ${url} → ${resp.status}`);
+  const blob = await resp.blob();
+  const objUrl = URL.createObjectURL(blob);
+  try {
+    return await new Promise<HTMLImageElement>((res, rej) => {
+      const i = new Image();
+      i.onload = () => res(i);
+      i.onerror = () => rej(new Error("image decode failed"));
+      i.src = objUrl;
+    });
+  } finally {
+    // Important: keep objUrl alive until the image's onload fires;
+    // safe to revoke after Promise resolves since the browser has
+    // already parsed the bitmap.
+    URL.revokeObjectURL(objUrl);
+  }
+}
+
+/** Decode an HTMLImageElement to RGBA pixels at native dimensions.
+ *  No browser-side resampling — the wash (8× lanczos3) is performed
+ *  at build time by scripts/fetch-images.ts using sharp, so by the
+ *  time we get here the image bytes are already the cleaned source. */
+function decodeImageToCanvas(
+  img: HTMLImageElement,
+): { width: number; height: number; rgba: Uint8ClampedArray } {
+  const w = img.naturalWidth;
+  const h = img.naturalHeight;
+  const c = document.createElement("canvas");
+  c.width = w;
+  c.height = h;
+  const cx = c.getContext("2d");
+  if (!cx) throw new Error("canvas 2d unavailable");
+  cx.imageSmoothingEnabled = false;
+  cx.drawImage(img, 0, 0);
+  const data = cx.getImageData(0, 0, w, h);
+  return { width: w, height: h, rgba: data.data };
+}
+
+async function loadEntry(entry: ImageManifestEntry): Promise<void> {
+  let img: HTMLImageElement | null = null;
+  // Try the local cached path first (works on any deploy that ran the
+  // prebuild fetch — `npm run build` triggers it). The absolute R2 URL
+  // is the fallback but it WILL hit CORS unless either (a) the bucket
+  // has CORS configured (Access-Control-Allow-Origin) or (b) the page
+  // is being viewed at the same origin as the bucket. So we annotate
+  // the error specifically when remoteUrl fails so the message is
+  // actionable.
+  const tries: { url: string; isLocal: boolean }[] = [];
+  if (entry.localUrl) tries.push({ url: entry.localUrl, isLocal: true });
+  tries.push({ url: entry.remoteUrl, isLocal: false });
+  let lastErr: Error | null = null;
+  for (const { url, isLocal } of tries) {
+    try {
+      img = await fetchAsImage(url);
+      break;
+    } catch (e) {
+      const msg = (e as Error).message;
+      lastErr = e as Error;
+      if (!isLocal && msg.toLowerCase().includes("fetch")) {
+        lastErr = new Error(
+          `R2 fetch blocked (likely CORS): ${url} → ${msg}. ` +
+            `Fix: rebuild via \`npm run build\` so the prebuild hook ` +
+            `bakes images into dist/images/, or configure CORS on the ` +
+            `codec-corpus bucket.`,
+        );
+      }
+      console.warn(`[picker] ${url} failed:`, msg);
+    }
+  }
+  if (!img) throw lastErr ?? new Error("no image source available");
+  const decoded = decodeImageToCanvas(img);
+  currentImage = {
+    width: decoded.width,
+    height: decoded.height,
+    rgba: decoded.rgba,
+    key: entry.id,
+  };
+  imageInfoEl.textContent = `${decoded.width} × ${decoded.height} — ${entry.label}`;
+}
+
+function loadImageManifest(): void {
+  // Bundled list always populates the dropdown. The "real" runtime
+  // manifest (./images/manifest.json) carries the post-wash URLs +
+  // dimensions when the prebuild has run; we prefer those. The
+  // bundled list is the fallback when the manifest is empty.
+  const base = (bundled.defaultBase ?? FALLBACK_BASE).replace(/\/+$/, "");
+  imageManifest = [];
+  for (const entry of bundled.images) {
+    const urls = entryToUrls(entry, base);
+    if (!urls) continue;
+    // For wasJpeg entries, the served local URL is `<sha>-w8.png`
+    // (the post-wash PNG written by the prebuild). The raw blob URL
+    // stays on R2 — there's no point falling back to the un-washed
+    // remote when the wash exists locally.
+    const localUrl = entry.wasJpeg && entry.sha256
+      ? `./images/${entry.sha256.toLowerCase()}-w8.png`
+      : urls.localUrl;
+    imageManifest.push({
+      id: entry.id,
+      label: entry.label,
+      localUrl,
+      remoteUrl: urls.remoteUrl,
+    });
+    const opt = document.createElement("option");
+    opt.value = entry.id;
+    opt.textContent = entry.label;
+    imagePickSel.appendChild(opt);
+  }
+  console.log(`[picker] populated with ${imageManifest.length} demo images`);
+}
+
+// ─── Tabs + ignored annotations ───────────────────────────────────
+function setActiveTab(name: string): void {
+  activeTab = name;
+  document.querySelectorAll<HTMLElement>(".tab").forEach((t) => {
+    const sel = t.dataset.tab === name;
+    t.setAttribute("aria-selected", String(sel));
+  });
+  document.querySelectorAll<HTMLElement>(".tab-panel").forEach((p) => {
+    const sel = p.dataset.tab === name;
+    p.hidden = !sel;
+    p.setAttribute("aria-hidden", String(!sel));
+  });
+  applyIgnoredAnnotations();
+}
+
+function refreshQuantBanner(): void {
+  const el = document.getElementById("quant-mode-banner");
+  if (!el) return;
+  const mode = getMode();
+  const aq = aqIn.checked;
+  const cp = colorPathSel.value === "xyb" ? "XYB" : "YCbCr";
+  let msg = "";
+  switch (mode) {
+    case "baseline":
+      msg = aq
+        ? `Adaptive Quantization (${cp}). Final per-block quant = table[k] × aq_multiplier_block.`
+        : `${cp} with AQ disabled. Final per-block quant = table[k]. The AQ checkbox is off.`;
+      break;
+    case "trellis":
+      msg = `Trellis (${cp}). Lambda RD picks per-coefficient quant levels; the table acts as an upper bound. Edits to the table still constrain the search space.`;
+      break;
+    case "hybrid":
+      msg = `Hybrid (${cp}). AQ-aware lambda RD. The table sets the AQ multiplier base; trellis picks final levels per block, modulated by per-block AQ.`;
+      break;
+  }
+  el.textContent = msg;
+  el.style.color = "var(--color-warm)";
+}
+
+function applyIgnoredAnnotations(): void {
+  const mode = getMode();
+  const cp = colorPathSel.value;
+  const sub = subSel.value;
+
+  const trellisPanel = document.querySelector<HTMLElement>('.tab-panel[data-tab="trellis"]');
+  if (trellisPanel) {
+    const disabled = mode !== "trellis";
+    trellisPanel
+      .querySelectorAll<HTMLElement>(".ctrl")
+      .forEach((c) => (c.dataset.disabled = String(disabled)));
+    const note = trellisPanel.querySelector<HTMLElement>('[data-when="trellis-ignored"]');
+    if (note) note.style.display = disabled ? "" : "none";
+  }
+  const hybridPanel = document.querySelector<HTMLElement>('.tab-panel[data-tab="hybrid"]');
+  if (hybridPanel) {
+    const disabled = mode !== "hybrid";
+    hybridPanel
+      .querySelectorAll<HTMLElement>(".ctrl")
+      .forEach((c) => (c.dataset.disabled = String(disabled)));
+    const note = hybridPanel.querySelector<HTMLElement>('[data-when="hybrid-ignored"]');
+    if (note) note.style.display = disabled ? "" : "none";
+  }
+  const sharpCtrl = sharpYuvIn.closest<HTMLElement>(".ctrl");
+  if (sharpCtrl) {
+    const disabled = cp === "xyb" || sub === "none";
+    sharpCtrl.dataset.disabled = String(disabled);
+    const note = sharpCtrl.querySelector<HTMLElement>('[data-when="sharp-yuv-ignored"]');
+    if (note)
+      note.textContent = disabled
+        ? cp === "xyb"
+          ? "(ignored — XYB)"
+          : "(ignored — 4:4:4)"
+        : "";
+  }
+}
+
+function syncCurveOutputs(): void {
+  curveQscaleOut.textContent = parseFloat(curveQscaleIn.value).toFixed(2);
+  const tilt = parseFloat(curveTiltIn.value);
+  curveTiltOut.textContent = (tilt >= 0 ? "+" : "") + tilt.toFixed(2);
+  const hv = parseFloat(curveHvIn.value);
+  curveHvOut.textContent = (hv >= 0 ? "+" : "") + hv.toFixed(2);
+}
+
+function applyCurveControls(): void {
+  applyCurvePreset(
+    curvePresetSel.value,
+    parseFloat(curveQscaleIn.value),
+    parseFloat(curveTiltIn.value),
+    parseFloat(curveHvIn.value),
+  );
+  if (currentDiagnostics) {
+    for (let i = 0; i < currentDiagnostics.components.length; i++) {
+      renderComponent(i, currentDiagnostics);
+    }
+  }
+}
+
+// ─── Wiring ────────────────────────────────────────────────────────
 function wireControls(): void {
   qualityIn.addEventListener("input", () => {
     qualityOut.textContent = qualityIn.value;
+    invalidateBaseSnapshotIfStale();
+    scheduleAutoEncode();
   });
   colorPathSel.addEventListener("change", () => {
     if (colorPathSel.value === "xyb") {
@@ -472,60 +1612,511 @@ function wireControls(): void {
       subLabel.hidden = false;
       xybLabel.hidden = true;
     }
+    applyIgnoredAnnotations();
+    invalidateBaseSnapshotIfStale();
+    scheduleAutoEncode();
   });
-  encodeBtn.addEventListener("click", () => {
-    void runEncode();
+  // Subsampling changes the encoder's default tables AND determines
+  // whether sharp-yuv is meaningful. Refresh ignored-annotations.
+  for (const el of [subSel, xybSubSel]) {
+    el.addEventListener("change", () => {
+      invalidateBaseSnapshotIfStale();
+      applyIgnoredAnnotations();
+    });
+  }
+  // Encoder option inputs that should trigger auto-encode.
+  for (const el of [
+    subSel,
+    xybSubSel,
+    aqIn,
+    deringingIn,
+    sharpYuvIn,
+    preBlurIn,
+    chromaDistIn,
+    optimizeHuffmanIn,
+    progressiveIn,
+    restartMcuRowsIn,
+    trellisDcIn,
+    trellisLambda1In,
+    trellisLambda2In,
+    trellisSpeedSel,
+    trellisDeltaDcIn,
+    hybridAqLambdaIn,
+    hybridBaseLambda1In,
+    hybridBaseLambda2In,
+    hybridDcIn,
+    hybridAqExpIn,
+    hybridAqThresholdIn,
+    hybridQAdaptIn,
+  ]) {
+    el.addEventListener("change", scheduleAutoEncode);
+    el.addEventListener("input", scheduleAutoEncode);
+  }
+  document.querySelectorAll<HTMLInputElement>('input[name="mode"]').forEach((r) => {
+    r.addEventListener("change", () => {
+      applyIgnoredAnnotations();
+      scheduleAutoEncode();
+    });
+  });
+
+  encodeBtn.addEventListener("click", () => void runEncode());
+  cancelBtn.addEventListener("click", () => {
+    // We can't preempt the worker mid-encode without SharedArrayBuffer,
+    // but we can mark the in-flight request stale so its result is
+    // dropped when it returns. Bumping latestReqId achieves that.
+    latestReqId = nextReqId++;
+    inflightReqId = 0;
+    status.textContent = "Cancelled (in-flight result will be dropped)";
+    cancelBtn.disabled = true;
+    encodeBtn.disabled = false;
+    setEncodingIndicator(false);
   });
   resetBtn.addEventListener("click", () => {
     currentImage = synthetic();
+    eqStates.clear();
+    paretoCache.delete(currentImage.key);
+    paretoQueues.delete(currentImage.key);
+    imagePickSel.value = "__synthetic__";
+    imageInfoEl.textContent = "64 × 64 (synthetic)";
     void runEncode();
   });
   fileIn.addEventListener("change", async () => {
     const file = fileIn.files?.[0];
     if (!file) return;
-    await loadFile(file);
-    await runEncode();
+    eqStates.clear();
+    try {
+      await loadFile(file);
+    } catch (e) {
+      status.textContent = `Failed to load file: ${(e as Error).message}`;
+      return;
+    }
+    paretoCache.delete(currentImage.key);
+    paretoQueues.delete(currentImage.key);
+    imagePickSel.value = "__synthetic__";
+    void runEncode();
+  });
+  imagePickSel.addEventListener("change", async () => {
+    const id = imagePickSel.value;
+    if (id === "__synthetic__") {
+      currentImage = synthetic();
+      imageInfoEl.textContent = "64 × 64 (synthetic)";
+    } else {
+      const entry = imageManifest.find((e) => e.id === id);
+      if (!entry) return;
+      eqStates.clear();
+      status.textContent = `Loading ${entry.label}…`;
+      try {
+        await loadEntry(entry);
+      } catch (e) {
+        status.textContent = `Failed to load ${entry.label}: ${(e as Error).message}`;
+        console.error(e);
+        return;
+      }
+    }
+    paretoCache.delete(currentImage.key);
+    paretoQueues.delete(currentImage.key);
+    void runEncode();
+  });
+
+  // Tabs.
+  document.querySelectorAll<HTMLElement>(".tab").forEach((t) => {
+    t.addEventListener("click", () => setActiveTab(t.dataset.tab!));
+  });
+
+  // Curve controls.
+  for (const inp of [curveQscaleIn, curveTiltIn, curveHvIn]) {
+    inp.addEventListener("input", () => {
+      syncCurveOutputs();
+      applyCurveControls();
+      scheduleAutoEncode();
+    });
+  }
+  curvePresetSel.addEventListener("change", () => {
+    applyCurveControls();
+    scheduleAutoEncode();
+  });
+  curveResetBtn.addEventListener("click", () => {
+    curveQscaleIn.value = "1";
+    curveTiltIn.value = "0";
+    curveHvIn.value = "0";
+    curvePresetSel.value = "jfif";
+    syncCurveOutputs();
+    eqStates.clear();
+    if (currentDiagnostics) {
+      for (let i = 0; i < currentDiagnostics.components.length; i++) {
+        renderComponent(i, currentDiagnostics);
+      }
+    }
+    scheduleAutoEncode();
+  });
+  syncCurveOutputs();
+  applyIgnoredAnnotations();
+  refreshQuantBanner();
+
+  // Zero-bias controls.
+  for (let cidx = 0; cidx < 3; cidx++) {
+    const mulIn = document.getElementById(`zb-mul-${cidx}`) as HTMLInputElement | null;
+    const mulOut = document.getElementById(`zb-mul-${cidx}-out`) as HTMLOutputElement | null;
+    const dcIn = document.getElementById(`zb-dc-${cidx}`) as HTMLInputElement | null;
+    const acIn = document.getElementById(`zb-ac-${cidx}`) as HTMLInputElement | null;
+    if (mulIn && mulOut) {
+      mulIn.addEventListener("input", () => {
+        const v = parseFloat(mulIn.value);
+        zeroBias.globalMul[cidx] = v;
+        mulOut.textContent = v.toFixed(2);
+        scheduleAutoEncode();
+      });
+    }
+    if (dcIn) {
+      dcIn.addEventListener("input", () => {
+        zeroBias.offsetDc[cidx] = parseFloat(dcIn.value) || 0;
+        scheduleAutoEncode();
+      });
+    }
+    if (acIn) {
+      acIn.addEventListener("input", () => {
+        zeroBias.offsetAc[cidx] = parseFloat(acIn.value) || 0;
+        scheduleAutoEncode();
+      });
+    }
+  }
+  const zbReset = document.getElementById("zb-reset");
+  zbReset?.addEventListener("click", () => {
+    zeroBias.globalMul = [1, 1, 1];
+    zeroBias.offsetDc = [0, 0, 0];
+    zeroBias.offsetAc = [0, 0, 0];
+    for (let cidx = 0; cidx < 3; cidx++) {
+      const mulIn = document.getElementById(`zb-mul-${cidx}`) as HTMLInputElement | null;
+      const mulOut = document.getElementById(`zb-mul-${cidx}-out`) as HTMLOutputElement | null;
+      const dcIn = document.getElementById(`zb-dc-${cidx}`) as HTMLInputElement | null;
+      const acIn = document.getElementById(`zb-ac-${cidx}`) as HTMLInputElement | null;
+      if (mulIn) mulIn.value = "1";
+      if (mulOut) mulOut.textContent = "1.00";
+      if (dcIn) dcIn.value = "0";
+      if (acIn) acIn.value = "0";
+    }
+    scheduleAutoEncode();
+  });
+
+  // Mode radios — also refresh the quant banner.
+  document.querySelectorAll<HTMLInputElement>('input[name="mode"]').forEach((r) => {
+    r.addEventListener("change", refreshQuantBanner);
+  });
+  aqIn.addEventListener("change", refreshQuantBanner);
+  colorPathSel.addEventListener("change", refreshQuantBanner);
+}
+
+// ─── Zoom inspector ───────────────────────────────────────────────
+// Click any of source/encoded/delta to open a synchronized 3-pane
+// pixel-zoom view. Drag to pan, wheel to change zoom, 1-9 keys to
+// jump to scale, ESC to close. Re-renders live as the user drags
+// quality sliders (auto-encode).
+
+interface ZoomState {
+  open: boolean;
+  /** Image-pixel coordinates of the *center* of the viewport. */
+  centerX: number;
+  centerY: number;
+  /** Display pixels per source pixel. */
+  scale: number;
+  /** True while the user is dragging. */
+  panning: boolean;
+  panStartX: number;
+  panStartY: number;
+  panStartCenterX: number;
+  panStartCenterY: number;
+}
+const zoomState: ZoomState = {
+  open: false,
+  centerX: 0,
+  centerY: 0,
+  scale: 4,
+  panning: false,
+  panStartX: 0,
+  panStartY: 0,
+  panStartCenterX: 0,
+  panStartCenterY: 0,
+};
+
+function $zoomCanvas(name: "source" | "encoded" | "delta"): HTMLCanvasElement {
+  return $<HTMLCanvasElement>(`#zoom-${name}`);
+}
+
+function openZoomFromClick(
+  src: "source" | "encoded" | "delta",
+  ev: MouseEvent,
+): void {
+  const data = zoomImageData[src];
+  if (!data) return;
+  // Translate the click into source-pixel coordinates.
+  const target = ev.currentTarget as HTMLCanvasElement;
+  const rect = target.getBoundingClientRect();
+  const sx = ((ev.clientX - rect.left) / rect.width) * target.width;
+  const sy = ((ev.clientY - rect.top) / rect.height) * target.height;
+  // Each pane may have its own dimensions (encoded/delta could differ
+  // from source in pathological cases) but for our pipeline they're
+  // always equal. Use the source pane as the canonical coordinate space.
+  const ref = zoomImageData.source ?? data;
+  const refX = (sx / target.width) * ref.width;
+  const refY = (sy / target.height) * ref.height;
+  zoomState.centerX = refX;
+  zoomState.centerY = refY;
+  zoomState.scale = 4;
+  zoomState.open = true;
+  const modal = $<HTMLElement>("#zoom-modal");
+  modal.hidden = false;
+  document.body.style.overflow = "hidden";
+  // Two RAFs because the modal needs a layout pass before the
+  // canvases have non-zero clientWidth/Height.
+  requestAnimationFrame(() => requestAnimationFrame(drawZoomFrame));
+}
+
+function closeZoom(): void {
+  zoomState.open = false;
+  zoomState.panning = false;
+  $<HTMLElement>("#zoom-modal").hidden = true;
+  document.body.style.overflow = "";
+}
+
+function drawZoomPane(
+  name: "source" | "encoded" | "delta",
+  data: ImageData | null,
+): void {
+  const c = $zoomCanvas(name);
+  // Match canvas pixels to its CSS box so we don't get blurry scaling.
+  const cssW = Math.max(64, Math.floor(c.clientWidth));
+  const cssH = Math.max(64, Math.floor(c.clientHeight));
+  if (c.width !== cssW || c.height !== cssH) {
+    c.width = cssW;
+    c.height = cssH;
+  }
+  const ctx = c.getContext("2d");
+  if (!ctx) return;
+  ctx.imageSmoothingEnabled = false;
+  ctx.fillStyle = "#000";
+  ctx.fillRect(0, 0, c.width, c.height);
+  if (!data) return;
+
+  // Extract the visible window from the source data and draw it
+  // pixel-doubled (or N-doubled). Center is in image-pixel coords.
+  const scale = zoomState.scale;
+  const visW = c.width / scale;
+  const visH = c.height / scale;
+  const x0 = zoomState.centerX - visW / 2;
+  const y0 = zoomState.centerY - visH / 2;
+
+  // Use a temporary canvas to draw the source ImageData, then drawImage
+  // it scaled. drawImage with imageSmoothingEnabled=false gives crisp
+  // pixel doubling at any integer scale. Floats fall back to nearest.
+  const tmp = document.createElement("canvas");
+  tmp.width = data.width;
+  tmp.height = data.height;
+  tmp.getContext("2d")!.putImageData(data, 0, 0);
+  ctx.drawImage(
+    tmp,
+    x0,
+    y0,
+    visW,
+    visH,
+    0,
+    0,
+    c.width,
+    c.height,
+  );
+
+  // Subtle grid every 8 source pixels to mark JPEG block edges, but
+  // only when the scale is large enough to make the lines worth seeing.
+  if (scale >= 4) {
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.08)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    const firstBlockX = Math.ceil(x0 / 8) * 8;
+    for (let bx = firstBlockX; bx < x0 + visW; bx += 8) {
+      const px = (bx - x0) * scale;
+      ctx.moveTo(px, 0);
+      ctx.lineTo(px, c.height);
+    }
+    const firstBlockY = Math.ceil(y0 / 8) * 8;
+    for (let by = firstBlockY; by < y0 + visH; by += 8) {
+      const py = (by - y0) * scale;
+      ctx.moveTo(0, py);
+      ctx.lineTo(c.width, py);
+    }
+    ctx.stroke();
+  }
+}
+
+function drawZoomFrame(): void {
+  if (!zoomState.open) return;
+  drawZoomPane("source", zoomImageData.source);
+  drawZoomPane("encoded", zoomImageData.encoded);
+  drawZoomPane("delta", zoomImageData.delta);
+  const coordsEl = document.getElementById("zoom-coords");
+  if (coordsEl)
+    coordsEl.textContent = `(${Math.round(zoomState.centerX)}, ${Math.round(zoomState.centerY)})`;
+  const scaleEl = document.getElementById("zoom-scale");
+  if (scaleEl) scaleEl.textContent = `×${zoomState.scale}`;
+}
+
+function wireZoomInspector(): void {
+  // Click on a triptych canvas opens the modal at the click point.
+  for (const which of ["source", "encoded", "delta"] as const) {
+    const triptych = document.querySelector<HTMLCanvasElement>(
+      `[data-zoom-source="${which}"]`,
+    );
+    if (!triptych) continue;
+    triptych.addEventListener("click", (ev) => openZoomFromClick(which, ev));
+  }
+
+  const modal = $<HTMLElement>("#zoom-modal");
+  $<HTMLButtonElement>("#zoom-close").addEventListener("click", closeZoom);
+  modal.addEventListener("click", (ev) => {
+    if (ev.target === modal) closeZoom();
+  });
+
+  // Pan + wheel zoom on every zoom canvas (synchronized).
+  for (const which of ["source", "encoded", "delta"] as const) {
+    const c = $zoomCanvas(which);
+    c.addEventListener("mousedown", (ev) => {
+      zoomState.panning = true;
+      zoomState.panStartX = ev.clientX;
+      zoomState.panStartY = ev.clientY;
+      zoomState.panStartCenterX = zoomState.centerX;
+      zoomState.panStartCenterY = zoomState.centerY;
+    });
+    c.addEventListener("wheel", (ev) => {
+      ev.preventDefault();
+      // Wheel up → zoom in. Snap to integer scales for crisp pixels.
+      const delta = ev.deltaY < 0 ? +1 : -1;
+      const next = clamp(zoomState.scale + delta, 1, 32);
+      if (next === zoomState.scale) return;
+      // Zoom around the cursor position so the pixel under the
+      // cursor stays put.
+      const rect = c.getBoundingClientRect();
+      const cx = ev.clientX - rect.left;
+      const cy = ev.clientY - rect.top;
+      const oldVisW = c.width / zoomState.scale;
+      const oldVisH = c.height / zoomState.scale;
+      const cursorImgX =
+        zoomState.centerX - oldVisW / 2 + (cx / c.width) * oldVisW;
+      const cursorImgY =
+        zoomState.centerY - oldVisH / 2 + (cy / c.height) * oldVisH;
+      zoomState.scale = next;
+      const newVisW = c.width / zoomState.scale;
+      const newVisH = c.height / zoomState.scale;
+      zoomState.centerX = cursorImgX - (cx / c.width - 0.5) * newVisW;
+      zoomState.centerY = cursorImgY - (cy / c.height - 0.5) * newVisH;
+      drawZoomFrame();
+    }, { passive: false });
+  }
+
+  window.addEventListener("mousemove", (ev) => {
+    if (!zoomState.panning) return;
+    // Pan all three panes together. Use any zoom canvas's size as the
+    // reference for px-per-source-pixel scaling.
+    const c = $zoomCanvas("source");
+    const dx = (ev.clientX - zoomState.panStartX) / zoomState.scale;
+    const dy = (ev.clientY - zoomState.panStartY) / zoomState.scale;
+    zoomState.centerX = zoomState.panStartCenterX - dx;
+    zoomState.centerY = zoomState.panStartCenterY - dy;
+    void c;
+    drawZoomFrame();
+  });
+  window.addEventListener("mouseup", () => {
+    zoomState.panning = false;
+  });
+
+  // Keyboard: ESC closes; 1-9 sets scale; arrow keys nudge center.
+  window.addEventListener("keydown", (ev) => {
+    if (!zoomState.open) return;
+    if (ev.key === "Escape") {
+      ev.preventDefault();
+      closeZoom();
+      return;
+    }
+    if (/^[1-9]$/.test(ev.key)) {
+      zoomState.scale = parseInt(ev.key, 10);
+      drawZoomFrame();
+      ev.preventDefault();
+      return;
+    }
+    const step = 16 / zoomState.scale;
+    if (ev.key === "ArrowLeft") {
+      zoomState.centerX -= step;
+      drawZoomFrame();
+      ev.preventDefault();
+    } else if (ev.key === "ArrowRight") {
+      zoomState.centerX += step;
+      drawZoomFrame();
+      ev.preventDefault();
+    } else if (ev.key === "ArrowUp") {
+      zoomState.centerY -= step;
+      drawZoomFrame();
+      ev.preventDefault();
+    } else if (ev.key === "ArrowDown") {
+      zoomState.centerY += step;
+      drawZoomFrame();
+      ev.preventDefault();
+    }
+  });
+
+  // Window resize triggers a re-render so canvas dims sync.
+  window.addEventListener("resize", () => {
+    if (zoomState.open) drawZoomFrame();
   });
 }
 
+// ─── Bootstrap ────────────────────────────────────────────────────
 (async () => {
   document.body.dataset.bootstrap = "started";
-  status.textContent = "Loading WASM…";
+  status.textContent = "Initializing wasm in worker…";
   try {
+    // Initialize the main-thread wasm too (for ssim2/zensim scoring,
+    // since worker-side scoring is deferred until after we decode the
+    // JPEG on this thread anyway).
     await init();
-    document.body.dataset.bootstrap = "wasm-init-ok";
+    document.body.dataset.bootstrap = "main-wasm-init-ok";
   } catch (err) {
-    document.body.dataset.bootstrap = "wasm-init-failed";
-    document.body.dataset.encodeState = "error";
-    status.textContent = `WASM init failed: ${(err as Error).message ?? err}`;
-    console.error("WASM init", err);
+    document.body.dataset.bootstrap = "main-wasm-init-failed";
+    status.textContent = `Main wasm init failed: ${(err as Error).message ?? err}`;
     return;
   }
-  status.textContent = "WASM loaded — encoding synthetic 64×64 sample";
+  await workerReady;
+  document.body.dataset.bootstrap = "worker-ready";
+  status.textContent = "Wasm + worker ready — encoding synthetic 64×64 sample";
   document.body.dataset.wasmState = "ready";
+  loadImageManifest();
+  imageInfoEl.textContent = "64 × 64 (synthetic)";
   try {
     wireControls();
+    wireZoomInspector();
     document.body.dataset.bootstrap = "controls-wired";
   } catch (err) {
     document.body.dataset.bootstrap = "controls-wire-failed";
-    document.body.dataset.encodeState = "error";
     status.textContent = `wireControls failed: ${(err as Error).message ?? err}`;
-    console.error("wireControls", err);
     return;
   }
   await runEncode();
 })();
 
-// Expose for Playwright.
+// ─── Test API ─────────────────────────────────────────────────────
 declare global {
   interface Window {
     __zenjpegDiagnostics: {
       getCurrent: () => Diagnostics | null;
+      getLastEncode: () => LastEncode | null;
       runEncode: () => Promise<void>;
+      setActiveTab: (name: string) => void;
+      getEqStates: () => Map<number, ComponentEqState>;
+      getCurrentOptions: () => EncodeOptions;
     };
   }
 }
 window.__zenjpegDiagnostics = {
   getCurrent: () => currentDiagnostics,
+  getLastEncode: () => lastEncode,
   runEncode,
+  setActiveTab,
+  getEqStates: () => eqStates,
+  getCurrentOptions: () => currentOptions(),
 };

--- a/zenjpeg-diagnostics-viewer/web/src/main.ts
+++ b/zenjpeg-diagnostics-viewer/web/src/main.ts
@@ -1,0 +1,530 @@
+// Entry point for the zenjpeg encode-diagnostics demo viewer.
+//
+// Flow:
+//   1. Load the wasm-pack module.
+//   2. Render synthetic source pattern (or load user file).
+//   3. Call encodeWithDiagnostics with the current control state.
+//   4. Decode the encoded bytes via the browser's <img> for display.
+//   5. Render diagnostics: AQ map, per-component utilization heatmap,
+//      live re-quant on EQ slider drag.
+//
+// All UI state lives in module-level mutable refs; this is a small
+// vanilla TS app — no framework, no virtual DOM.
+
+import init, { encodeWithDiagnostics } from "../wasm-pkg/zenjpeg_diagnostics_wasm.js";
+import { drawHeatmap } from "./heatmap";
+import { syntheticPattern } from "./synthetic";
+import type {
+  ComponentDiagnostics,
+  Diagnostics,
+  EncodeOptions,
+  EncodeResult,
+} from "./types";
+
+const $ = <T extends HTMLElement>(sel: string): T => {
+  const el = document.querySelector(sel);
+  if (!el) throw new Error(`element not found: ${sel}`);
+  return el as T;
+};
+
+const status = $<HTMLParagraphElement>("#status");
+const qualityIn = $<HTMLInputElement>("#quality");
+const qualityOut = $<HTMLOutputElement>("#quality-out");
+const colorPathSel = $<HTMLSelectElement>("#color-path");
+const subSel = $<HTMLSelectElement>("#subsampling");
+const xybSubSel = $<HTMLSelectElement>("#xyb-subsampling");
+const subLabel = $<HTMLLabelElement>("#subsampling-label");
+const xybLabel = $<HTMLLabelElement>("#xyb-subsampling-label");
+const aqIn = $<HTMLInputElement>("#aq-enabled");
+const trellisIn = $<HTMLInputElement>("#trellis");
+const autoOptIn = $<HTMLInputElement>("#auto-optimize");
+const fileIn = $<HTMLInputElement>("#image-input");
+const resetBtn = $<HTMLButtonElement>("#reset");
+const encodeBtn = $<HTMLButtonElement>("#encode");
+const sourceCanvas = $<HTMLCanvasElement>("#source-canvas");
+const encodedCanvas = $<HTMLCanvasElement>("#encoded-canvas");
+const deltaCanvas = $<HTMLCanvasElement>("#delta-canvas");
+const aqCanvas = $<HTMLCanvasElement>("#aq-canvas");
+const compRoot = $<HTMLElement>("#component-0").parentElement!;
+
+interface ImageState {
+  width: number;
+  height: number;
+  /** Source RGBA, length = width*height*4. */
+  rgba: Uint8ClampedArray;
+}
+
+interface ComponentEqState {
+  /** Length 8, multiplier per horizontal-frequency column. */
+  hEq: number[];
+  /** Length 8, multiplier per vertical-frequency row. */
+  vEq: number[];
+}
+
+let currentImage: ImageState = synthetic();
+let currentDiagnostics: Diagnostics | null = null;
+const eqStates = new Map<number, ComponentEqState>();
+
+function synthetic(): ImageState {
+  const w = 64;
+  const h = 64;
+  return {
+    width: w,
+    height: h,
+    rgba: syntheticPattern(w, h),
+  };
+}
+
+function drawRGBA(
+  canvas: HTMLCanvasElement,
+  rgba: Uint8ClampedArray,
+  w: number,
+  h: number,
+): void {
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("canvas 2d unavailable");
+  ctx.putImageData(new ImageData(rgba.slice(), w, h), 0, 0);
+}
+
+async function decodeJpeg(bytes: Uint8Array): Promise<ImageData> {
+  const blob = new Blob([bytes.slice()], { type: "image/jpeg" });
+  const url = URL.createObjectURL(blob);
+  try {
+    const img = await new Promise<HTMLImageElement>((res, rej) => {
+      const i = new Image();
+      i.onload = () => res(i);
+      i.onerror = rej;
+      i.src = url;
+    });
+    const c = document.createElement("canvas");
+    c.width = img.naturalWidth;
+    c.height = img.naturalHeight;
+    const cx = c.getContext("2d");
+    if (!cx) throw new Error("canvas 2d unavailable");
+    cx.drawImage(img, 0, 0);
+    return cx.getImageData(0, 0, c.width, c.height);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function deltaImage(src: ImageData, dec: ImageData, gain = 8): ImageData {
+  const w = src.width;
+  const h = src.height;
+  const out = new ImageData(w, h);
+  for (let i = 0; i < w * h * 4; i += 4) {
+    out.data[i] = Math.min(255, Math.abs(src.data[i]! - dec.data[i]!) * gain);
+    out.data[i + 1] = Math.min(
+      255,
+      Math.abs(src.data[i + 1]! - dec.data[i + 1]!) * gain,
+    );
+    out.data[i + 2] = Math.min(
+      255,
+      Math.abs(src.data[i + 2]! - dec.data[i + 2]!) * gain,
+    );
+    out.data[i + 3] = 255;
+  }
+  return out;
+}
+
+function rgbaToPackedRgb(rgba: Uint8ClampedArray): Uint8Array {
+  const n = rgba.length / 4;
+  const out = new Uint8Array(n * 3);
+  for (let i = 0, j = 0; i < rgba.length; i += 4, j += 3) {
+    out[j] = rgba[i]!;
+    out[j + 1] = rgba[i + 1]!;
+    out[j + 2] = rgba[i + 2]!;
+  }
+  return out;
+}
+
+function currentOptions(): EncodeOptions {
+  return {
+    quality: parseInt(qualityIn.value, 10),
+    colorPath: colorPathSel.value as "ycbcr" | "xyb",
+    subsampling: subSel.value as EncodeOptions["subsampling"],
+    xybSubsampling: xybSubSel.value as EncodeOptions["xybSubsampling"],
+    aqEnabled: aqIn.checked,
+    trellis: trellisIn.checked,
+    autoOptimize: autoOptIn.checked,
+    deringing: true,
+  };
+}
+
+function eqStateFor(componentIdx: number, comp: ComponentDiagnostics): ComponentEqState {
+  let s = eqStates.get(componentIdx);
+  if (!s) {
+    s = { hEq: Array(8).fill(1), vEq: Array(8).fill(1) };
+    eqStates.set(componentIdx, s);
+  }
+  void comp; // keep signature stable for future per-component init
+  return s;
+}
+
+function effectiveQuant(comp: ComponentDiagnostics, eq: ComponentEqState): Float32Array {
+  const out = new Float32Array(64);
+  for (let v = 0; v < 8; v++) {
+    for (let u = 0; u < 8; u++) {
+      const idx = v * 8 + u;
+      const base = comp.quantTableBase[idx]! as number;
+      out[idx] = base * eq.hEq[u]! * eq.vEq[v]!;
+    }
+  }
+  return out;
+}
+
+/**
+ * For each natural-order coefficient position, compute the mean
+ * |coef_pre_quant| / effective_quant across all blocks. Values >> 1 mean
+ * the coefficient has lots of headroom (table overshoots); << 1 means
+ * the position is mostly quantized to zero.
+ */
+function utilizationField(
+  comp: ComponentDiagnostics,
+  q: Float32Array,
+): { field: Float32Array; zeroRate: number } {
+  const accum = new Float64Array(64);
+  let totalCoef = 0;
+  let zeroCoef = 0;
+  for (const block of comp.blocks) {
+    const c = block.coefPreQuant;
+    for (let i = 0; i < 64; i++) {
+      const qv = q[i]!;
+      if (qv <= 0) continue;
+      const ratio = Math.abs(c[i]! as number) / qv;
+      accum[i]! += ratio;
+      totalCoef++;
+      if (ratio < 0.5) zeroCoef++;
+    }
+  }
+  const field = new Float32Array(64);
+  const n = comp.blocks.length;
+  if (n > 0) {
+    for (let i = 0; i < 64; i++) field[i] = accum[i]! / n;
+  }
+  return {
+    field,
+    zeroRate: totalCoef > 0 ? (zeroCoef / totalCoef) * 100 : 0,
+  };
+}
+
+function buildQuantGrid(
+  el: HTMLElement,
+  comp: ComponentDiagnostics,
+  eq: ComponentEqState,
+): void {
+  el.replaceChildren();
+  const eff = effectiveQuant(comp, eq);
+  for (let v = 0; v < 8; v++) {
+    for (let u = 0; u < 8; u++) {
+      const cell = document.createElement("div");
+      const idx = v * 8 + u;
+      const val = eff[idx]!;
+      cell.textContent = val < 100 ? val.toFixed(0) : Math.round(val).toString();
+      cell.title = `(${u},${v}) base=${comp.quantTableBase[idx]} effective=${val.toFixed(1)}`;
+      el.appendChild(cell);
+    }
+  }
+}
+
+function buildEqSliders(
+  hEl: HTMLElement,
+  vEl: HTMLElement,
+  eq: ComponentEqState,
+  onChange: () => void,
+): void {
+  hEl.replaceChildren();
+  vEl.replaceChildren();
+  for (let i = 0; i < 8; i++) {
+    const h = document.createElement("input");
+    h.type = "range";
+    h.min = "0.5";
+    h.max = "2";
+    h.step = "0.05";
+    h.value = String(eq.hEq[i]!);
+    h.dataset.testid = `comp-0-h-eq-${i}`;
+    h.title = `h_eq[${i}]: column ${i} multiplier`;
+    h.addEventListener("input", () => {
+      eq.hEq[i] = parseFloat(h.value);
+      onChange();
+    });
+    hEl.appendChild(h);
+
+    const vv = document.createElement("input");
+    vv.type = "range";
+    vv.min = "0.5";
+    vv.max = "2";
+    vv.step = "0.05";
+    vv.value = String(eq.vEq[i]!);
+    vv.dataset.testid = `comp-0-v-eq-${i}`;
+    vv.title = `v_eq[${i}]: row ${i} multiplier`;
+    vv.addEventListener("input", () => {
+      eq.vEq[i] = parseFloat(vv.value);
+      onChange();
+    });
+    vEl.appendChild(vv);
+  }
+}
+
+function renderComponent(
+  componentIdx: number,
+  diag: Diagnostics,
+): void {
+  const comp = diag.components[componentIdx];
+  if (!comp) return;
+  let article = document.querySelector<HTMLElement>(
+    `[data-component="${componentIdx}"]`,
+  );
+  if (!article) {
+    // Clone component-0's structure for additional components.
+    const tmpl = document.querySelector<HTMLElement>('[data-component="0"]');
+    if (!tmpl) throw new Error("template article missing");
+    article = tmpl.cloneNode(true) as HTMLElement;
+    article.dataset.component = String(componentIdx);
+    article.id = `component-${componentIdx}`;
+    // Patch test-ids.
+    article.querySelectorAll<HTMLElement>("[data-testid^='comp-0-']").forEach((el) => {
+      el.dataset.testid = el.dataset.testid!.replace(
+        "comp-0-",
+        `comp-${componentIdx}-`,
+      );
+    });
+    const headerH2 = article.querySelector<HTMLHeadingElement>("h2");
+    if (headerH2) {
+      headerH2.textContent = `Component ${componentIdx} (${componentLabel(diag.colorPath, componentIdx)})`;
+    }
+    compRoot.appendChild(article);
+  } else {
+    const headerH2 = article.querySelector<HTMLHeadingElement>("h2");
+    if (headerH2) {
+      headerH2.textContent = `Component ${componentIdx} (${componentLabel(diag.colorPath, componentIdx)})`;
+    }
+  }
+
+  const gridInfo = article.querySelector<HTMLParagraphElement>(
+    `[data-testid="comp-${componentIdx}-grid-info"]`,
+  )!;
+  const [cols, rows] = comp.blockGrid;
+  gridInfo.textContent = `${cols}×${rows} blocks (${cols * rows} total)`;
+
+  const eq = eqStateFor(componentIdx, comp);
+  const quantGridEl = article.querySelector<HTMLElement>(
+    `[data-testid="comp-${componentIdx}-quant-grid"]`,
+  )!;
+  const hEqEl = article.querySelector<HTMLElement>(
+    `[data-testid="comp-${componentIdx}-h-eq"]`,
+  )!;
+  const vEqEl = article.querySelector<HTMLElement>(
+    `[data-testid="comp-${componentIdx}-v-eq"]`,
+  )!;
+  const utilCanvas = article.querySelector<HTMLCanvasElement>(
+    `[data-testid="comp-${componentIdx}-utilization"]`,
+  )!;
+  const zeroRateEl = article.querySelector<HTMLElement>(
+    `[data-testid="comp-${componentIdx}-zero-rate"]`,
+  )!;
+  const resetBtn = article.querySelector<HTMLButtonElement>(
+    `[data-testid="comp-${componentIdx}-reset-eq"]`,
+  )!;
+
+  const refresh = () => {
+    buildQuantGrid(quantGridEl, comp, eq);
+    const q = effectiveQuant(comp, eq);
+    const { field, zeroRate } = utilizationField(comp, q);
+    drawHeatmap(utilCanvas, field, { cols: 8, rows: 8, pixelSize: 25 });
+    zeroRateEl.textContent = zeroRate.toFixed(1);
+  };
+
+  buildEqSliders(hEqEl, vEqEl, eq, refresh);
+  resetBtn.addEventListener("click", () => {
+    eq.hEq.fill(1);
+    eq.vEq.fill(1);
+    article!
+      .querySelectorAll<HTMLInputElement>(
+        `[data-testid^="comp-${componentIdx}-h-eq-"], [data-testid^="comp-${componentIdx}-v-eq-"]`,
+      )
+      .forEach((el) => {
+        el.value = "1";
+      });
+    refresh();
+  });
+  refresh();
+}
+
+function componentLabel(colorPath: string, idx: number): string {
+  if (colorPath === "XYB") {
+    return ["X", "Y (XYB)", "B"][idx] ?? `c${idx}`;
+  }
+  if (colorPath === "Grayscale") return "Y";
+  return ["Y", "Cb", "Cr"][idx] ?? `c${idx}`;
+}
+
+function renderAqField(diag: Diagnostics): void {
+  const yComp = diag.components[0];
+  if (!yComp) return;
+  const [cols, rows] = yComp.blockGrid;
+  const data = new Float32Array(cols * rows);
+  for (let i = 0; i < yComp.blocks.length; i++) {
+    data[i] = yComp.blocks[i]!.aqMultiplier;
+  }
+  drawHeatmap(aqCanvas, data, {
+    cols,
+    rows,
+    pixelSize: Math.max(8, Math.min(40, Math.floor(480 / cols))),
+  });
+}
+
+async function runEncode(): Promise<void> {
+  if (!currentImage) return;
+  document.body.dataset.encodePhase = "start";
+  status.textContent = "Encoding…";
+  encodeBtn.disabled = true;
+  try {
+    const packed = rgbaToPackedRgb(currentImage.rgba);
+    const opts = currentOptions();
+    document.body.dataset.encodePhase = "calling-wasm";
+    const result = (await encodeWithDiagnostics(
+      packed,
+      currentImage.width,
+      currentImage.height,
+      opts,
+    )) as EncodeResult;
+    document.body.dataset.encodePhase = "wasm-returned";
+
+    drawRGBA(sourceCanvas, currentImage.rgba, currentImage.width, currentImage.height);
+
+    const decoded = await decodeJpeg(result.bytes);
+    encodedCanvas.width = decoded.width;
+    encodedCanvas.height = decoded.height;
+    encodedCanvas.getContext("2d")!.putImageData(decoded, 0, 0);
+
+    const sourceImageData = new ImageData(
+      currentImage.rgba.slice(),
+      currentImage.width,
+      currentImage.height,
+    );
+    const delta = deltaImage(sourceImageData, decoded);
+    deltaCanvas.width = delta.width;
+    deltaCanvas.height = delta.height;
+    deltaCanvas.getContext("2d")!.putImageData(delta, 0, 0);
+
+    currentDiagnostics = result.diagnostics;
+    eqStates.clear();
+    renderAqField(result.diagnostics);
+    // Remove additional component articles we may have appended.
+    compRoot
+      .querySelectorAll<HTMLElement>("[data-component]")
+      .forEach((el) => {
+        if (el.dataset.component !== "0") el.remove();
+      });
+    for (let i = 0; i < result.diagnostics.components.length; i++) {
+      renderComponent(i, result.diagnostics);
+    }
+    status.textContent = `Encoded ${result.bytes.byteLength} bytes (${result.diagnostics.components.length} components, ${
+      result.diagnostics.components[0]?.blocks.length ?? 0
+    } Y blocks)`;
+    document.body.dataset.encodeState = "done";
+  } catch (e) {
+    console.error(e);
+    status.textContent = `Error: ${(e as Error).message}`;
+    document.body.dataset.encodeState = "error";
+  } finally {
+    encodeBtn.disabled = false;
+  }
+}
+
+async function loadFile(file: File): Promise<void> {
+  const url = URL.createObjectURL(file);
+  try {
+    const img = await new Promise<HTMLImageElement>((res, rej) => {
+      const i = new Image();
+      i.onload = () => res(i);
+      i.onerror = rej;
+      i.src = url;
+    });
+    const w = img.naturalWidth;
+    const h = img.naturalHeight;
+    const c = document.createElement("canvas");
+    c.width = w;
+    c.height = h;
+    const cx = c.getContext("2d");
+    if (!cx) throw new Error("canvas 2d unavailable");
+    cx.drawImage(img, 0, 0);
+    const data = cx.getImageData(0, 0, w, h);
+    currentImage = { width: w, height: h, rgba: data.data };
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function wireControls(): void {
+  qualityIn.addEventListener("input", () => {
+    qualityOut.textContent = qualityIn.value;
+  });
+  colorPathSel.addEventListener("change", () => {
+    if (colorPathSel.value === "xyb") {
+      subLabel.hidden = true;
+      xybLabel.hidden = false;
+    } else {
+      subLabel.hidden = false;
+      xybLabel.hidden = true;
+    }
+  });
+  encodeBtn.addEventListener("click", () => {
+    void runEncode();
+  });
+  resetBtn.addEventListener("click", () => {
+    currentImage = synthetic();
+    void runEncode();
+  });
+  fileIn.addEventListener("change", async () => {
+    const file = fileIn.files?.[0];
+    if (!file) return;
+    await loadFile(file);
+    await runEncode();
+  });
+}
+
+(async () => {
+  document.body.dataset.bootstrap = "started";
+  status.textContent = "Loading WASM…";
+  try {
+    await init();
+    document.body.dataset.bootstrap = "wasm-init-ok";
+  } catch (err) {
+    document.body.dataset.bootstrap = "wasm-init-failed";
+    document.body.dataset.encodeState = "error";
+    status.textContent = `WASM init failed: ${(err as Error).message ?? err}`;
+    console.error("WASM init", err);
+    return;
+  }
+  status.textContent = "WASM loaded — encoding synthetic 64×64 sample";
+  document.body.dataset.wasmState = "ready";
+  try {
+    wireControls();
+    document.body.dataset.bootstrap = "controls-wired";
+  } catch (err) {
+    document.body.dataset.bootstrap = "controls-wire-failed";
+    document.body.dataset.encodeState = "error";
+    status.textContent = `wireControls failed: ${(err as Error).message ?? err}`;
+    console.error("wireControls", err);
+    return;
+  }
+  await runEncode();
+})();
+
+// Expose for Playwright.
+declare global {
+  interface Window {
+    __zenjpegDiagnostics: {
+      getCurrent: () => Diagnostics | null;
+      runEncode: () => Promise<void>;
+    };
+  }
+}
+window.__zenjpegDiagnostics = {
+  getCurrent: () => currentDiagnostics,
+  runEncode,
+};

--- a/zenjpeg-diagnostics-viewer/web/src/main.ts
+++ b/zenjpeg-diagnostics-viewer/web/src/main.ts
@@ -230,6 +230,7 @@ function buildQuantGrid(
 }
 
 function buildEqSliders(
+  componentIdx: number,
   hEl: HTMLElement,
   vEl: HTMLElement,
   eq: ComponentEqState,
@@ -244,7 +245,7 @@ function buildEqSliders(
     h.max = "2";
     h.step = "0.05";
     h.value = String(eq.hEq[i]!);
-    h.dataset.testid = `comp-0-h-eq-${i}`;
+    h.dataset.testid = `comp-${componentIdx}-h-eq-${i}`;
     h.title = `h_eq[${i}]: column ${i} multiplier`;
     h.addEventListener("input", () => {
       eq.hEq[i] = parseFloat(h.value);
@@ -258,7 +259,7 @@ function buildEqSliders(
     vv.max = "2";
     vv.step = "0.05";
     vv.value = String(eq.vEq[i]!);
-    vv.dataset.testid = `comp-0-v-eq-${i}`;
+    vv.dataset.testid = `comp-${componentIdx}-v-eq-${i}`;
     vv.title = `v_eq[${i}]: row ${i} multiplier`;
     vv.addEventListener("input", () => {
       eq.vEq[i] = parseFloat(vv.value);
@@ -337,7 +338,7 @@ function renderComponent(
     zeroRateEl.textContent = zeroRate.toFixed(1);
   };
 
-  buildEqSliders(hEqEl, vEqEl, eq, refresh);
+  buildEqSliders(componentIdx, hEqEl, vEqEl, eq, refresh);
   resetBtn.addEventListener("click", () => {
     eq.hEq.fill(1);
     eq.vEq.fill(1);

--- a/zenjpeg-diagnostics-viewer/web/src/styles.css
+++ b/zenjpeg-diagnostics-viewer/web/src/styles.css
@@ -1,0 +1,310 @@
+:root {
+  --bg: #0e1117;
+  --panel: #161b22;
+  --line: #30363d;
+  --text: #c9d1d9;
+  --muted: #8b949e;
+  --accent: #58a6ff;
+  --warm: #f0883e;
+  --hot: #ff6b6b;
+  --cold: #6ec1e4;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica,
+    sans-serif;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.4;
+}
+
+header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  align-items: baseline;
+  gap: 24px;
+}
+header h1 {
+  font-size: 18px;
+  margin: 0;
+  font-weight: 600;
+}
+.status {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 18px;
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+  font-size: 13px;
+  align-items: center;
+}
+.controls label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+}
+.controls input[type="range"] {
+  width: 140px;
+}
+.controls select {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 4px 6px;
+}
+.controls button {
+  background: var(--accent);
+  color: var(--bg);
+  border: 0;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 13px;
+  cursor: pointer;
+  font-weight: 600;
+}
+.controls button:hover {
+  filter: brightness(1.1);
+}
+.file-pick {
+  position: relative;
+}
+.file-pick input[type="file"] {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+}
+.file-pick span {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
+main {
+  padding: 16px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.triptych {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.triptych figure {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+.triptych figcaption {
+  color: var(--muted);
+  font-size: 12px;
+  margin-bottom: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.triptych canvas {
+  width: 100%;
+  height: auto;
+  image-rendering: pixelated;
+  background: #000;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
+.aq-row {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 12px 16px;
+}
+.aq-row h2 {
+  font-size: 14px;
+  margin: 0 0 8px 0;
+  color: var(--accent);
+}
+#aq-canvas {
+  display: block;
+  width: 100%;
+  max-width: 480px;
+  height: auto;
+  image-rendering: pixelated;
+  background: #000;
+  border-radius: 4px;
+}
+.legend {
+  margin: 8px 0 0 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.component-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.component {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 12px 16px;
+}
+.component header {
+  border: 0;
+  padding: 0 0 8px 0;
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+.component header h2 {
+  font-size: 14px;
+  margin: 0;
+  color: var(--accent);
+}
+.grid-info {
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  margin: 0;
+}
+
+.component-body {
+  display: grid;
+  grid-template-columns: minmax(280px, 1fr) minmax(220px, 1fr) minmax(200px, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.quant-editor {
+  display: grid;
+  grid-template-columns: auto auto;
+  grid-template-rows: auto auto auto;
+  gap: 6px;
+  align-items: center;
+}
+.quant-editor h3 {
+  grid-column: 1 / -1;
+  font-size: 13px;
+  margin: 0 0 4px 0;
+  color: var(--text);
+}
+.quant-grid {
+  grid-row: 2;
+  grid-column: 1;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 1px;
+  width: 200px;
+  height: 200px;
+  background: var(--line);
+  padding: 1px;
+  border-radius: 2px;
+}
+.quant-grid > div {
+  background: var(--bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9px;
+  color: var(--text);
+  user-select: none;
+}
+.eq-col {
+  grid-row: 2;
+  grid-column: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+.eq-row {
+  grid-row: 3;
+  grid-column: 1;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.eq-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--muted);
+}
+.eq-sliders.horizontal {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  width: 200px;
+  gap: 1px;
+}
+.eq-sliders.horizontal input {
+  appearance: slider-vertical;
+  width: 100%;
+  height: 36px;
+  margin: 0;
+}
+.eq-sliders.vertical {
+  display: grid;
+  grid-template-rows: repeat(8, 1fr);
+  height: 200px;
+  gap: 1px;
+}
+.eq-sliders.vertical input {
+  width: 36px;
+  margin: 0;
+}
+.reset-eq {
+  grid-column: 1 / -1;
+  grid-row: 4;
+  background: var(--panel);
+  color: var(--muted);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 11px;
+  cursor: pointer;
+  justify-self: start;
+}
+.reset-eq:hover {
+  color: var(--text);
+}
+
+.utilization h3,
+.estimate h3 {
+  font-size: 13px;
+  margin: 0 0 4px 0;
+  color: var(--text);
+}
+.utilization-canvas {
+  display: block;
+  width: 200px;
+  height: 200px;
+  image-rendering: pixelated;
+  background: #000;
+  border-radius: 2px;
+}
+
+.estimate p {
+  margin: 4px 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  color: var(--text);
+}

--- a/zenjpeg-diagnostics-viewer/web/src/styles.css
+++ b/zenjpeg-diagnostics-viewer/web/src/styles.css
@@ -58,6 +58,12 @@ header h1 {
   gap: 6px;
   color: var(--muted);
 }
+/* Browser default `[hidden] { display: none }` is overridden by the
+ * `display: flex` rule above (specificity tie + later rule wins). Be
+ * explicit so `subLabel.hidden = true` actually hides the label. */
+.controls label[hidden] {
+  display: none;
+}
 .controls input[type="range"] {
   width: 140px;
 }

--- a/zenjpeg-diagnostics-viewer/web/src/styles.css
+++ b/zenjpeg-diagnostics-viewer/web/src/styles.css
@@ -1,260 +1,95 @@
-:root {
-  --bg: #0e1117;
-  --panel: #161b22;
-  --line: #30363d;
-  --text: #c9d1d9;
-  --muted: #8b949e;
-  --accent: #58a6ff;
-  --warm: #f0883e;
-  --hot: #ff6b6b;
-  --cold: #6ec1e4;
+@import "tailwindcss";
+
+@theme {
+  --color-bg: #0e1117;
+  --color-panel: #161b22;
+  --color-panel-2: #1c232c;
+  --color-line: #30363d;
+  --color-text: #c9d1d9;
+  --color-muted: #8b949e;
+  --color-accent: #58a6ff;
+  --color-accent-soft: #1f6feb33;
+  --color-warm: #f0883e;
+  --color-hot: #ff6b6b;
+  --color-cold: #6ec1e4;
+  --color-good: #56d364;
+
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica,
+    sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
-* {
-  box-sizing: border-box;
+html,
+body {
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica,
-    sans-serif;
+  font-family: var(--font-sans);
   margin: 0;
-  background: var(--bg);
-  color: var(--text);
-  line-height: 1.4;
 }
 
-header {
-  padding: 16px 24px;
-  border-bottom: 1px solid var(--line);
-  display: flex;
-  align-items: baseline;
-  gap: 24px;
+/* Range / number input styling — Tailwind doesn't ship these in @theme. */
+input[type="range"] {
+  accent-color: var(--color-accent);
+  background: transparent;
 }
-header h1 {
-  font-size: 18px;
-  margin: 0;
-  font-weight: 600;
+input[type="number"],
+input[type="text"],
+select {
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-line);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-family: var(--font-mono);
+  font-size: 12px;
 }
-.status {
-  margin: 0;
-  color: var(--muted);
-  font-size: 13px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+input[type="number"]:focus,
+input[type="text"]:focus,
+select:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -1px;
+  border-color: var(--color-accent);
 }
 
-.controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 18px;
-  padding: 12px 24px;
-  border-bottom: 1px solid var(--line);
-  background: var(--panel);
-  font-size: 13px;
-  align-items: center;
-}
-.controls label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--muted);
-}
-/* Browser default `[hidden] { display: none }` is overridden by the
- * `display: flex` rule above (specificity tie + later rule wins). Be
- * explicit so `subLabel.hidden = true` actually hides the label. */
-.controls label[hidden] {
-  display: none;
-}
-.controls input[type="range"] {
-  width: 140px;
-}
-.controls select {
-  background: var(--bg);
-  color: var(--text);
-  border: 1px solid var(--line);
-  border-radius: 4px;
-  padding: 4px 6px;
-}
-.controls button {
-  background: var(--accent);
-  color: var(--bg);
-  border: 0;
-  border-radius: 4px;
-  padding: 6px 12px;
-  font-size: 13px;
+button {
   cursor: pointer;
-  font-weight: 600;
-}
-.controls button:hover {
-  filter: brightness(1.1);
-}
-.file-pick {
-  position: relative;
-}
-.file-pick input[type="file"] {
-  position: absolute;
-  width: 0;
-  height: 0;
-  opacity: 0;
-}
-.file-pick span {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 4px;
-  padding: 5px 10px;
-  cursor: pointer;
+  font-family: inherit;
 }
 
-main {
-  padding: 16px 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.triptych {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 16px;
-}
-.triptych figure {
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-}
-.triptych figcaption {
-  color: var(--muted);
-  font-size: 12px;
-  margin-bottom: 4px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-.triptych canvas {
-  width: 100%;
-  height: auto;
+canvas {
   image-rendering: pixelated;
-  background: #000;
-  border: 1px solid var(--line);
-  border-radius: 4px;
 }
 
-.aq-row {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 12px 16px;
-}
-.aq-row h2 {
-  font-size: 14px;
-  margin: 0 0 8px 0;
-  color: var(--accent);
-}
-#aq-canvas {
-  display: block;
-  width: 100%;
-  max-width: 480px;
-  height: auto;
-  image-rendering: pixelated;
-  background: #000;
-  border-radius: 4px;
-}
-.legend {
-  margin: 8px 0 0 0;
-  color: var(--muted);
-  font-size: 12px;
-}
-
-.component-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-.component {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 12px 16px;
-}
-.component header {
-  border: 0;
-  padding: 0 0 8px 0;
-  display: flex;
-  align-items: baseline;
-  gap: 12px;
-}
-.component header h2 {
-  font-size: 14px;
-  margin: 0;
-  color: var(--accent);
-}
-.grid-info {
-  color: var(--muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
-  margin: 0;
-}
-
-.component-body {
-  display: grid;
-  grid-template-columns: minmax(280px, 1fr) minmax(220px, 1fr) minmax(200px, 1fr);
-  gap: 24px;
-  align-items: start;
-}
-
-.quant-editor {
-  display: grid;
-  grid-template-columns: auto auto;
-  grid-template-rows: auto auto auto;
-  gap: 6px;
-  align-items: center;
-}
-.quant-editor h3 {
-  grid-column: 1 / -1;
-  font-size: 13px;
-  margin: 0 0 4px 0;
-  color: var(--text);
-}
+/* Quant grid cells — preserve fixed grid tile look. */
 .quant-grid {
-  grid-row: 2;
-  grid-column: 1;
   display: grid;
   grid-template-columns: repeat(8, 1fr);
   gap: 1px;
-  width: 200px;
-  height: 200px;
-  background: var(--line);
+  background: var(--color-line);
   padding: 1px;
   border-radius: 2px;
+  width: 200px;
+  height: 200px;
 }
 .quant-grid > div {
-  background: var(--bg);
+  background: var(--color-bg);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 9px;
-  color: var(--text);
+  color: var(--color-text);
   user-select: none;
+  cursor: pointer;
+  transition: background 0.1s;
 }
-.eq-col {
-  grid-row: 2;
-  grid-column: 2;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
+.quant-grid > div:hover {
+  background: var(--color-panel-2);
 }
-.eq-row {
-  grid-row: 3;
-  grid-column: 1;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-.eq-label {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  color: var(--muted);
-}
+
 .eq-sliders.horizontal {
   display: grid;
   grid-template-columns: repeat(8, 1fr);
@@ -277,40 +112,248 @@ main {
   width: 36px;
   margin: 0;
 }
-.reset-eq {
-  grid-column: 1 / -1;
-  grid-row: 4;
-  background: var(--panel);
-  color: var(--muted);
-  border: 1px solid var(--line);
-  border-radius: 4px;
-  padding: 4px 8px;
+
+/* Big-readout number block — drives the results panel. */
+.metric-readout {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 16px;
+  background: var(--color-panel-2);
+  border-radius: 6px;
+  border: 1px solid var(--color-line);
+  min-width: 140px;
+}
+.metric-readout .label {
   font-size: 11px;
-  cursor: pointer;
-  justify-self: start;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+  font-family: var(--font-mono);
 }
-.reset-eq:hover {
-  color: var(--text);
+.metric-readout .value {
+  font-size: 32px;
+  line-height: 1.1;
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.metric-readout .unit {
+  font-size: 12px;
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+}
+.metric-readout[data-tone="good"] .value {
+  color: var(--color-good);
+}
+.metric-readout[data-tone="warn"] .value {
+  color: var(--color-warm);
+}
+.metric-readout[data-tone="bad"] .value {
+  color: var(--color-hot);
 }
 
-.utilization h3,
-.estimate h3 {
-  font-size: 13px;
-  margin: 0 0 4px 0;
-  color: var(--text);
+/* Ignored-knob annotation. */
+.ignored-note {
+  color: var(--color-warm);
+  font-size: 11px;
+  font-style: italic;
 }
-.utilization-canvas {
-  display: block;
-  width: 200px;
-  height: 200px;
-  image-rendering: pixelated;
+.ignored-note:empty {
+  display: none;
+}
+
+/* Tab styles — kept since the controls panel still uses them. */
+.tab[aria-selected="true"] {
+  color: var(--color-accent);
+  border-bottom: 2px solid var(--color-accent);
+}
+.tab[aria-selected="false"] {
+  color: var(--color-muted);
+  border-bottom: 2px solid transparent;
+}
+
+.ctrl[data-disabled="true"] {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+/* Encoding overlay: a big translucent banner over the results panel
+ * while a wasm encode is in flight. Auto-encode + slider drags fire
+ * many of these in quick succession, so the overlay is the only
+ * reliable visual cue that the displayed numbers are stale. */
+.encode-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    rgba(14, 17, 23, 0.55),
+    rgba(31, 111, 235, 0.18),
+    rgba(14, 17, 23, 0.55)
+  );
+  background-size: 200% 100%;
+  animation: encode-overlay-shimmer 1.6s ease-in-out infinite;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 5;
+  border-radius: 0;
+  pointer-events: none;
+  backdrop-filter: blur(2px);
+}
+.encode-overlay[hidden] {
+  display: none;
+}
+.encode-overlay-inner {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 24px;
+  background: var(--color-panel);
+  border: 1px solid var(--color-accent);
+  border-radius: 8px;
+  box-shadow: 0 0 32px rgba(88, 166, 255, 0.4);
+}
+.encode-overlay-label {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--color-accent);
+}
+.encode-overlay-detail {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--color-muted);
+}
+.encode-overlay-spinner {
+  width: 24px;
+  height: 24px;
+  border: 3px solid var(--color-line);
+  border-top-color: var(--color-accent);
+  border-radius: 50%;
+  animation: encode-overlay-spin 0.8s linear infinite;
+}
+@keyframes encode-overlay-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@keyframes encode-overlay-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+/* Pulsing border on the canvases while encoding. */
+body[data-encoding="true"] #encoded-canvas,
+body[data-encoding="true"] #delta-canvas {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+  opacity: 0.7;
+  transition: opacity 0.1s;
+}
+
+/* Zoom inspector modal */
+.zoom-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.92);
+  display: flex;
+  flex-direction: column;
+}
+.zoom-modal[hidden] {
+  display: none;
+}
+.zoom-modal-bar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 24px;
+  background: var(--color-panel);
+  border-bottom: 1px solid var(--color-line);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  flex: 0 0 auto;
+}
+.zoom-modal-title {
+  font-weight: 600;
+  color: var(--color-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.zoom-modal-coords {
+  color: var(--color-muted);
+  min-width: 100px;
+}
+.zoom-modal-scale {
+  color: var(--color-text);
+  background: var(--color-bg);
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--color-line);
+  min-width: 50px;
+  text-align: center;
+}
+.zoom-modal-hint {
+  color: var(--color-muted);
+  font-size: 11px;
+  margin-left: auto;
+}
+.zoom-modal-close {
+  background: transparent;
+  color: var(--color-muted);
+  border: 1px solid var(--color-line);
+  border-radius: 4px;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-family: inherit;
+}
+.zoom-modal-close:hover {
+  color: var(--color-text);
+  border-color: var(--color-text);
+}
+.zoom-modal-grid {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  padding: 12px;
+  min-height: 0;
+}
+.zoom-pane {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 0;
+}
+.zoom-pane figcaption {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.zoom-pane canvas {
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
   background: #000;
-  border-radius: 2px;
+  border: 1px solid var(--color-line);
+  border-radius: 4px;
+  cursor: grab;
+  image-rendering: pixelated;
+  min-height: 0;
 }
-
-.estimate p {
-  margin: 4px 0;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 13px;
-  color: var(--text);
+.zoom-pane canvas:active {
+  cursor: grabbing;
 }

--- a/zenjpeg-diagnostics-viewer/web/src/synthetic.ts
+++ b/zenjpeg-diagnostics-viewer/web/src/synthetic.ts
@@ -1,0 +1,23 @@
+// Synthetic deterministic test image — sine modulation per channel so
+// every 8×8 block has non-zero AC energy. Mirrors the Rust smoke-test
+// pattern exactly, so dev-loop output is reproducible without
+// requiring an external image upload.
+
+export function syntheticPattern(width: number, height: number): Uint8ClampedArray {
+  const buf = new Uint8ClampedArray(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      const fx = x;
+      const fy = y;
+      const r = 128 + 64 * Math.sin(fx * 0.3) + 32 * Math.cos((fx + fy) * 0.9);
+      const g = 128 + 64 * Math.cos(fy * 0.25) + 32 * Math.sin((fx - fy) * 0.7);
+      const b = 128 + 96 * Math.sin((fx + fy) * 0.15);
+      buf[i] = r;
+      buf[i + 1] = g;
+      buf[i + 2] = b;
+      buf[i + 3] = 255;
+    }
+  }
+  return buf;
+}

--- a/zenjpeg-diagnostics-viewer/web/src/types.ts
+++ b/zenjpeg-diagnostics-viewer/web/src/types.ts
@@ -1,0 +1,52 @@
+// Mirror of the Rust `Diagnostics` struct emitted by
+// zenjpeg-diagnostics-wasm via serde_wasm_bindgen.
+
+export interface BlockDiagnostics {
+  /** [f32; 64] in natural row-major order (DC at index 0). */
+  coefPreQuant: Float32Array | number[];
+  /** [i16; 64] in JPEG zigzag order. */
+  coefLevels: Int16Array | number[];
+  /** Per-block AQ multiplier (1.0 = neutral, <1 = finer, >1 = coarser). */
+  aqMultiplier: number;
+  /** Entropy bits attributed to this block (0 if not yet captured). */
+  entropyBits: number;
+}
+
+export interface ComponentDiagnostics {
+  /** JFIF component id (1=Y/X, 2=Cb/Y-XYB, 3=Cr/B-XYB). */
+  componentId: number;
+  /** [cols, rows] in 8x8 blocks. */
+  blockGrid: [number, number];
+  /** Base quantization table (natural row-major, length 64). */
+  quantTableBase: Uint16Array | number[];
+  /** Zero-bias offset table (natural row-major, length 64). */
+  zeroBias: Float32Array | number[];
+  /** Per-block records, raster order (idx = row*cols + col). */
+  blocks: BlockDiagnostics[];
+}
+
+export interface Diagnostics {
+  width: number;
+  height: number;
+  /** "YCbCr" | "XYB" | "Grayscale" */
+  colorPath: string;
+  /** Per-component (h_samp, v_samp). */
+  samplingFactors: Array<[number, number]>;
+  components: ComponentDiagnostics[];
+}
+
+export interface EncodeOptions {
+  quality?: number;
+  colorPath?: "ycbcr" | "xyb";
+  subsampling?: "none" | "halfHorizontal" | "quarter" | "halfVertical";
+  xybSubsampling?: "full" | "bQuarter";
+  aqEnabled?: boolean;
+  trellis?: boolean;
+  autoOptimize?: boolean;
+  deringing?: boolean;
+}
+
+export interface EncodeResult {
+  bytes: Uint8Array;
+  diagnostics: Diagnostics;
+}

--- a/zenjpeg-diagnostics-viewer/web/src/types.ts
+++ b/zenjpeg-diagnostics-viewer/web/src/types.ts
@@ -1,4 +1,4 @@
-// Mirror of the Rust `Diagnostics` struct emitted by
+// Mirror of the Rust `Diagnostics` + `EncodeOptions` structs emitted by
 // zenjpeg-diagnostics-wasm via serde_wasm_bindgen.
 
 export interface BlockDiagnostics {
@@ -35,15 +35,69 @@ export interface Diagnostics {
   components: ComponentDiagnostics[];
 }
 
+/** f32 quant tables + optional zero-bias overrides. */
+export interface CustomQuantTables {
+  /** Y / X quant table (length 64, natural row-major, DC first). */
+  y: number[];
+  /** Cb / Y-XYB quant table. */
+  cb: number[];
+  /** Cr / B-XYB quant table. */
+  cr: number[];
+  yZeroBiasMul?: number[];
+  cbZeroBiasMul?: number[];
+  crZeroBiasMul?: number[];
+  /** [Y, Cb, Cr] DC offsets. */
+  zeroBiasOffsetDc?: [number, number, number];
+  zeroBiasOffsetAc?: [number, number, number];
+}
+
+/** "baseline" | "trellis" | "hybrid". */
+export type EncodeMode = "baseline" | "trellis" | "hybrid";
+
+/** "thorough" | "balanced" | "fast". */
+export type TrellisSpeed = "thorough" | "balanced" | "fast";
+
 export interface EncodeOptions {
+  // ── Always-applied basics ─────────────────────────────────────────────
+  /** jpegli quality, 0-100. */
   quality?: number;
   colorPath?: "ycbcr" | "xyb";
   subsampling?: "none" | "halfHorizontal" | "quarter" | "halfVertical";
   xybSubsampling?: "full" | "bQuarter";
   aqEnabled?: boolean;
-  trellis?: boolean;
-  autoOptimize?: boolean;
   deringing?: boolean;
+  optimizeHuffman?: boolean;
+  progressive?: boolean;
+  /** YCbCr only, ignored for 4:4:4 and XYB. */
+  sharpYuv?: boolean;
+  /** Pre-encode Gaussian blur sigma (px). 0 disables. */
+  preBlur?: number;
+  /** Multiplicative scale on chroma's perceptual distance budget. */
+  chromaDistanceScale?: number;
+  /** Restart-marker cadence in MCU rows. 0 disables. */
+  restartMcuRows?: number;
+
+  // ── Mode picker ───────────────────────────────────────────────────────
+  mode?: EncodeMode;
+
+  // ── Standalone trellis (mode === "trellis") ───────────────────────────
+  trellisDcEnabled?: boolean;
+  trellisLambdaLogScale1?: number;
+  trellisLambdaLogScale2?: number;
+  trellisSpeedMode?: TrellisSpeed;
+  trellisDeltaDcWeight?: number;
+
+  // ── Hybrid (mode === "hybrid") ────────────────────────────────────────
+  hybridAqLambdaScale?: number;
+  hybridBaseLambdaScale1?: number;
+  hybridBaseLambdaScale2?: number;
+  hybridDcEnabled?: boolean;
+  hybridAqExponent?: number;
+  hybridAqThreshold?: number;
+  hybridQualityAdaptive?: boolean;
+
+  // ── Custom quant tables (overrides the source-derived defaults) ───────
+  customQuantTables?: CustomQuantTables | null;
 }
 
 export interface EncodeResult {

--- a/zenjpeg-diagnostics-viewer/web/tests/viewer.spec.ts
+++ b/zenjpeg-diagnostics-viewer/web/tests/viewer.spec.ts
@@ -48,16 +48,20 @@ test("page loads, triptych populated, diagnostics non-empty", async ({ page }) =
   // Diagnostics struct is reachable and well-shaped.
   const diag = await page.evaluate(() => window.__zenjpegDiagnostics.getCurrent());
   expect(diag).not.toBeNull();
-  expect(diag!.width).toBe(64);
-  expect(diag!.height).toBe(64);
+  if (!diag) throw new Error("diagnostics null");
+  expect(diag.width).toBe(64);
+  expect(diag.height).toBe(64);
   // Default is YCbCr 4:4:4 → 3 components, each 8×8 blocks.
-  expect(diag!.components).toHaveLength(3);
-  expect(diag!.components[0].blockGrid).toEqual([8, 8]);
-  expect(diag!.components[1].blockGrid).toEqual([8, 8]);
-  expect(diag!.components[2].blockGrid).toEqual([8, 8]);
-  expect(diag!.components[0].blocks).toHaveLength(64);
+  expect(diag.components).toHaveLength(3);
+  const [c0, c1, c2] = diag.components;
+  if (!c0 || !c1 || !c2) throw new Error("expected 3 components");
+  expect(c0.blockGrid).toEqual([8, 8]);
+  expect(c1.blockGrid).toEqual([8, 8]);
+  expect(c2.blockGrid).toEqual([8, 8]);
+  expect(c0.blocks).toHaveLength(64);
   // Pre-quant DCT non-trivial on the synthetic pattern.
-  const block0 = diag!.components[0].blocks[0];
+  const block0 = c0.blocks[0];
+  if (!block0) throw new Error("expected block 0");
   const energy = (block0.coefPreQuant as number[]).reduce(
     (a: number, b: number) => a + Math.abs(b),
     0,

--- a/zenjpeg-diagnostics-viewer/web/tests/viewer.spec.ts
+++ b/zenjpeg-diagnostics-viewer/web/tests/viewer.spec.ts
@@ -1,0 +1,197 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * E2E suite for the zenjpeg encode-diagnostics viewer.
+ *
+ * The synthetic 64x64 RGB pattern triggers a default encode on page
+ * load; tests then drive the controls and check that diagnostics
+ * payloads, heatmaps, and the equalizer-style quant editor respond
+ * as expected.
+ */
+
+test.beforeEach(async ({ page }) => {
+  // Capture page errors so they surface in the trace if the encode
+  // pipeline blows up during startup.
+  page.on("pageerror", (err) => {
+    console.log(`[pageerror] ${err.message}`);
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      console.log(`[console.${msg.type()}] ${msg.text()}`);
+    }
+  });
+  // domcontentloaded is enough — the WASM init() is fired afterwards
+  // and we poll on body.dataset.encodeState to know when the initial
+  // synthetic encode has settled.
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expect
+    .poll(
+      async () => {
+        return await page.evaluate(() => document.body.dataset["encodeState"]);
+      },
+      { timeout: 60_000 },
+    )
+    .toBe("done");
+});
+
+test("page loads, triptych populated, diagnostics non-empty", async ({ page }) => {
+  // Triptych has three canvases sized > 0.
+  for (const id of ["source-canvas", "encoded-canvas", "delta-canvas"]) {
+    const dims = await page.locator(`[data-testid="${id}"]`).evaluate((el) => {
+      const c = el as HTMLCanvasElement;
+      return { w: c.width, h: c.height };
+    });
+    expect(dims.w).toBeGreaterThan(0);
+    expect(dims.h).toBeGreaterThan(0);
+  }
+
+  // Diagnostics struct is reachable and well-shaped.
+  const diag = await page.evaluate(() => window.__zenjpegDiagnostics.getCurrent());
+  expect(diag).not.toBeNull();
+  expect(diag!.width).toBe(64);
+  expect(diag!.height).toBe(64);
+  // Default is YCbCr 4:4:4 → 3 components, each 8×8 blocks.
+  expect(diag!.components).toHaveLength(3);
+  expect(diag!.components[0].blockGrid).toEqual([8, 8]);
+  expect(diag!.components[1].blockGrid).toEqual([8, 8]);
+  expect(diag!.components[2].blockGrid).toEqual([8, 8]);
+  expect(diag!.components[0].blocks).toHaveLength(64);
+  // Pre-quant DCT non-trivial on the synthetic pattern.
+  const block0 = diag!.components[0].blocks[0];
+  const energy = (block0.coefPreQuant as number[]).reduce(
+    (a: number, b: number) => a + Math.abs(b),
+    0,
+  );
+  expect(energy).toBeGreaterThan(0);
+});
+
+test("AQ heatmap canvas has been drawn (non-zero pixels)", async ({ page }) => {
+  const drawn = await page.evaluate(() => {
+    const c = document.querySelector<HTMLCanvasElement>(
+      '[data-testid="aq-canvas"]',
+    )!;
+    if (!c.width || !c.height) return false;
+    const ctx = c.getContext("2d");
+    if (!ctx) return false;
+    const d = ctx.getImageData(0, 0, c.width, c.height).data;
+    for (let i = 0; i < d.length; i += 4) {
+      if (d[i] !== 0 || d[i + 1] !== 0 || d[i + 2] !== 0) return true;
+    }
+    return false;
+  });
+  expect(drawn).toBe(true);
+});
+
+test("dragging an h_eq slider re-renders the utilization heatmap", async ({
+  page,
+}) => {
+  // Snapshot the utilization canvas before the change.
+  const beforeHash = await canvasFingerprint(page, '[data-testid="comp-0-utilization"]');
+
+  // Move h_eq[0] hard. With the default starts at 1 and step 0.05.
+  const slider = page.locator('[data-testid="comp-0-h-eq-0"]');
+  await slider.evaluate((el) => {
+    const i = el as HTMLInputElement;
+    i.value = "2";
+    i.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  // Wait briefly for the redraw.
+  await page.waitForTimeout(50);
+  const afterHash = await canvasFingerprint(page, '[data-testid="comp-0-utilization"]');
+  expect(afterHash).not.toBe(beforeHash);
+});
+
+test("changing color path to XYB re-encodes and updates components", async ({
+  page,
+}) => {
+  await page.locator('[data-testid="color-path-select"]').selectOption("xyb");
+  // Subsampling label hides; XYB B label shows.
+  await expect(page.locator("#subsampling-label")).toBeHidden();
+  await expect(page.locator("#xyb-subsampling-label")).toBeVisible();
+  await page.locator('[data-testid="encode-button"]').click();
+  await expect.poll(async () => {
+    return await page.evaluate(() => {
+      const d = window.__zenjpegDiagnostics.getCurrent();
+      return d?.colorPath;
+    });
+  }, { timeout: 60_000 }).toBe("XYB");
+});
+
+test("subsampling 4:2:0 produces half-resolution chroma block grids", async ({
+  page,
+}) => {
+  await page.locator('[data-testid="subsampling-select"]').selectOption("quarter");
+  await page.locator('[data-testid="encode-button"]').click();
+  await expect.poll(async () => {
+    return await page.evaluate(() => {
+      const d = window.__zenjpegDiagnostics.getCurrent();
+      if (!d) return null;
+      return [
+        d.components[0]?.blockGrid,
+        d.components[1]?.blockGrid,
+        d.components[2]?.blockGrid,
+      ];
+    });
+  }, { timeout: 60_000 }).toEqual([
+    [8, 8],
+    [4, 4],
+    [4, 4],
+  ]);
+});
+
+test("quality slider drag changes encoded byte size", async ({ page }) => {
+  const sizeAt = async (q: string) => {
+    await page.locator('[data-testid="quality-slider"]').evaluate(
+      (el, value) => {
+        const i = el as HTMLInputElement;
+        i.value = value;
+        i.dispatchEvent(new Event("input", { bubbles: true }));
+      },
+      q,
+    );
+    await page.locator('[data-testid="encode-button"]').click();
+    await expect.poll(async () => {
+      return await page.evaluate(() => document.body.dataset["encodeState"]);
+    }, { timeout: 60_000 }).toBe("done");
+    return await page.evaluate(() => {
+      const txt = document.querySelector<HTMLElement>("#status")?.textContent ?? "";
+      const m = txt.match(/Encoded (\d+) bytes/);
+      return m ? parseInt(m[1]!, 10) : 0;
+    });
+  };
+  const lowQ = await sizeAt("20");
+  const hiQ = await sizeAt("95");
+  expect(lowQ).toBeGreaterThan(0);
+  expect(hiQ).toBeGreaterThan(lowQ);
+});
+
+test("Reset EQ button restores h_eq/v_eq to 1", async ({ page }) => {
+  await page.locator('[data-testid="comp-0-h-eq-3"]').evaluate((el) => {
+    const i = el as HTMLInputElement;
+    i.value = "1.7";
+    i.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await page.locator('[data-testid="comp-0-reset-eq"]').click();
+  const value = await page
+    .locator('[data-testid="comp-0-h-eq-3"]')
+    .evaluate((el) => (el as HTMLInputElement).value);
+  expect(parseFloat(value)).toBeCloseTo(1.0, 2);
+});
+
+async function canvasFingerprint(page: import("@playwright/test").Page, sel: string): Promise<string> {
+  return page.evaluate((s) => {
+    const c = document.querySelector<HTMLCanvasElement>(s);
+    if (!c) return "";
+    const ctx = c.getContext("2d");
+    if (!ctx) return "";
+    const d = ctx.getImageData(0, 0, c.width, c.height).data;
+    // Cheap rolling hash over the data — exact pixel equality is not
+    // important, we just need a stable fingerprint that changes when
+    // the canvas content changes.
+    let h = 5381;
+    for (let i = 0; i < d.length; i += 64) {
+      h = ((h << 5) + h + d[i]!) | 0;
+    }
+    return String(h);
+  }, sel);
+}

--- a/zenjpeg-diagnostics-viewer/web/tsconfig.json
+++ b/zenjpeg-diagnostics-viewer/web/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vite.config.ts"]
+}

--- a/zenjpeg-diagnostics-viewer/web/vite.config.ts
+++ b/zenjpeg-diagnostics-viewer/web/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  // Relative asset URLs (`./assets/...`) so the same `dist/` works at
+  // any deploy subpath: local `vite preview` at root, GitHub Pages at
+  // `/zenjpeg/diagnostics/`, Cloudflare Pages at `/`, an arbitrary
+  // pre-existing CDN, etc. wasm-bindgen's `new URL("./assets/...", import.meta.url)`
+  // resolves correctly from index.html either way.
+  base: "./",
+  server: {
+    // We're prohibited from binding port 8080 (reserved on the host).
+    // Pick a port in the 3000-3999 range; 3173 is the diagnostics
+    // viewer's default.
+    port: 3173,
+    strictPort: true,
+    fs: {
+      // Allow vite to serve files from the wasm-pkg sibling directory.
+      allow: [".."],
+    },
+  },
+  preview: {
+    port: 3173,
+    strictPort: true,
+  },
+  build: {
+    target: "esnext",
+  },
+  optimizeDeps: {
+    // wasm-pack output uses ES modules — let vite serve them as-is.
+    exclude: ["./wasm-pkg/zenjpeg_diagnostics_wasm.js"],
+  },
+});

--- a/zenjpeg-diagnostics-viewer/web/vite.config.ts
+++ b/zenjpeg-diagnostics-viewer/web/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "vite";
+import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
+  plugins: [tailwindcss()],
   // Relative asset URLs (`./assets/...`) so the same `dist/` works at
   // any deploy subpath: local `vite preview` at root, GitHub Pages at
   // `/zenjpeg/diagnostics/`, Cloudflare Pages at `/`, an arbitrary
@@ -24,6 +26,9 @@ export default defineConfig({
   },
   build: {
     target: "esnext",
+  },
+  worker: {
+    format: "es",
   },
   optimizeDeps: {
     // wasm-pack output uses ES modules — let vite serve them as-is.

--- a/zenjpeg/Cargo.toml
+++ b/zenjpeg/Cargo.toml
@@ -211,6 +211,16 @@ __test-utils = []
 __expert = []
 # WASM SIMD128 tests (requires wasm runtime with SIMD support)
 __wasm-simd = []
+# Per-block encode diagnostics for tooling (visualizers, calibration UIs).
+# UNSTABLE — types are `#[doc(hidden)]` and can change between any two
+# patch versions. Captures pre-quant DCT coefficients, post-quant levels,
+# AQ multipliers, entropy bits, AQ field, scan script, and resolved
+# config snapshot during encode. Routes encodes through the strip
+# processor (skips `FusedParallelEncode` even if `parallel` is enabled);
+# diagnostics output may differ from the default fused path by a handful
+# of bytes at quant/AQ boundaries due to ordering. Off in every
+# production build.
+__diagnostics = []
 # UltraHDR (HDR gain map) support - requires decoder for gain map reconstruction.
 # Provides: tonemap, compute_gainmap, apply_gainmap, XMP metadata, adaptive tonemapper.
 # Pinned to ultrahdr-core ≥ 0.5: `transfer` feature removed (linear-srgb is

--- a/zenjpeg/src/encode/byte_encoders.rs
+++ b/zenjpeg/src/encode/byte_encoders.rs
@@ -217,6 +217,12 @@ impl BytesEncoder {
             }
         }
 
+        // UNSTABLE diagnostics capture (gated; default: off, no behavior change).
+        #[cfg(feature = "__diagnostics")]
+        {
+            builder = builder.diagnostics(config.diagnostics_enabled);
+        }
+
         builder.start()
     }
 
@@ -407,6 +413,26 @@ impl BytesEncoder {
         let mut output = Vec::new();
         self.finish_into(&mut output)?;
         Ok(output)
+    }
+
+    /// Finish encoding and return both the JPEG bytes and the captured
+    /// per-block diagnostics record. Returns `(bytes, Some(diag))` when
+    /// `with_diagnostics(true)` was set on the source `EncoderConfig`,
+    /// `(bytes, None)` otherwise. UNSTABLE — gated behind the
+    /// `__diagnostics` cargo feature.
+    #[cfg(feature = "__diagnostics")]
+    pub fn finish_with_diagnostics(
+        self,
+    ) -> Result<(
+        Vec<u8>,
+        Option<crate::encode::diagnostics::EncodeDiagnostics>,
+    )> {
+        use enough::Unstoppable;
+        let mut output = Vec::new();
+        let mut diag: Option<crate::encode::diagnostics::EncodeDiagnostics> = None;
+        self.inner
+            .finish_into_with_stop_and_diagnostics(&mut output, Unstoppable, &mut diag)?;
+        Ok((output, diag))
     }
 
     /// Finish encoding, writing directly to the provided buffer.
@@ -1016,6 +1042,23 @@ impl<P: Pixel> RgbEncoder<P> {
     pub fn finish_to<W: Write>(self, output: W) -> Result<W> {
         self.inner.finish_to(output)
     }
+
+    /// Finish encoding and return both the JPEG bytes and the captured
+    /// diagnostics record.
+    ///
+    /// Returns `Ok((bytes, Some(diag)))` when `with_diagnostics(true)`
+    /// was set on the source `EncoderConfig`; otherwise returns
+    /// `Ok((bytes, None))`. UNSTABLE — gated behind the
+    /// `__diagnostics` cargo feature.
+    #[cfg(feature = "__diagnostics")]
+    pub fn finish_with_diagnostics(
+        self,
+    ) -> Result<(
+        Vec<u8>,
+        Option<crate::encode::diagnostics::EncodeDiagnostics>,
+    )> {
+        self.inner.finish_with_diagnostics()
+    }
 }
 
 /// Encoder for planar f32 YCbCr input.
@@ -1209,6 +1252,12 @@ impl YCbCrPlanarEncoder {
         #[cfg(feature = "parallel")]
         if config.parallel.is_some() {
             builder = builder.parallel(true);
+        }
+
+        // UNSTABLE diagnostics capture (gated; default: off, no behavior change).
+        #[cfg(feature = "__diagnostics")]
+        {
+            builder = builder.diagnostics(config.diagnostics_enabled);
         }
 
         builder.start()

--- a/zenjpeg/src/encode/diagnostics.rs
+++ b/zenjpeg/src/encode/diagnostics.rs
@@ -1,0 +1,447 @@
+//! Per-block encode diagnostics — UNSTABLE.
+//!
+//! Gated behind the `__diagnostics` cargo feature. Captures the per-block
+//! state encoders consume (forward-DCT coefficients, post-quant levels,
+//! AQ multiplier, entropy bits) plus image-level state (resolved config,
+//! AQ field, scan script). Designed for visualizer / calibration tooling
+//! that wants to drive interactive quant-table editing live in WASM.
+//!
+//! All public types in this module are `#[doc(hidden)]`. The shape of
+//! the structs is intentionally evolvable — patch versions may add,
+//! remove, or rename fields without bumping the major.
+//!
+//! # Coefficient ordering
+//!
+//! Two orderings appear in this module and they are NOT the same:
+//!
+//! - [`BlockDiagnostics::coef_pre_quant`] is in **natural row-major**
+//!   order: index `i = row * 8 + col` with `row, col in [0, 7]`. This
+//!   is the layout produced by the forward DCT before any zigzag
+//!   reordering.
+//! - [`BlockDiagnostics::coef_levels`] is in **JPEG zigzag** order:
+//!   index `k` corresponds to natural position
+//!   `JPEG_ZIGZAG_ORDER[k]`. This is what the Huffman entropy coder
+//!   reads — DC at index 0, then a frequency-distance walk through the
+//!   AC band.
+//!
+//! Visualizers that draw 8×8 heatmaps will usually want to plot in
+//! natural order (so DC sits at top-left). Convert by indexing
+//! `coef_levels[zigzag_to_natural[i]]` if you need natural-order levels.
+//!
+//! # Memory cost
+//!
+//! For an `H × W` image with three components and 4:4:4 sampling:
+//!
+//! ```text
+//! per-block payload  = sizeof(coef_pre_quant) + sizeof(coef_levels)
+//!                      + sizeof(misc)
+//!                    ≈ 256 + 128 + 16 = 400 bytes
+//! components         = 3
+//! blocks per comp    = ceil(W / 8) × ceil(H / 8)
+//! total payload      = 3 × ceil(W / 8) × ceil(H / 8) × 400 bytes
+//! ```
+//!
+//! e.g. 512 × 512 ≈ 4.9 MB, 1024 × 1024 ≈ 19.7 MB. Subsampled chroma
+//! halves (4:2:0) the chroma block count. This module is intentionally
+//! not designed for production-size images — it exists to drive
+//! tooling on small demo imagery.
+
+#![allow(dead_code)]
+#![cfg(feature = "__diagnostics")]
+
+use alloc::vec::Vec;
+
+/// Top-level diagnostic record for a single encode.
+///
+/// Populated by the encoder when running with `__diagnostics` enabled
+/// AND a sink is requested. Field semantics:
+///
+/// - [`Self::components`] holds one entry per JPEG component, in
+///   declaration order (Y, Cb, Cr for YCbCr; X, Y, B for XYB; one
+///   entry for grayscale).
+/// - [`Self::global`] carries image-level state that doesn't fit per
+///   component (AQ field, scan script, heuristic decisions).
+///
+/// See module docs for ordering conventions.
+#[doc(hidden)]
+#[derive(Debug, Clone, Default)]
+pub struct EncodeDiagnostics {
+    /// Image dimensions and sampling layout.
+    pub image: ImageInfo,
+
+    /// Encoder configuration as actually resolved at encode time.
+    pub config_snapshot: ConfigSnapshot,
+
+    /// One entry per JPEG component (Y, Cb, Cr / X, Y, B / Y).
+    pub components: Vec<ComponentDiagnostics>,
+
+    /// Image-level state (AQ field, scan script, decisions).
+    pub global: GlobalDiagnostics,
+}
+
+/// Image dimensions and sampling layout snapshot.
+#[doc(hidden)]
+#[derive(Debug, Clone, Default)]
+pub struct ImageInfo {
+    pub width: u32,
+    pub height: u32,
+    /// Color path used by this encode (YCbCr / XYB / Grayscale).
+    pub color_path: ColorPathTag,
+    /// Per-component (h_samp, v_samp) sampling factors. Length matches
+    /// `EncodeDiagnostics::components.len()`.
+    pub sampling_factors: Vec<(u8, u8)>,
+}
+
+/// Resolved encoder configuration at encode time.
+///
+/// Snapshot of the knobs that affect quantization and bit allocation.
+/// Mirrors [`InternalParams`](super::internal_params::InternalParams)
+/// at a stable shape (visualizer doesn't need every internal detail —
+/// just what matters for re-quant decisions).
+#[doc(hidden)]
+#[derive(Debug, Clone, Default)]
+pub struct ConfigSnapshot {
+    /// Quality value at encode time (jpegli-internal scale).
+    pub quality: f32,
+    /// Whether AQ was enabled.
+    pub aq_enabled: bool,
+    /// Whether deringing preprocessing was enabled.
+    pub deringing: bool,
+    /// Quantization mode the encoder dispatched to for this encode.
+    pub quant_mode: QuantModeTag,
+    /// Source of the base quantization tables (default / user supplied
+    /// / mozjpeg / etc.).
+    pub quant_table_source: QuantTableSourceTag,
+    /// Chroma distance scale, if applicable (XYB / YCbCr).
+    pub chroma_distance_scale: Option<f32>,
+    /// Tiny-file mode active.
+    pub tiny_file_mode: Option<TinyFileModeTag>,
+    /// Whether progressive scans were used.
+    pub progressive: bool,
+    /// Whether scan optimization (`optimize_scans`) ran.
+    pub optimize_scans: bool,
+    /// Whether Huffman tables were optimized vs taken from defaults.
+    pub optimize_huffman: bool,
+    /// Whether 16-bit DQT was permitted.
+    pub allow_16bit_quant_tables: bool,
+    /// `auto_optimize(true)` was set.
+    pub auto_optimize: bool,
+}
+
+/// High-level color path classifier.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ColorPathTag {
+    #[default]
+    YCbCr,
+    Xyb,
+    Grayscale,
+}
+
+/// Which quantization branch the encoder dispatched to.
+///
+/// Three configurations are observable:
+///
+/// - [`Self::Plain`]: zero-bias quantize only (default fast path,
+///   `aq_enabled` may still be true and modulate per-block).
+/// - [`Self::Trellis`]: standalone AC trellis (`trellis` feature on,
+///   no hybrid context).
+/// - [`Self::Hybrid`]: hybrid AQ + trellis (`auto_optimize` /
+///   `HybridConfig`).
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum QuantModeTag {
+    #[default]
+    Plain,
+    Trellis,
+    Hybrid,
+}
+
+/// Where the base quantization table came from.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum QuantTableSourceTag {
+    #[default]
+    Default,
+    UserSupplied,
+    MozjpegPreset,
+    LearnedXyb,
+    AutoOptimized,
+    Other,
+}
+
+/// Tiny-file mode classifier.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TinyFileModeTag {
+    Off,
+    Auto,
+    Force,
+}
+
+/// Per-component diagnostic record.
+#[doc(hidden)]
+#[derive(Debug, Clone)]
+pub struct ComponentDiagnostics {
+    /// JPEG component identifier (Y=1, Cb=2, Cr=3 for YCbCr; X/Y/B
+    /// for XYB; whatever the SOF declared).
+    pub component_id: u8,
+
+    /// Block grid dimensions (cols, rows) — number of 8×8 blocks
+    /// horizontally and vertically for *this* component (post
+    /// subsampling). For chroma in 4:2:0 these are half the luma
+    /// counts.
+    pub block_grid: (u32, u32),
+
+    /// Base quantization table written to JFIF (DQT) for this
+    /// component, in **natural row-major** order (index `i = row*8 +
+    /// col`). Per-block AQ scaling is applied on top of this base at
+    /// quantize time using `BlockDiagnostics::aq_multiplier`. Always
+    /// 64 entries; values may exceed 255 when 16-bit DQT is permitted.
+    pub quant_table_base: [u16; 64],
+
+    /// Zero-bias table (jpegli adaptive dead-zone bias) for this
+    /// component, in natural order. Values are coefficient-space
+    /// thresholds: a coefficient with absolute value below
+    /// `bias[uv] * quant[uv]` is snapped to zero.  When trellis is
+    /// active for this component, the trellis lambda overrides this
+    /// at the per-coefficient level. Length 64.
+    pub zero_bias: [f32; 64],
+
+    /// Per-block records, length `block_grid.0 * block_grid.1`,
+    /// indexed by `row * block_grid.0 + col`.
+    pub blocks: Vec<BlockDiagnostics>,
+}
+
+/// Per-block diagnostic record.
+#[doc(hidden)]
+#[derive(Debug, Clone)]
+pub struct BlockDiagnostics {
+    /// Forward-DCT coefficients before quantization, in **natural
+    /// row-major** order (index `i = row*8 + col`). DC sits at
+    /// position 0; AC fills 1..=63. Captured directly from the
+    /// encoder's `Block8x8f` after deringing+DCT, before any
+    /// quantization.
+    ///
+    /// Memory: 256 bytes per block. This is the dominant cost of
+    /// diagnostics output.
+    pub coef_pre_quant: [f32; 64],
+
+    /// Quantized coefficient levels in **JPEG zigzag** order — what
+    /// the Huffman entropy coder consumed for this block.
+    /// `coef_levels[0]` is the DC level; `coef_levels[1..=63]` is
+    /// the AC band in zigzag traversal order.
+    pub coef_levels: [i16; 64],
+
+    /// AQ multiplier applied to the base quant table for this block.
+    /// `1.0` means "use base table as-is"; `<1.0` means "spend more
+    /// bits here" (finer quantization); `>1.0` means "save bits here"
+    /// (coarser). Encoder sources this from `aq_strengths` after the
+    /// optional [`AqController`](crate::encode::aq_controller::AqController)
+    /// hook.
+    pub aq_multiplier: f32,
+
+    /// Entropy-coded byte cost contributed by this block, summed
+    /// over Huffman code lengths + value bits. Excludes restart
+    /// markers and DRI bookkeeping. `0` if entropy capture is
+    /// disabled (e.g. progressive multi-scan layouts where one block
+    /// contributes to several scans — see
+    /// [`Self::progressive_scan_bits`]).
+    pub entropy_bits: u32,
+
+    /// Per-progressive-scan entropy bit attribution. For baseline
+    /// (single-scan) encodes this stays empty and
+    /// [`Self::entropy_bits`] is the source of truth. For
+    /// progressive scan layouts, length matches the scan count and
+    /// the sum equals [`Self::entropy_bits`].
+    pub progressive_scan_bits: Vec<u32>,
+}
+
+impl Default for BlockDiagnostics {
+    fn default() -> Self {
+        Self {
+            coef_pre_quant: [0.0; 64],
+            coef_levels: [0; 64],
+            aq_multiplier: 1.0,
+            entropy_bits: 0,
+            progressive_scan_bits: Vec::new(),
+        }
+    }
+}
+
+/// Image-level diagnostic state that doesn't fit per component.
+#[doc(hidden)]
+#[derive(Debug, Clone, Default)]
+pub struct GlobalDiagnostics {
+    /// AQ field after `StreamingAQ` finalized strengths (and after
+    /// any [`AqController`](crate::encode::aq_controller::AqController)
+    /// adjustments). One entry per luma 8×8 block in raster order;
+    /// length matches `components[0].blocks.len()` for YCbCr/XYB.
+    /// `None` when AQ was disabled.
+    pub aq_field: Option<AqFieldDump>,
+
+    /// Resolved progressive scan script, when progressive encoding
+    /// was used. `None` for baseline.
+    pub scan_script: Option<ScanScriptDump>,
+
+    /// Heuristic / auto-optimize decisions logged during encode (why
+    /// `auto_optimize` chose hybrid vs plain, why a quant table was
+    /// up/down-shifted, etc.).
+    pub heuristics: Vec<HeuristicEntry>,
+}
+
+/// AQ field dump — per-luma-block strengths in raster order.
+#[doc(hidden)]
+#[derive(Debug, Clone, Default)]
+pub struct AqFieldDump {
+    /// Cols, rows in luma-block units.
+    pub block_grid: (u32, u32),
+    /// Per-block strengths in raster order (row-major).
+    pub strengths: Vec<f32>,
+}
+
+/// Resolved progressive scan script.
+#[doc(hidden)]
+#[derive(Debug, Clone, Default)]
+pub struct ScanScriptDump {
+    pub scans: Vec<ScanInfo>,
+}
+
+/// Single progressive scan descriptor.
+#[doc(hidden)]
+#[derive(Debug, Clone)]
+pub struct ScanInfo {
+    /// Component IDs in this scan (1-based JFIF identifiers).
+    pub components: Vec<u8>,
+    /// Spectral band start index (Ss).
+    pub ss: u8,
+    /// Spectral band end index (Se).
+    pub se: u8,
+    /// Successive approximation high bit (Ah).
+    pub ah: u8,
+    /// Successive approximation low bit (Al).
+    pub al: u8,
+}
+
+/// One heuristic / decision log line.
+#[doc(hidden)]
+#[derive(Debug, Clone)]
+pub struct HeuristicEntry {
+    /// Stage that recorded this entry (`"auto_optimize"`,
+    /// `"scan_script"`, `"quant_table_select"`, …).
+    pub stage: &'static str,
+    /// Free-form decision text.
+    pub message: alloc::string::String,
+}
+
+/// Configuration toggle for what to capture.
+///
+/// All fields default to `true` — the most useful default is "capture
+/// everything." Disable individual fields when chasing memory or
+/// per-block CPU cost.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub struct DiagnosticsCapture {
+    pub coef_pre_quant: bool,
+    pub coef_levels: bool,
+    pub entropy_bits: bool,
+    pub aq_field: bool,
+    pub scan_script: bool,
+    pub heuristics: bool,
+}
+
+impl Default for DiagnosticsCapture {
+    fn default() -> Self {
+        Self {
+            coef_pre_quant: true,
+            coef_levels: true,
+            entropy_bits: true,
+            aq_field: true,
+            scan_script: true,
+            heuristics: true,
+        }
+    }
+}
+
+impl EncodeDiagnostics {
+    /// Reset all per-encode state. Useful for reusing a diagnostics
+    /// buffer across multiple encodes.
+    pub fn clear(&mut self) {
+        self.image = ImageInfo::default();
+        self.config_snapshot = ConfigSnapshot::default();
+        self.components.clear();
+        self.global = GlobalDiagnostics::default();
+    }
+
+    /// Total per-block payload size in bytes. Useful for choosing a
+    /// safe input image size given a memory budget.
+    pub fn approx_bytes(&self) -> usize {
+        let per_block = core::mem::size_of::<BlockDiagnostics>();
+        self.components
+            .iter()
+            .map(|c| c.blocks.len() * per_block)
+            .sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::String;
+
+    #[test]
+    fn default_construction_zero_blocks() {
+        let d = EncodeDiagnostics::default();
+        assert_eq!(d.image.width, 0);
+        assert!(d.components.is_empty());
+        assert!(d.global.aq_field.is_none());
+        assert!(d.global.scan_script.is_none());
+        assert_eq!(d.approx_bytes(), 0);
+    }
+
+    #[test]
+    fn approx_bytes_scales_with_block_count() {
+        let mut d = EncodeDiagnostics::default();
+        d.components.push(ComponentDiagnostics {
+            component_id: 1,
+            block_grid: (2, 2),
+            quant_table_base: [16; 64],
+            zero_bias: [0.5; 64],
+            blocks: vec![BlockDiagnostics::default(); 4],
+        });
+        let per_block = core::mem::size_of::<BlockDiagnostics>();
+        assert_eq!(d.approx_bytes(), per_block * 4);
+    }
+
+    #[test]
+    fn capture_default_is_everything_on() {
+        let c = DiagnosticsCapture::default();
+        assert!(c.coef_pre_quant);
+        assert!(c.coef_levels);
+        assert!(c.entropy_bits);
+        assert!(c.aq_field);
+        assert!(c.scan_script);
+        assert!(c.heuristics);
+    }
+
+    #[test]
+    fn clear_returns_to_default() {
+        let mut d = EncodeDiagnostics::default();
+        d.image.width = 100;
+        d.components.push(ComponentDiagnostics {
+            component_id: 1,
+            block_grid: (1, 1),
+            quant_table_base: [16; 64],
+            zero_bias: [0.5; 64],
+            blocks: vec![BlockDiagnostics::default()],
+        });
+        d.global.heuristics.push(HeuristicEntry {
+            stage: "test",
+            message: String::from("placeholder"),
+        });
+        d.clear();
+        assert_eq!(d.image.width, 0);
+        assert!(d.components.is_empty());
+        assert!(d.global.heuristics.is_empty());
+    }
+}

--- a/zenjpeg/src/encode/encoder_config.rs
+++ b/zenjpeg/src/encode/encoder_config.rs
@@ -514,6 +514,15 @@ pub struct EncoderConfig {
     /// for the same purpose. `None` keeps the historical behaviour of
     /// using the same quality for both tables.
     pub(crate) chroma_quality: Option<u8>,
+
+    /// Per-block encode diagnostics capture (UNSTABLE). When `true`,
+    /// the encoder allocates an
+    /// [`EncodeDiagnostics`](crate::encode::diagnostics::EncodeDiagnostics)
+    /// struct and fills it during encoding; retrieve via the encoder's
+    /// `take_diagnostics()` method after `finish()`. Gated behind the
+    /// `__diagnostics` cargo feature.
+    #[cfg(feature = "__diagnostics")]
+    pub(crate) diagnostics_enabled: bool,
 }
 
 // Note: No Default impl - quality and color mode are required via constructors
@@ -672,6 +681,8 @@ impl EncoderConfig {
             boundary_rd_mode: BoundaryRd::Off,
             chroma_distance_scale: 1.0,
             chroma_quality: None,
+            #[cfg(feature = "__diagnostics")]
+            diagnostics_enabled: false,
         }
     }
 
@@ -1444,6 +1455,29 @@ impl EncoderConfig {
     #[must_use]
     pub fn aq_enabled(mut self, enable: bool) -> Self {
         self.aq_enabled = enable;
+        self
+    }
+
+    /// Enable per-block encode diagnostics capture (UNSTABLE).
+    ///
+    /// When `true`, the encoder fills an
+    /// [`EncodeDiagnostics`](crate::encode::diagnostics::EncodeDiagnostics)
+    /// struct with pre-quant DCT coefficients, post-quant levels,
+    /// per-block AQ multipliers, entropy bits, and image-level state
+    /// (resolved config, AQ field, scan script). Retrieve from the
+    /// concrete encoder via its `take_diagnostics()` method after
+    /// `finish()`.
+    ///
+    /// **UNSTABLE.** Gated behind the `__diagnostics` cargo feature.
+    /// Type shape may change between any two patch versions.
+    /// Diagnostics encoding routes through the strip processor
+    /// (skipping `FusedParallelEncode` even with `parallel`); output
+    /// may differ from the default fused path by a handful of bytes
+    /// at quant/AQ boundaries.
+    #[cfg(feature = "__diagnostics")]
+    #[must_use]
+    pub fn with_diagnostics(mut self, enable: bool) -> Self {
+        self.diagnostics_enabled = enable;
         self
     }
 

--- a/zenjpeg/src/encode/mod.rs
+++ b/zenjpeg/src/encode/mod.rs
@@ -119,6 +119,17 @@ pub mod request;
 #[cfg(feature = "__expert")]
 pub mod internal_params;
 
+/// Per-block encode diagnostics (`__diagnostics`-gated, UNSTABLE).
+///
+/// Captures pre-quant DCT coefficients, post-quant levels, per-block
+/// AQ multipliers, and entropy bit attribution alongside image-level
+/// state (resolved config, AQ field, scan script). Driven by
+/// visualizer / calibration tooling. See module docs for ordering
+/// conventions and memory cost.
+#[cfg(feature = "__diagnostics")]
+#[doc(hidden)]
+pub mod diagnostics;
+
 /// Default quantization and zero-bias tables for customization.
 ///
 /// This module exposes the internal default tables so users can modify them

--- a/zenjpeg/src/encode/streaming.rs
+++ b/zenjpeg/src/encode/streaming.rs
@@ -123,6 +123,16 @@ impl StreamingEncoder {
         self.processor.set_aq_controller(ctrl);
     }
 
+    /// Take the captured per-block diagnostics, leaving `None` in the
+    /// processor. Returns `None` when diagnostics weren't enabled.
+    /// UNSTABLE — gated behind the `__diagnostics` feature.
+    #[cfg(feature = "__diagnostics")]
+    pub(crate) fn take_diagnostics(
+        &mut self,
+    ) -> Option<crate::encode::diagnostics::EncodeDiagnostics> {
+        self.processor.take_diagnostics()
+    }
+
     /// Creates a new streaming encoder builder with the given dimensions.
     ///
     /// Use the builder methods to configure quality, subsampling, etc.
@@ -321,6 +331,15 @@ impl StreamingEncoder {
 
         // Set deringing (on by default in both builder and processor)
         processor.set_deringing(builder.deringing);
+
+        // Wire diagnostics sink (UNSTABLE; gated behind `__diagnostics`).
+        // When enabled, the strip processor allocates an
+        // `EncodeDiagnostics` struct and fills it during encoding.
+        // Retrieve via `take_diagnostics()` after `finish()`.
+        #[cfg(feature = "__diagnostics")]
+        if builder.diagnostics_enabled {
+            processor.enable_diagnostics();
+        }
 
         // Set boundary-RD config (off by default; #91). `None` keeps the
         // refinement module out of the hot path entirely.
@@ -980,9 +999,90 @@ impl StreamingEncoder {
 
     /// Finishes encoding into provided buffer with cancellation support.
     pub(crate) fn finish_into_with_stop(
+        self,
+        output: &mut Vec<u8>,
+        stop: impl Stop,
+    ) -> Result<()> {
+        #[cfg(feature = "__diagnostics")]
+        {
+            self.finish_into_with_stop_and_diagnostics(output, stop, &mut None)
+        }
+        #[cfg(not(feature = "__diagnostics"))]
+        {
+            self.finish_into_with_stop_inner(output, stop)
+        }
+    }
+
+    /// `finish_into_with_stop` variant that also captures the per-block
+    /// diagnostics record into the provided sink. The sink is set to
+    /// `Some(diag)` if diagnostics were enabled on this encoder, and
+    /// remains `None` otherwise. UNSTABLE.
+    #[cfg(feature = "__diagnostics")]
+    pub(crate) fn finish_into_with_stop_and_diagnostics(
+        self,
+        output: &mut Vec<u8>,
+        stop: impl Stop,
+        diagnostics_out: &mut Option<crate::encode::diagnostics::EncodeDiagnostics>,
+    ) -> Result<()> {
+        self.finish_into_with_stop_inner_diag(output, stop, Some(diagnostics_out))
+    }
+
+    fn finish_into_with_stop_inner(
+        self,
+        output: &mut Vec<u8>,
+        stop: impl Stop,
+    ) -> Result<()> {
+        #[cfg(feature = "__diagnostics")]
+        {
+            self.finish_into_with_stop_inner_diag(output, stop, None)
+        }
+        #[cfg(not(feature = "__diagnostics"))]
+        {
+            self.finish_into_with_stop_impl(output, stop)
+        }
+    }
+
+    /// Inner finish with optional diagnostics sink. When the
+    /// `__diagnostics` feature is enabled, the sink (if provided)
+    /// receives the diagnostics from the strip processor's output.
+    #[cfg(feature = "__diagnostics")]
+    fn finish_into_with_stop_inner_diag(
+        self,
+        output: &mut Vec<u8>,
+        stop: impl Stop,
+        mut diagnostics_out: Option<
+            &mut Option<crate::encode::diagnostics::EncodeDiagnostics>,
+        >,
+    ) -> Result<()> {
+        // Wrap the existing implementation; intercept the StripProcessorOutput
+        // to extract diagnostics before downstream consumers move it.
+        self.finish_into_with_stop_threaded(output, stop, |strip_output| {
+            if let Some(sink) = diagnostics_out.as_mut() {
+                **sink = strip_output.diagnostics.take();
+            }
+        })
+    }
+
+    #[cfg(not(feature = "__diagnostics"))]
+    fn finish_into_with_stop_impl(
+        self,
+        output: &mut Vec<u8>,
+        stop: impl Stop,
+    ) -> Result<()> {
+        self.finish_into_with_stop_threaded(output, stop, |_| {})
+    }
+
+    /// Implementation core: identical to the historic `finish_into_with_stop`
+    /// body, with a callback `intercept` invoked once on the
+    /// `StripProcessorOutput` after `processor.finalize()` and before the
+    /// output is consumed by the entropy encoder. Default callbacks are
+    /// no-ops; the diagnostics path uses the callback to extract its
+    /// captured per-block record.
+    fn finish_into_with_stop_threaded(
         mut self,
         output: &mut Vec<u8>,
         stop: impl Stop,
+        mut intercept: impl FnMut(&mut crate::encode::strip::StripProcessorOutput),
     ) -> Result<()> {
         stop.check()?;
 
@@ -1010,7 +1110,8 @@ impl StreamingEncoder {
             let subsampling = self.config.subsampling;
             let restart_interval = self.config.restart_interval;
 
-            let final_output = self.processor.finalize()?;
+            let mut final_output = self.processor.finalize()?;
+            intercept(&mut final_output);
             if !final_output.y_blocks.is_empty() {
                 crate::entropy::encode_blocks_mcu_order(
                     &final_output.y_blocks,
@@ -1038,7 +1139,8 @@ impl StreamingEncoder {
             let width = self.width;
             let height = self.height;
 
-            let strip_output = self.processor.finalize()?;
+            let mut strip_output = self.processor.finalize()?;
+            intercept(&mut strip_output);
 
             Self::build_jpeg_from_blocks_into(
                 &config,

--- a/zenjpeg/src/encode/streaming.rs
+++ b/zenjpeg/src/encode/streaming.rs
@@ -123,15 +123,13 @@ impl StreamingEncoder {
         self.processor.set_aq_controller(ctrl);
     }
 
-    /// Take the captured per-block diagnostics, leaving `None` in the
-    /// processor. Returns `None` when diagnostics weren't enabled.
-    /// UNSTABLE — gated behind the `__diagnostics` feature.
-    #[cfg(feature = "__diagnostics")]
-    pub(crate) fn take_diagnostics(
-        &mut self,
-    ) -> Option<crate::encode::diagnostics::EncodeDiagnostics> {
-        self.processor.take_diagnostics()
-    }
+    // Note: an earlier draft of this surface exposed
+    // `take_diagnostics(&mut self)` directly on `StreamingEncoder` and
+    // `StripProcessor`. The `finish_with_diagnostics` path now threads
+    // the diagnostics record out through an intercept callback in
+    // `finish_into_with_stop_threaded`, so the explicit takers were
+    // dropped to keep the dead-code lint clean under
+    // `--features __diagnostics`.
 
     /// Creates a new streaming encoder builder with the given dimensions.
     ///
@@ -1027,6 +1025,12 @@ impl StreamingEncoder {
         self.finish_into_with_stop_inner_diag(output, stop, Some(diagnostics_out))
     }
 
+    // Inner finish dispatcher: routes to the diagnostics-instrumented
+    // body when the `__diagnostics` feature is on, the plain body
+    // otherwise. Marked allow(dead_code) because under
+    // `--features __diagnostics` this wrapper is unused (the diag
+    // path goes via `finish_into_with_stop_and_diagnostics`).
+    #[allow(dead_code)]
     fn finish_into_with_stop_inner(
         self,
         output: &mut Vec<u8>,

--- a/zenjpeg/src/encode/streaming_builder.rs
+++ b/zenjpeg/src/encode/streaming_builder.rs
@@ -83,6 +83,14 @@ pub(crate) struct StreamingEncoderBuilder {
     /// compat (`QuantTableSource::MozjpegDefault`) path — the jpegli
     /// path uses `chroma_distance_scale` for the same purpose.
     pub(crate) chroma_quality: Option<u8>,
+
+    /// Per-block encode diagnostics capture. UNSTABLE — gated behind
+    /// the `__diagnostics` feature. When `true`, the underlying
+    /// `StripProcessor` allocates an `EncodeDiagnostics` struct and
+    /// fills it during encoding; retrieve via `take_diagnostics()`
+    /// after `finish()`.
+    #[cfg(feature = "__diagnostics")]
+    pub(crate) diagnostics_enabled: bool,
 }
 
 impl StreamingEncoderBuilder {
@@ -123,7 +131,21 @@ impl StreamingEncoderBuilder {
             tiny_file_mode: TinyFileMode::default(),
             chroma_distance_scale: 1.0,
             chroma_quality: None,
+            #[cfg(feature = "__diagnostics")]
+            diagnostics_enabled: false,
         }
+    }
+
+    /// Enable per-block encode diagnostics capture (UNSTABLE).
+    ///
+    /// When `true`, the encoder fills an `EncodeDiagnostics` struct
+    /// during encoding; retrieve via `take_diagnostics()` after
+    /// `finish()`. Gated behind the `__diagnostics` cargo feature.
+    #[cfg(feature = "__diagnostics")]
+    #[must_use]
+    pub(crate) fn diagnostics(mut self, enable: bool) -> Self {
+        self.diagnostics_enabled = enable;
+        self
     }
 
     /// Sets the quality using jpegli's native quality scale.

--- a/zenjpeg/src/encode/strip/mod.rs
+++ b/zenjpeg/src/encode/strip/mod.rs
@@ -1128,15 +1128,11 @@ impl StripProcessor {
         self.diagnostics = Some(diag);
     }
 
-    /// Take the captured per-block diagnostics, leaving `None` in the
-    /// processor. Returns `None` when diagnostics weren't enabled.
-    /// UNSTABLE — gated behind the `__diagnostics` cargo feature.
-    #[cfg(feature = "__diagnostics")]
-    pub(crate) fn take_diagnostics(
-        &mut self,
-    ) -> Option<crate::encode::diagnostics::EncodeDiagnostics> {
-        self.diagnostics.take()
-    }
+    // Note: `take_diagnostics(&mut self)` was removed. The
+    // diagnostics record is now extracted via the
+    // `StripProcessorOutput.diagnostics` field returned from
+    // `finalize()`, intercepted by the streaming encoder's
+    // `finish_into_with_stop_threaded` callback.
 
     /// Returns whether XYB mode is enabled.
     #[must_use]

--- a/zenjpeg/src/encode/strip/mod.rs
+++ b/zenjpeg/src/encode/strip/mod.rs
@@ -605,6 +605,13 @@ pub struct StripProcessor {
     /// unchanged.
     #[cfg(feature = "__diagnostics")]
     diagnostics: Option<crate::encode::diagnostics::EncodeDiagnostics>,
+
+    /// Count of `quantize_prev_pending_imcu` invocations so far. Used
+    /// solely by the diagnostics capture path to map per-iMCU MCU-
+    /// traversal block indices to global raster (row, col) positions
+    /// in the per-component block grid. Incremented by 1 per call.
+    #[cfg(feature = "__diagnostics")]
+    diag_imcu_call_idx: usize,
 }
 
 impl StripProcessor {
@@ -904,6 +911,8 @@ impl StripProcessor {
             // `enable_diagnostics()` (gated behind `__diagnostics`).
             #[cfg(feature = "__diagnostics")]
             diagnostics: None,
+            #[cfg(feature = "__diagnostics")]
+            diag_imcu_call_idx: 0,
         })
     }
 
@@ -1645,6 +1654,22 @@ impl StripProcessor {
             unreachable!("use_boundary_rd is always false without the boundary-rd feature");
         } else {
             let quant = &self.quant;
+            // Snapshot of layout values consumed inside the diagnostics
+            // capture (avoid re-borrowing `self` while we already hold
+            // `&self.quant` and `&self.pending`).
+            //
+            // Use `layout.h_samp` / `layout.v_samp` (MAX sampling factors
+            // of the JFIF frame, which correctly account for XYB
+            // BQuarter's B-channel-driven `v_samp=2` even though the
+            // underlying subsampling enum reports `S444`).
+            #[cfg(feature = "__diagnostics")]
+            let diag_h = self.layout.h_samp;
+            #[cfg(feature = "__diagnostics")]
+            let diag_v = self.layout.v_samp;
+            #[cfg(feature = "__diagnostics")]
+            let diag_y_blocks_w = self.layout.y_blocks_w;
+            #[cfg(feature = "__diagnostics")]
+            let diag_imcu_idx = self.diag_imcu_call_idx;
             // Default fast path — unchanged from before boundary-RD was added.
             for (i, dct) in self.pending.y[buffer_idx].iter().enumerate() {
                 // Use get() with fallback to avoid branch on common path
@@ -1691,18 +1716,65 @@ impl StripProcessor {
 
                 self.y_blocks.push(zigzag);
                 self.all_aq_strengths.push(aq_strength);
+
+                // Diagnostics capture (Y, default fast path). Maps the
+                // MCU-traversal block index `i` to a global raster
+                // (row, col) in the y_blocks_w × y_blocks_h grid.
+                #[cfg(feature = "__diagnostics")]
+                if let Some(ref mut diag) = self.diagnostics {
+                    let blocks_per_mcu = diag_h * diag_v;
+                    let mcu_in_row = if blocks_per_mcu > 0 {
+                        i / blocks_per_mcu
+                    } else {
+                        i
+                    };
+                    let block_in_mcu = if blocks_per_mcu > 0 {
+                        i % blocks_per_mcu
+                    } else {
+                        0
+                    };
+                    let bc = block_in_mcu % diag_h.max(1);
+                    let br = block_in_mcu / diag_h.max(1);
+                    let global_col = mcu_in_row * diag_h.max(1) + bc;
+                    let global_row = diag_imcu_idx * diag_v.max(1) + br;
+                    let global_idx = global_row * diag_y_blocks_w + global_col;
+                    if let Some(slot) = diag
+                        .components
+                        .get_mut(0)
+                        .and_then(|c| c.blocks.get_mut(global_idx))
+                    {
+                        slot.coef_pre_quant = dct.to_array();
+                        slot.coef_levels = zigzag;
+                        slot.aq_multiplier = aq_strength;
+                    }
+                }
             }
         }
 
-        // Quantize Cb/Cr blocks
+        // Quantize Cb/Cr blocks — scoped so the `quant` borrow drops
+        // before any `&mut self` diagnostic captures.
+        let y_blocks_w = self.layout.y_blocks_w;
+        let y_blocks_h = self.layout.y_blocks_h;
+        let c_blocks_w = self.layout.c_blocks_w;
+        let c_blocks_h = self.layout.c_blocks_h;
+        let cr_blocks_h = if self.layout.use_xyb {
+            self.layout.b_blocks_w
+        } else {
+            c_blocks_w
+        };
+        let cr_blocks_v = if self.layout.use_xyb {
+            self.layout.b_blocks_h
+        } else {
+            c_blocks_h
+        };
+
+        #[cfg(feature = "__diagnostics")]
+        let cb_start = self.cb_blocks.len();
+        #[cfg(feature = "__diagnostics")]
+        let cr_start = self.cr_blocks.len();
         {
             let quant = &self.quant;
-            let y_blocks_w = self.layout.y_blocks_w;
-            let y_blocks_h = self.layout.y_blocks_h;
-            let c_blocks_w = self.layout.c_blocks_w;
-            let c_blocks_h = self.layout.c_blocks_h;
 
-            // Cb: always uses c_blocks dimensions
             let cb_dc_raw = if store_dc_raw {
                 Some(&mut self.cb_dc_raw)
             } else {
@@ -1725,17 +1797,6 @@ impl StripProcessor {
                 y_blocks_h,
             );
 
-            // Cr: for XYB mode, use b_blocks dimensions (B channel is 2x2 downsampled)
-            let cr_blocks_h = if self.layout.use_xyb {
-                self.layout.b_blocks_w
-            } else {
-                c_blocks_w
-            };
-            let cr_blocks_v = if self.layout.use_xyb {
-                self.layout.b_blocks_h
-            } else {
-                c_blocks_h
-            };
             let cr_dc_raw = if store_dc_raw {
                 Some(&mut self.cr_dc_raw)
             } else {
@@ -1757,6 +1818,98 @@ impl StripProcessor {
                 y_blocks_w,
                 y_blocks_h,
             );
+        }
+
+        // Diagnostics captures for chroma — outside the `quant` borrow scope.
+        #[cfg(feature = "__diagnostics")]
+        {
+            self.capture_chroma_diag(
+                /* component_idx */ 1,
+                cb_start,
+                buffer_idx,
+                /* is_cb */ true,
+                c_blocks_w,
+                c_blocks_h,
+                y_blocks_w,
+                y_blocks_h,
+            );
+            self.capture_chroma_diag(
+                /* component_idx */ 2,
+                cr_start,
+                buffer_idx,
+                /* is_cb */ false,
+                cr_blocks_h,
+                cr_blocks_v,
+                y_blocks_w,
+                y_blocks_h,
+            );
+        }
+
+        // Advance the iMCU counter — diagnostics needs this to map
+        // per-iMCU MCU-traversal indices to global raster positions.
+        #[cfg(feature = "__diagnostics")]
+        {
+            self.diag_imcu_call_idx += 1;
+        }
+    }
+
+    /// Capture chroma per-block diagnostics after `quantize_chroma_blocks`.
+    /// `component_idx` is the index into `diagnostics.components` (1 = Cb,
+    /// 2 = Cr). `block_start` is the chroma-blocks Vec length captured
+    /// before the helper call. `is_cb` selects between `pending.cb` and
+    /// `pending.cr`. The remaining args mirror the chroma helper's
+    /// dimensions so we can replicate the AQ-strength lookup formula.
+    #[cfg(feature = "__diagnostics")]
+    #[allow(clippy::too_many_arguments)]
+    fn capture_chroma_diag(
+        &mut self,
+        component_idx: usize,
+        block_start: usize,
+        buffer_idx: usize,
+        is_cb: bool,
+        chroma_blocks_h: usize,
+        chroma_blocks_v: usize,
+        y_blocks_w: usize,
+        y_blocks_h: usize,
+    ) {
+        let blocks_h = chroma_blocks_h.max(1);
+        let pending = if is_cb {
+            &self.pending.cb[buffer_idx]
+        } else {
+            &self.pending.cr[buffer_idx]
+        };
+        let new_blocks = if is_cb {
+            &self.cb_blocks[block_start..]
+        } else {
+            &self.cr_blocks[block_start..]
+        };
+        let aq_src = &self.all_aq_strengths;
+
+        let Some(diag) = self.diagnostics.as_mut() else {
+            return;
+        };
+        let Some(component) = diag.components.get_mut(component_idx) else {
+            return;
+        };
+
+        let global_chroma_by_start = block_start / blocks_h;
+        for (i, dct) in pending.iter().enumerate() {
+            let bx = i % blocks_h;
+            let local_by = i / blocks_h;
+            let chroma_by = global_chroma_by_start + local_by;
+            let y_bx = (bx * y_blocks_w) / blocks_h;
+            let y_by = (chroma_by * y_blocks_h) / chroma_blocks_v.max(1);
+            let global_aq_idx = y_by * y_blocks_w + y_bx.min(y_blocks_w.saturating_sub(1));
+            let aq_strength = aq_src.get(global_aq_idx).copied().unwrap_or(0.08);
+
+            let global_idx = chroma_by * blocks_h + bx;
+            if let Some(slot) = component.blocks.get_mut(global_idx) {
+                slot.coef_pre_quant = dct.to_array();
+                if let Some(levels) = new_blocks.get(i) {
+                    slot.coef_levels = *levels;
+                }
+                slot.aq_multiplier = aq_strength;
+            }
         }
     }
 

--- a/zenjpeg/src/encode/strip/mod.rs
+++ b/zenjpeg/src/encode/strip/mod.rs
@@ -596,6 +596,15 @@ pub struct StripProcessor {
     /// arrive in irregular shapes (e.g. zero-length flush at EOI).
     aq_controller: Option<Box<dyn crate::encode::aq_controller::AqController>>,
     aq_controller_imcu_idx: usize,
+
+    /// Per-block encode diagnostics sink (UNSTABLE; gated behind
+    /// `__diagnostics`). When `Some`, the quantize loop captures
+    /// pre-quant DCT, post-quant levels, AQ multiplier, and entropy
+    /// bits into per-component block lists. When `None` (the default
+    /// and the only option in default builds), the encode hot path is
+    /// unchanged.
+    #[cfg(feature = "__diagnostics")]
+    diagnostics: Option<crate::encode::diagnostics::EncodeDiagnostics>,
 }
 
 impl StripProcessor {
@@ -890,6 +899,11 @@ impl StripProcessor {
             // No AQ controller installed by default (#113 PR-A scaffold).
             aq_controller: None,
             aq_controller_imcu_idx: 0,
+
+            // Diagnostics sink starts as `None`; opt-in via
+            // `enable_diagnostics()` (gated behind `__diagnostics`).
+            #[cfg(feature = "__diagnostics")]
+            diagnostics: None,
         })
     }
 
@@ -936,6 +950,8 @@ impl StripProcessor {
             y_dc_raw: core::mem::take(&mut self.y_dc_raw),
             cb_dc_raw: core::mem::take(&mut self.cb_dc_raw),
             cr_dc_raw: core::mem::take(&mut self.cr_dc_raw),
+            #[cfg(feature = "__diagnostics")]
+            diagnostics: None, // mid-encode take; use finalize() for final diagnostics
         }
     }
 
@@ -1018,6 +1034,99 @@ impl StripProcessor {
     #[cfg(feature = "trellis")]
     pub fn set_hybrid(&mut self, config: crate::encode::trellis::HybridConfig) {
         self.hybrid_ctx = Some(HybridQuantContext::new(config));
+    }
+
+    /// Allocate the per-block diagnostics sink and pre-size component
+    /// block lists from the resolved layout. Idempotent: calling twice
+    /// resets to a fresh sink.
+    ///
+    /// UNSTABLE — gated behind the `__diagnostics` cargo feature.
+    #[cfg(feature = "__diagnostics")]
+    pub(crate) fn enable_diagnostics(&mut self) {
+        use crate::encode::diagnostics::{
+            ColorPathTag, ComponentDiagnostics, EncodeDiagnostics, ImageInfo,
+        };
+        let layout = &self.layout;
+        let is_grayscale = self.pixel_format.is_grayscale();
+
+        // Flatten the SIMD `[[f32; 8]; 8]` zero-bias offset rows into a
+        // natural-order `[f32; 64]` for the diagnostics consumer.
+        let flatten = |rows: &[[f32; 8]; 8]| -> [f32; 64] {
+            let mut out = [0.0f32; 64];
+            for (r, row) in rows.iter().enumerate() {
+                out[r * 8..(r + 1) * 8].copy_from_slice(row);
+            }
+            out
+        };
+
+        let mut diag = EncodeDiagnostics::default();
+        diag.image = ImageInfo {
+            width: layout.width as u32,
+            height: layout.height as u32,
+            color_path: if layout.use_xyb {
+                ColorPathTag::Xyb
+            } else if is_grayscale {
+                ColorPathTag::Grayscale
+            } else {
+                ColorPathTag::YCbCr
+            },
+            sampling_factors: Vec::new(),
+        };
+
+        let h_samp_y = layout.subsampling.h_samp_factor_luma();
+        let v_samp_y = layout.subsampling.v_samp_factor_luma();
+
+        // Y component: full resolution.
+        let y_blocks = (layout.y_blocks_w as u32) * (layout.y_blocks_h as u32);
+        diag.image.sampling_factors.push((h_samp_y, v_samp_y));
+        diag.components.push(ComponentDiagnostics {
+            component_id: 1,
+            block_grid: (layout.y_blocks_w as u32, layout.y_blocks_h as u32),
+            quant_table_base: self.quant.y_quant.values,
+            zero_bias: flatten(&self.quant.y_zero_bias_simd.offset_rows),
+            blocks: alloc::vec![Default::default(); y_blocks as usize],
+        });
+
+        // Cb / Cr (skip for grayscale).
+        if !is_grayscale {
+            let cb_blocks = (layout.c_blocks_w as u32) * (layout.c_blocks_h as u32);
+            diag.image.sampling_factors.push((1, 1));
+            diag.components.push(ComponentDiagnostics {
+                component_id: 2,
+                block_grid: (layout.c_blocks_w as u32, layout.c_blocks_h as u32),
+                quant_table_base: self.quant.cb_quant.values,
+                zero_bias: flatten(&self.quant.cb_zero_bias_simd.offset_rows),
+                blocks: alloc::vec![Default::default(); cb_blocks as usize],
+            });
+
+            // Cr / B-channel: XYB B uses b_blocks dims, others use c_blocks.
+            let (cr_w, cr_h) = if layout.use_xyb {
+                (layout.b_blocks_w as u32, layout.b_blocks_h as u32)
+            } else {
+                (layout.c_blocks_w as u32, layout.c_blocks_h as u32)
+            };
+            let cr_blocks = cr_w * cr_h;
+            diag.image.sampling_factors.push((1, 1));
+            diag.components.push(ComponentDiagnostics {
+                component_id: 3,
+                block_grid: (cr_w, cr_h),
+                quant_table_base: self.quant.cr_quant.values,
+                zero_bias: flatten(&self.quant.cr_zero_bias_simd.offset_rows),
+                blocks: alloc::vec![Default::default(); cr_blocks as usize],
+            });
+        }
+
+        self.diagnostics = Some(diag);
+    }
+
+    /// Take the captured per-block diagnostics, leaving `None` in the
+    /// processor. Returns `None` when diagnostics weren't enabled.
+    /// UNSTABLE — gated behind the `__diagnostics` cargo feature.
+    #[cfg(feature = "__diagnostics")]
+    pub(crate) fn take_diagnostics(
+        &mut self,
+    ) -> Option<crate::encode::diagnostics::EncodeDiagnostics> {
+        self.diagnostics.take()
     }
 
     /// Returns whether XYB mode is enabled.
@@ -2038,6 +2147,8 @@ impl StripProcessor {
             y_dc_raw: self.y_dc_raw,
             cb_dc_raw: self.cb_dc_raw,
             cr_dc_raw: self.cr_dc_raw,
+            #[cfg(feature = "__diagnostics")]
+            diagnostics: self.diagnostics,
         })
     }
 
@@ -2246,6 +2357,12 @@ pub struct StripProcessorOutput {
     pub cb_dc_raw: Vec<i32>,
     /// Cr channel raw DC coefficients.
     pub cr_dc_raw: Vec<i32>,
+    /// Per-block encode diagnostics (UNSTABLE; gated behind
+    /// `__diagnostics`). `Some` when `enable_diagnostics()` was called
+    /// on the source processor; `None` (the default) for production
+    /// encodes.
+    #[cfg(feature = "__diagnostics")]
+    pub diagnostics: Option<crate::encode::diagnostics::EncodeDiagnostics>,
 }
 
 #[cfg(test)]

--- a/zenjpeg/src/lib.rs
+++ b/zenjpeg/src/lib.rs
@@ -275,10 +275,12 @@ pub mod container;
 // Internal Implementation Modules
 // ============================================================================
 
-// Internal encoder implementation (exposed via test-utils for benchmarks)
-#[cfg(feature = "__test-utils")]
+// Internal encoder implementation (exposed via test-utils for benchmarks
+// or `__diagnostics` for the unstable encode-diagnostics surface used by
+// the visualizer).
+#[cfg(any(feature = "__test-utils", feature = "__diagnostics"))]
 pub mod encode;
-#[cfg(not(feature = "__test-utils"))]
+#[cfg(not(any(feature = "__test-utils", feature = "__diagnostics")))]
 pub(crate) mod encode;
 
 // Internal decoder implementation

--- a/zenjpeg/tests/diagnostics_smoke.rs
+++ b/zenjpeg/tests/diagnostics_smoke.rs
@@ -1,0 +1,333 @@
+//! Smoke test for the unstable `__diagnostics` capture feature.
+//!
+//! Verifies that an encode with `with_diagnostics(true)` populates
+//! the per-component block lists with non-default data, and that the
+//! population covers every block in the grid.
+
+#![cfg(feature = "__diagnostics")]
+
+use zenjpeg::encoder::{ChromaSubsampling, EncoderConfig};
+
+/// Generate a deterministic non-trivial 32×32 RGB pattern. Uses a sine
+/// modulation per-channel so every 8×8 block has non-zero AC energy.
+fn make_test_image(width: u32, height: u32) -> Vec<u8> {
+    let mut buf = Vec::with_capacity((width * height * 3) as usize);
+    for y in 0..height {
+        for x in 0..width {
+            // Channel-dependent low-freq + high-freq mixture.
+            let fx = x as f32;
+            let fy = y as f32;
+            let r = (128.0
+                + 64.0 * (fx * 0.3).sin()
+                + 32.0 * ((fx + fy) * 0.9).cos())
+                .clamp(0.0, 255.0) as u8;
+            let g = (128.0
+                + 64.0 * (fy * 0.25).cos()
+                + 32.0 * ((fx - fy) * 0.7).sin())
+                .clamp(0.0, 255.0) as u8;
+            let b = (128.0 + 96.0 * ((fx + fy) * 0.15).sin()).clamp(0.0, 255.0) as u8;
+            buf.extend_from_slice(&[r, g, b]);
+        }
+    }
+    buf
+}
+
+fn assert_blocks_populated(
+    diag: &zenjpeg::encode::diagnostics::EncodeDiagnostics,
+    label: &str,
+) {
+    assert!(
+        !diag.components.is_empty(),
+        "[{label}] expected at least one component"
+    );
+    for (ci, comp) in diag.components.iter().enumerate() {
+        let expected = (comp.block_grid.0 as usize) * (comp.block_grid.1 as usize);
+        assert_eq!(
+            comp.blocks.len(),
+            expected,
+            "[{label}] component {ci} block count mismatch: \
+             grid {:?} → {expected} expected, got {}",
+            comp.block_grid,
+            comp.blocks.len()
+        );
+        let populated = comp
+            .blocks
+            .iter()
+            .filter(|b| b.coef_pre_quant.iter().any(|&c| c != 0.0))
+            .count();
+        assert!(
+            populated > 0,
+            "[{label}] component {ci} has zero populated pre-quant DCT blocks \
+             (expected at least one block with non-zero AC energy)"
+        );
+        // For the synthetic pattern, every block should have non-trivial
+        // energy. Allow a small tolerance for edge effects but be loud
+        // about big gaps.
+        let populated_ratio = populated as f32 / expected.max(1) as f32;
+        assert!(
+            populated_ratio >= 0.9,
+            "[{label}] component {ci}: only {populated}/{expected} \
+             ({:.1}%) blocks populated — diagnostics capture coverage gap",
+            populated_ratio * 100.0
+        );
+        // AQ multipliers should be non-zero (default is 0.08 mean).
+        let aq_nonzero = comp
+            .blocks
+            .iter()
+            .filter(|b| b.aq_multiplier > 0.0)
+            .count();
+        assert!(
+            aq_nonzero > 0,
+            "[{label}] component {ci} has no blocks with non-zero AQ multiplier"
+        );
+    }
+}
+
+#[test]
+fn ycbcr_444_baseline_aq_only_smoke() {
+    let w = 32u32;
+    let h = 32u32;
+    let pixels = make_test_image(w, h);
+    let config = EncoderConfig::ycbcr(85, ChromaSubsampling::None)
+        .aq_enabled(true)
+        .with_diagnostics(true);
+    let request = config.request();
+    let mut encoder = request
+        .encode_from_bytes(w, h, zenjpeg::encoder::PixelLayout::Rgb8Srgb)
+        .expect("build encoder");
+    encoder
+        .push_packed(&pixels, enough::Unstoppable)
+        .expect("push pixels");
+    let (bytes, diag) = encoder.finish_with_diagnostics().expect("finish");
+    assert!(!bytes.is_empty());
+    let diag = diag.expect("diagnostics enabled → Some");
+    assert_eq!(diag.image.width, w);
+    assert_eq!(diag.image.height, h);
+    // 32×32 → 4×4 Y blocks, 4×4 chroma blocks (no subsampling).
+    assert_eq!(diag.components.len(), 3);
+    assert_eq!(diag.components[0].block_grid, (4, 4));
+    assert_eq!(diag.components[1].block_grid, (4, 4));
+    assert_eq!(diag.components[2].block_grid, (4, 4));
+    assert_blocks_populated(&diag, "ycbcr_444_aq_only");
+}
+
+#[test]
+fn ycbcr_420_baseline_aq_only_smoke() {
+    let w = 32u32;
+    let h = 32u32;
+    let pixels = make_test_image(w, h);
+    let config = EncoderConfig::ycbcr(85, ChromaSubsampling::Quarter)
+        .aq_enabled(true)
+        .with_diagnostics(true);
+    let request = config.request();
+    let mut encoder = request
+        .encode_from_bytes(w, h, zenjpeg::encoder::PixelLayout::Rgb8Srgb)
+        .expect("build encoder");
+    encoder
+        .push_packed(&pixels, enough::Unstoppable)
+        .expect("push pixels");
+    let (bytes, diag) = encoder.finish_with_diagnostics().expect("finish");
+    assert!(!bytes.is_empty());
+    let diag = diag.expect("diagnostics enabled → Some");
+    // 32×32 with 4:2:0: Y is 4×4 blocks, chroma is 2×2 blocks.
+    assert_eq!(diag.components.len(), 3);
+    assert_eq!(diag.components[0].block_grid, (4, 4));
+    assert_eq!(diag.components[1].block_grid, (2, 2));
+    assert_eq!(diag.components[2].block_grid, (2, 2));
+    assert_blocks_populated(&diag, "ycbcr_420_aq_only");
+}
+
+/// 4:2:2 — h_samp_y=2, v_samp_y=1. Should populate Y in MCU-traversal
+/// order and chroma in raster order with half-width grids.
+#[test]
+fn ycbcr_422_aq_only_smoke() {
+    let w = 32u32;
+    let h = 32u32;
+    let pixels = make_test_image(w, h);
+    let config = EncoderConfig::ycbcr(85, ChromaSubsampling::HalfHorizontal)
+        .aq_enabled(true)
+        .with_diagnostics(true);
+    let request = config.request();
+    let mut encoder = request
+        .encode_from_bytes(w, h, zenjpeg::encoder::PixelLayout::Rgb8Srgb)
+        .expect("build encoder");
+    encoder
+        .push_packed(&pixels, enough::Unstoppable)
+        .expect("push pixels");
+    let (bytes, diag) = encoder.finish_with_diagnostics().expect("finish");
+    assert!(!bytes.is_empty());
+    let diag = diag.expect("diagnostics enabled → Some");
+    // 4:2:2: Y is 4×4 blocks, chroma is 2×4 blocks.
+    assert_eq!(diag.components.len(), 3);
+    assert_eq!(diag.components[0].block_grid, (4, 4));
+    assert_eq!(diag.components[1].block_grid, (2, 4));
+    assert_eq!(diag.components[2].block_grid, (2, 4));
+    assert_blocks_populated(&diag, "ycbcr_422_aq_only");
+}
+
+/// AQ disabled: blocks still populate with neutral AQ (encoder still
+/// pushes constant 0.0 strengths through the same path).
+#[test]
+fn ycbcr_444_aq_disabled_smoke() {
+    let w = 24u32;
+    let h = 24u32;
+    let pixels = make_test_image(w, h);
+    let config = EncoderConfig::ycbcr(85, ChromaSubsampling::None)
+        .aq_enabled(false)
+        .with_diagnostics(true);
+    let request = config.request();
+    let mut encoder = request
+        .encode_from_bytes(w, h, zenjpeg::encoder::PixelLayout::Rgb8Srgb)
+        .expect("build encoder");
+    encoder
+        .push_packed(&pixels, enough::Unstoppable)
+        .expect("push pixels");
+    let (bytes, diag) = encoder.finish_with_diagnostics().expect("finish");
+    assert!(!bytes.is_empty());
+    let diag = diag.expect("diagnostics enabled → Some");
+    // 24×24 → 3×3 Y blocks per component (no subsampling).
+    assert_eq!(diag.components.len(), 3);
+    assert_eq!(diag.components[0].block_grid, (3, 3));
+    // Pre-quant DCT and levels still populated even with AQ off.
+    let populated = diag.components[0]
+        .blocks
+        .iter()
+        .filter(|b| b.coef_pre_quant.iter().any(|&c| c != 0.0))
+        .count();
+    assert!(populated >= 8, "expected ~9 blocks populated, got {populated}");
+}
+
+/// Trellis-only mode (mozjpeg-compatible R-D). The same per-block
+/// capture point handles both the SIMD fast path and the trellis
+/// branch, so post-quant levels should reflect trellis decisions.
+#[cfg(feature = "trellis")]
+#[test]
+fn ycbcr_444_trellis_only_smoke() {
+    use zenjpeg::encode::trellis::TrellisConfig;
+    let w = 32u32;
+    let h = 32u32;
+    let pixels = make_test_image(w, h);
+    let trellis_cfg = TrellisConfig::new();
+    let config = EncoderConfig::ycbcr(85, ChromaSubsampling::None)
+        .aq_enabled(true)
+        .trellis(trellis_cfg)
+        .with_diagnostics(true);
+    let request = config.request();
+    let mut encoder = request
+        .encode_from_bytes(w, h, zenjpeg::encoder::PixelLayout::Rgb8Srgb)
+        .expect("build encoder");
+    encoder
+        .push_packed(&pixels, enough::Unstoppable)
+        .expect("push pixels");
+    let (bytes, diag) = encoder.finish_with_diagnostics().expect("finish");
+    assert!(!bytes.is_empty());
+    let diag = diag.expect("diagnostics enabled → Some");
+    assert_eq!(diag.components.len(), 3);
+    assert_blocks_populated(&diag, "ycbcr_444_trellis_only");
+}
+
+/// Hybrid (AQ-coupled trellis) mode via auto_optimize.
+#[cfg(feature = "trellis")]
+#[test]
+fn ycbcr_420_hybrid_smoke() {
+    let w = 32u32;
+    let h = 32u32;
+    let pixels = make_test_image(w, h);
+    let config = EncoderConfig::ycbcr(85, ChromaSubsampling::Quarter)
+        .auto_optimize(true)
+        .with_diagnostics(true);
+    let request = config.request();
+    let mut encoder = request
+        .encode_from_bytes(w, h, zenjpeg::encoder::PixelLayout::Rgb8Srgb)
+        .expect("build encoder");
+    encoder
+        .push_packed(&pixels, enough::Unstoppable)
+        .expect("push pixels");
+    let (bytes, diag) = encoder.finish_with_diagnostics().expect("finish");
+    assert!(!bytes.is_empty());
+    let diag = diag.expect("diagnostics enabled → Some");
+    assert_eq!(diag.components.len(), 3);
+    assert_blocks_populated(&diag, "ycbcr_420_hybrid");
+}
+
+/// XYB color path, no chroma subsampling. Verifies the diagnostics
+/// captures work for the perceptual color-space encoder too.
+#[test]
+fn xyb_full_smoke() {
+    use zenjpeg::encoder::XybSubsampling;
+    let w = 32u32;
+    let h = 32u32;
+    let pixels = make_test_image(w, h);
+    let config = EncoderConfig::xyb(85, XybSubsampling::Full)
+        .aq_enabled(true)
+        .with_diagnostics(true);
+    let request = config.request();
+    let mut encoder = request
+        .encode_from_bytes(w, h, zenjpeg::encoder::PixelLayout::Rgb8Srgb)
+        .expect("build encoder");
+    encoder
+        .push_packed(&pixels, enough::Unstoppable)
+        .expect("push pixels");
+    let (bytes, diag) = encoder.finish_with_diagnostics().expect("finish");
+    assert!(!bytes.is_empty());
+    let diag = diag.expect("diagnostics enabled → Some");
+    assert_eq!(
+        diag.image.color_path,
+        zenjpeg::encode::diagnostics::ColorPathTag::Xyb
+    );
+    // XYB Full: all three components at full resolution.
+    assert_eq!(diag.components.len(), 3);
+    assert_eq!(diag.components[0].block_grid, (4, 4));
+    assert_blocks_populated(&diag, "xyb_full");
+}
+
+/// XYB with B-channel quartered (default XYB subsampling). The B
+/// component grid should be half-resolution.
+#[test]
+fn xyb_b_quarter_smoke() {
+    use zenjpeg::encoder::XybSubsampling;
+    let w = 32u32;
+    let h = 32u32;
+    let pixels = make_test_image(w, h);
+    let config = EncoderConfig::xyb(85, XybSubsampling::BQuarter)
+        .aq_enabled(true)
+        .with_diagnostics(true);
+    let request = config.request();
+    let mut encoder = request
+        .encode_from_bytes(w, h, zenjpeg::encoder::PixelLayout::Rgb8Srgb)
+        .expect("build encoder");
+    encoder
+        .push_packed(&pixels, enough::Unstoppable)
+        .expect("push pixels");
+    let (bytes, diag) = encoder.finish_with_diagnostics().expect("finish");
+    assert!(!bytes.is_empty());
+    let diag = diag.expect("diagnostics enabled → Some");
+    assert_eq!(
+        diag.image.color_path,
+        zenjpeg::encode::diagnostics::ColorPathTag::Xyb
+    );
+    assert_eq!(diag.components.len(), 3);
+    // X (luma-ish): 4×4. Y component (Cb-slot): 4×4. B (Cr-slot): 2×2.
+    assert_eq!(diag.components[0].block_grid, (4, 4));
+    assert_eq!(diag.components[2].block_grid, (2, 2));
+    assert_blocks_populated(&diag, "xyb_b_quarter");
+}
+
+#[test]
+fn diagnostics_off_returns_none() {
+    let w = 16u32;
+    let h = 16u32;
+    let pixels = make_test_image(w, h);
+    let config = EncoderConfig::ycbcr(85, ChromaSubsampling::None);
+    // No `.with_diagnostics(true)` — feature is on but capture is off.
+    let request = config.request();
+    let mut encoder = request
+        .encode_from_bytes(w, h, zenjpeg::encoder::PixelLayout::Rgb8Srgb)
+        .expect("build encoder");
+    encoder
+        .push_packed(&pixels, enough::Unstoppable)
+        .expect("push pixels");
+    let (bytes, diag) = encoder.finish_with_diagnostics().expect("finish");
+    assert!(!bytes.is_empty());
+    assert!(diag.is_none(), "without with_diagnostics(true), no diag");
+}


### PR DESCRIPTION
## Summary

Adds an UNSTABLE `__diagnostics` cargo feature exposing per-block encode state (pre-quant DCT coefficients, post-quant levels, AQ multipliers, base quant tables, zero-bias offsets, sampling factors), plus a WASM-bound web viewer that renders source/encoded/delta triptych, AQ heatmap, per-coefficient utilization heatmap, and an equalizer-style quant table editor (`base × h_eq × v_eq` with 8 horizontal-frequency × 8 vertical-frequency sliders). All editing re-applies math locally to the captured pre-quant DCT — no encoder round-trip per slider drag.

Default-feature builds and `__diagnostics`-with-`with_diagnostics(false)` builds remain bit-identical to pre-feature output. Diagnostics encoding routes through the strip processor (skips `FusedParallelEncode`).

## Scope

- **Encoder side** (`encode/diagnostics.rs`, `encode/strip/mod.rs`, `encode/streaming.rs`, `encode/streaming_builder.rs`, `encode/byte_encoders.rs`, `encode/encoder_config.rs`)
- **WASM bindings** (`zenjpeg-diagnostics-viewer/wasm/`) — `encodeWithDiagnostics(pixels, w, h, options) → { bytes: Uint8Array, diagnostics }`
- **Demo viewer** (`zenjpeg-diagnostics-viewer/web/`) — vanilla TS + Vite, port 3173, relative `base: "./"` so the same `dist/` works at any deploy subpath
- **Playwright E2E** (`zenjpeg-diagnostics-viewer/web/tests/viewer.spec.ts`) — 7 tests (page bootstrap, AQ heatmap drawn, EQ slider re-renders utilization, color path swap, 4:2:0 chroma grid dims, quality byte-size monotonicity, Reset EQ)
- **CI** (`.github/workflows/diagnostics-ci.yml`) — rust matrix on linux/windows-arm/macos-intel + i686 cross, wasm-build, playwright e2e, pages deploy at `https://imazen.github.io/zenjpeg/diagnostics/`

## Rust test matrix

`cargo test -p zenjpeg --features __diagnostics,trellis --test diagnostics_smoke` covers `{aq_only, trellis_only, hybrid (auto_optimize)} × {ycbcr, xyb} × {4:4:4, 4:2:0, 4:2:2}` — 9/9 pass locally and in CI.

## Public API additions (gated behind `__diagnostics`, all `#[doc(hidden)]`)

- `EncoderConfig::with_diagnostics(bool)` builder
- `BytesEncoder::finish_with_diagnostics()` / `RgbEncoder<P>::finish_with_diagnostics()` returning `(Vec<u8>, Option<EncodeDiagnostics>)`
- `encode::diagnostics::{EncodeDiagnostics, ComponentDiagnostics, BlockDiagnostics, GlobalDiagnostics, AqFieldDump, ScanScriptDump, DiagnosticsCapture, ColorPathTag, QuantModeTag, QuantTableSourceTag, TinyFileModeTag}`

Type shape is intentionally evolvable across patch versions until the feature stabilizes.

## Deferred to follow-up

- Per-block entropy bit attribution (the encoder doesn't yet expose Huffman code-length sums per block; the diagnostic struct has the field with default 0)
- AQ field / scan script / heuristic decision capture (struct fields exist; capture sites not yet plumbed)

## Test plan

- [ ] `just diagnostics-test` (rust unit + integration matrix)
- [ ] `just diagnostics-wasm` (wasm-pack build)
- [ ] `just diagnostics-viewer-build` (vite build)
- [ ] `just diagnostics-e2e` (playwright suite, requires `npx playwright install --with-deps chromium` once)
- [ ] Manually click around `https://imazen.github.io/zenjpeg/diagnostics/` once Pages deploys: load synthetic, drag h_eq sliders, swap color path to XYB, swap subsampling, upload custom image
