### PR TITLE
docs(readme): make the cancellation example use a real, constructible token

### DIFF
--- a/zenjpeg/README.md
+++ b/zenjpeg/README.md
@@ -375,8 +375,13 @@ use enough::Unstoppable;
 // Never cancel
 let image = Decoder::new().decode(&jpeg_data, Unstoppable)?;
 
-// Custom cancellation (e.g., user clicked cancel)
-let result = Decoder::new().decode(&jpeg_data, &cancel_token);
+// Real cancellation: `almost_enough::Stopper` is a thread-safe `Stop` token
+// (`cargo add almost-enough`). It is `Clone` — flip it from a watcher thread.
+use almost_enough::Stopper;
+let stop = Stopper::new();
+let watcher = stop.clone();
+std::thread::spawn(move || watcher.cancel()); // e.g. on a deadline or client disconnect
+let image = Decoder::new().decode(&jpeg_data, &stop)?;
 ```
 
 ## Detect API (Encoder Identification)


### PR DESCRIPTION
## What

Makes the "Cooperative Cancellation" example compile by using a real cancellation token.

## Why

The example passed `&cancel_token` but never constructed it. An **insulated external-developer test** (agent given only README + public API) couldn't build a real token and fabricated `impl enough::Stop for AtomicBool`. Replaced it with `almost_enough::Stopper` (`cargo add almost-enough`), which is `Clone` and implements `enough::Stop`.

The **error-handling** half of that test is blocked by a real API gap, filed as #162: `Error::kind()`/`into_kind()` return an `ErrorKind` that external callers can't name (the `error` module is `pub(crate)`), so they can't classify limit-vs-cancel-vs-malformed failures except by string-matching. That needs an additive `pub use ErrorKind` (or `is_*` predicates), which touches the public API — hence the separate issue rather than bundling it here.

## Verification

`decode` accepts `&impl enough::Stop` (matches the README's prior `&cancel_token` usage); `#[derive(Clone)] Stopper` + `impl Stop for Stopper` (almost-enough `stopper.rs`). The crate README is not `include_str!`-compiled.
