### PR TITLE
fix(limits): raise default decode pixel cap 100 MP -> 120 MP

### DIFF
--- a/zenjpeg/src/foundation/alloc.rs
+++ b/zenjpeg/src/foundation/alloc.rs
@@ -25,9 +25,10 @@ pub use crate::foundation::instrumented_vec::{
 /// Slightly under 64K to prevent overflow in 16-bit calculations.
 pub const JPEG_MAX_DIMENSION: u32 = 65500;
 
-/// Default maximum pixels (100 megapixels).
-/// This is a reasonable limit for most applications.
-pub const DEFAULT_MAX_PIXELS: u64 = 100_000_000;
+/// Default maximum pixels (120 megapixels).
+/// Admits modern high-resolution phone photos (108 MP sensors are common)
+/// while still bounding decode allocation against untrusted input.
+pub const DEFAULT_MAX_PIXELS: u64 = 120_000_000;
 
 /// Maximum number of progressive scans allowed.
 pub const MAX_SCANS: usize = 256;


### PR DESCRIPTION
## What
Raises `DEFAULT_MAX_PIXELS` (zenjpeg/src/foundation/alloc.rs) from `100_000_000` to `120_000_000`.

## Why
Part of a cross-codec production-readiness sweep. Modern phone sensors (108 MP) and pro cameras routinely exceed the old 100 MP default decode cap, so legitimate images were rejected. 120 MP admits those while still bounding decode allocation against untrusted input.

## Scope / safety
- Per-dimension `JPEG_MAX_DIMENSION` (65500) unchanged.
- `DEFAULT_MAX_MEMORY` (512 MB) unchanged — the memory budget still bounds total allocation.
- Callers can tighten/relax via `Limits::max_pixels()`.
- No public API change (const value only). `cargo check` clean; no test asserts the old default (the `DEFAULT_MAX_PIXELS`-symbol test adapts; explicit-limit tests pass their own values).

Built and verified in an isolated jj workspace; the primary checkout was not touched.