### PR TITLE
fix(limits): raise default max pixels 100MP -> 120MP

### DIFF
--- a/zenjpeg/src/codec.rs
+++ b/zenjpeg/src/codec.rs
@@ -1315,8 +1315,8 @@ impl<'a> zencodec::decode::DecodeJob<'a> for JpegDecodeJob {
 impl JpegDecodeJob {
     /// The inner decode config with this job's resource limits applied —
     /// probes must honor `with_limits` exactly like the decode path does
-    /// (a 108 MP corpus file probes fine under a raised `max_pixels` but the
-    /// inner config's default cap rejected it).
+    /// (a corpus file above the default cap probes fine under a raised `max_pixels`
+    /// but the inner config's default cap rejected it).
     fn limit_adjusted_inner(&self) -> crate::decode::DecodeConfig {
         let mut cfg = self.config.inner.clone();
         if let Some(max) = self.limits.max_pixels {

--- a/zenjpeg/src/decode/config.rs
+++ b/zenjpeg/src/decode/config.rs
@@ -873,7 +873,7 @@ pub struct DecodeConfig {
     /// (default), no color conversion is performed.
     pub correct_color: Option<TargetColorSpace>,
     /// Maximum pixels allowed (for DoS protection).
-    /// Default is 100 megapixels. Set to 0 for unlimited.
+    /// Default is 120 megapixels. Set to 0 for unlimited.
     /// Use `max_pixels()` method to set.
     pub(crate) max_pixels: u64,
     /// Maximum total memory for allocations (for DoS protection).

--- a/zenjpeg/src/decode/mod.rs
+++ b/zenjpeg/src/decode/mod.rs
@@ -355,7 +355,7 @@ impl DecodeConfig {
 
     /// Sets the maximum number of pixels allowed (for DoS protection).
     ///
-    /// Default is 100 megapixels. Set to 0 for unlimited.
+    /// Default is 120 megapixels. Set to 0 for unlimited.
     #[must_use]
     pub fn max_pixels(mut self, pixels: u64) -> Self {
         self.max_pixels = pixels;

--- a/zenjpeg/src/foundation/alloc.rs
+++ b/zenjpeg/src/foundation/alloc.rs
@@ -25,9 +25,10 @@ pub use crate::foundation::instrumented_vec::{
 /// Slightly under 64K to prevent overflow in 16-bit calculations.
 pub const JPEG_MAX_DIMENSION: u32 = 65500;
 
-/// Default maximum pixels (100 megapixels).
-/// This is a reasonable limit for most applications.
-pub const DEFAULT_MAX_PIXELS: u64 = 100_000_000;
+/// Default maximum pixels (120 megapixels).
+/// Sized to admit common high-resolution still output (e.g. 108 MP phone
+/// cameras) while still bounding decode work for untrusted input.
+pub const DEFAULT_MAX_PIXELS: u64 = 120_000_000;
 
 /// Maximum number of progressive scans allowed.
 pub const MAX_SCANS: usize = 256;

--- a/zenjpeg/tests/bundled/gain_map_render.rs
+++ b/zenjpeg/tests/bundled/gain_map_render.rs
@@ -431,20 +431,20 @@ fn components_gain_map_oriented_with_base() {
 /// the job raises `max_pixels` (and still fails without it).
 #[test]
 fn probe_honors_job_limits() {
-    // Patch a real fixture's SOF dimensions up to 12000x9000 (108 MP) —
+    // Patch a real fixture's SOF dimensions up to 12000x11000 (132 MP) —
     // read_info only parses headers, so no scan data needs to match.
     let mut jpeg = ultrahdr_jpeg();
     let sof = jpeg
         .windows(2)
         .position(|w| w[0] == 0xFF && (w[1] == 0xC0 || w[1] == 0xC2))
         .expect("SOF marker");
-    jpeg[sof + 5..sof + 7].copy_from_slice(&9000u16.to_be_bytes()); // height
+    jpeg[sof + 5..sof + 7].copy_from_slice(&11000u16.to_be_bytes()); // height
     jpeg[sof + 7..sof + 9].copy_from_slice(&12000u16.to_be_bytes()); // width
 
     let probe_default = JpegDecoderConfig::new().job().probe(&jpeg);
     assert!(
         probe_default.is_err(),
-        "108 MP must exceed the default probe cap (precondition)"
+        "132 MP must exceed the default probe cap (precondition)"
     );
 
     let info = JpegDecoderConfig::new()
@@ -452,5 +452,5 @@ fn probe_honors_job_limits() {
         .with_limits(zencodec::ResourceLimits::default().with_max_pixels(1_000_000_000))
         .probe(&jpeg)
         .expect("probe with raised max_pixels");
-    assert_eq!((info.width, info.height), (12000, 9000));
+    assert_eq!((info.width, info.height), (12000, 11000));
 }


### PR DESCRIPTION
## What

Raise `DEFAULT_MAX_PIXELS` from 100 MP to 120 MP in `zenjpeg/src/foundation/alloc.rs`.

## Why

108 MP phone-camera stills (and similar high-resolution captures) are now common. The previous 100 MP default rejected them before decode. 120 MP admits such input while still bounding per-image decode work for untrusted callers.

This aligns zenjpeg with the 120 MP default already shipped in `zencodec::ResourceLimits` and `zenpng`.

## Verification

- `cargo build -p zenjpeg --lib` — clean (rc=0)
- No test or doc asserts the old `100_000_000` default. The remaining `100_000_000` literals are independent example values in doc comments and a standalone `validate_dimensions` test case, intentionally left unchanged.
