### PR TITLE
feat(decoder): re-export ErrorKind so decode errors are matchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to zenjpeg are documented here. Earlier history
 
 ## [Unreleased]
 
+### Added
+- **`zenjpeg::decoder::ErrorKind` is now re-exported** so callers can
+  pattern-match decode failures (via `err.error()` / `err.kind()`) to map them
+  to HTTP status codes. Previously `ErrorKind` lived in a `pub(crate)` module
+  and was unnameable outside the crate, forcing brittle `Display` string
+  matching. Additive, non-breaking. README gains a worked error→HTTP-status
+  example; the `ErrorKind` rustdoc no longer points at the deprecated
+  `At::into_inner()`. Surfaced by a memory-insulated ignorant-agent docs pass.
+
 ### Changed
 - **4:2:2 (h2v1) fancy chroma upsampler is now SIMD on all arches** — it was
   pure scalar everywhere (confirmed via `cargo asm`: 177 scalar instrs, 0

--- a/zenjpeg/README.md
+++ b/zenjpeg/README.md
@@ -206,6 +206,40 @@ Request builder methods: `.icc_profile()`, `.exif()`, `.xmp()`, `.stop()`, `.lim
 | `.max_pixels(n)` | 100M | DoS protection |
 | `.max_memory(n)` | 512 MB | Memory limit |
 
+### Errors (for a server)
+
+`decode` returns `Result<_, zenjpeg::decoder::Error>`, where `Error` is
+`whereat::At<ErrorKind>` — the `At` wrapper records the source location for your
+logs (`format!("{e}")`). Borrow the inner kind with `e.error()` (or own it with
+`e.decompose().0`) and match `ErrorKind` to pick an HTTP status. `ErrorKind` is
+`#[non_exhaustive]`, so keep a wildcard arm:
+
+```rust
+use zenjpeg::decoder::{Decoder, ErrorKind};
+use enough::Unstoppable;
+
+let status = match Decoder::new().decode(&jpeg_bytes, Unstoppable) {
+    Ok(result) => {
+        // u8 output targets: result.into_pixels_u8() -> Option<Vec<u8>>
+        200
+    }
+    Err(e) => match e.error() {
+        ErrorKind::ImageTooLarge { .. }
+        | ErrorKind::AllocationFailed { .. }
+        | ErrorKind::TooManyRows { .. }
+        | ErrorKind::TooManyScans { .. } => 413, // Payload Too Large
+        ErrorKind::UnsupportedFeature { .. }
+        | ErrorKind::UnsupportedPixelFormat { .. }
+        | ErrorKind::UnsupportedOperation(_) => 415, // Unsupported Media Type
+        ErrorKind::Cancelled => 499, // client closed request
+        ErrorKind::InternalError { .. } | ErrorKind::IoError { .. } => 500,
+        // malformed input (InvalidJpegData, TruncatedData, InvalidMarker,
+        // InvalidDimensions, ...) -> 400 Bad Request
+        _ => 400,
+    },
+};
+```
+
 ### Decode Paths
 
 For most web JPEGs, `Decoder::new().decode(&data, stop)` hits the streaming path -- no coefficient storage, one MCU-row pass through entropy/IDCT/color/output. This is the fastest path.

--- a/zenjpeg/src/decoder/mod.rs
+++ b/zenjpeg/src/decoder/mod.rs
@@ -56,8 +56,12 @@
 // === Error types ===
 /// Errors that can occur during JPEG decoding.
 pub type DecodeError = crate::error::Error;
-// Keep legacy aliases for backward compatibility
-pub use crate::error::{Error, Result};
+// Keep legacy aliases for backward compatibility.
+// `ErrorKind` is re-exported so callers can pattern-match the inner error
+// (via `err.error()` / `err.kind()`) to map decode failures to HTTP status
+// codes — without it, `ErrorKind` is unnameable outside the crate and the
+// only option is brittle string-matching on `Display`.
+pub use crate::error::{Error, ErrorKind, Result};
 
 // === Main decoder types ===
 pub use crate::decode::{

--- a/zenjpeg/src/error.rs
+++ b/zenjpeg/src/error.rs
@@ -160,8 +160,9 @@ pub enum ResourceError {
 /// The specific kind of error that occurred.
 ///
 /// This is the inner error type wrapped by [`Error`] (which is `At<ErrorKind>`).
-/// Use [`Error::error()`](At::error) to access the kind, or pattern-match
-/// after calling [`Error::into_inner()`](At::into_inner).
+/// Use [`At::error()`](whereat::At::error) to borrow the kind, or
+/// [`At::decompose()`](whereat::At::decompose) to take it by value, then
+/// pattern-match (it is `#[non_exhaustive]`, so keep a wildcard arm).
 #[derive(Debug, Clone, PartialEq, Error)]
 #[non_exhaustive]
 pub enum ErrorKind {


### PR DESCRIPTION
## What
Re-exports `zenjpeg::decoder::ErrorKind` so callers can pattern-match decode failures.

## Why (found by an ignorant-agent docs pass)
A memory-insulated agent (fresh user, README + public signatures only) tried to map a decode error to an HTTP status and discovered it's **impossible**: `Error::kind()` returns `&ErrorKind`, but `ErrorKind` lived in `pub(crate) mod error` and was re-exported nowhere reachable. The only fallback was brittle `Display` string-matching — a real production footgun for an image proxy.

## Change (additive, non-breaking)
- `decoder/mod.rs`: add `ErrorKind` to `pub use crate::error::{Error, Result}` → `{Error, ErrorKind, Result}`. `ErrorKind` is already `pub` + `#[non_exhaustive]`, so this only makes it *reachable*.
- `error.rs`: the `ErrorKind` rustdoc pointed at the **deprecated** `At::into_inner()`; now points at `At::error()` / `At::decompose()`.
- `README.md`: adds a worked decode-error → HTTP-status example, verified against the actual variant names + shapes (`Cancelled` unit, `UnsupportedOperation(_)` tuple, the rest struct).

## Verified
`cargo check -p zenjpeg` clean (285 pre-existing warnings, no new). Built in an isolated jj workspace; the primary checkout (which has unrelated uncommitted work) was untouched.

## Note
`src/decoder/error.rs` is **orphan dead code** — no `mod error;` declares it, and it describes a *different* nested error taxonomy (`ErrorKind::Argument/Resource/...`) than the real flat `crate::error::ErrorKind`. Left as-is here (may be intended future work) but flagged: it's a docs-confusion source and should be either wired up or removed.