### PR TITLE
test(decode): verify all decode paths are byte-identical under IdctMethod::Libjpeg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ All notable changes to zenjpeg are documented here. Earlier history
   default limit. Callers that set an explicit `max_pixels(...)` are unaffected.
   Updated the decoder/`Limits` default docs and README examples to match.
 
+### Tests
+- **All decode paths verified byte-identical under `IdctMethod::Libjpeg`.** New
+  `tests/libjpeg_idct_all_paths_parity.rs` asserts that `decode()` (streaming),
+  `scanline_reader()` (pull-based), and the multi-threaded fused-parallel path
+  produce **byte-for-byte identical** u8 RGB under `IdctMethod::Libjpeg`, across
+  4:2:0 / 4:2:2 / 4:4:0 / 4:4:4 × baseline/progressive × MCU-aligned and
+  non-aligned sizes. Previously only 4:2:0 baseline `decode()` vs
+  `scanline_reader()` was covered; this widens the lock to the full matrix, so a
+  caller gets the libjpeg-turbo-exact reconstruction regardless of which path the
+  decoder auto-selects. Under `--features __ffi-tests` it additionally asserts
+  every path is byte-identical to **real libjpeg-turbo** (`mozjpeg-sys`) across
+  4:2:2 / 4:4:0 / 4:4:4 too — extending the prior 4:2:0-only FFI exactness check
+  to every subsampling on every path (verified `max_diff == 0` throughout).
+  (The f32-output path routes the same unclamped libjpeg islow IDCT but in f32
+  precision, so it is intentionally not byte-exact with the u8 paths — guarded
+  loosely. The `force_f32_idct` transform path and Knusperli deblocking use the
+  f32 IDCT by design and are out of scope.)
+
 ### Fixed
 - **docs(readme): unify `Unstoppable` import path + quality arg type, name
   `Strictness`, add end-to-end decode→encode example — fixes first-try compile

--- a/zenjpeg/src/decode/config.rs
+++ b/zenjpeg/src/decode/config.rs
@@ -149,6 +149,10 @@ pub enum IdctMethod {
     /// (`test_idct_method_libjpeg_fancy_matches_mozjpeg_exact`). Pair with
     /// [`ChromaUpsampling::Triangle`] for the full byte-exact pipeline; ~3%
     /// slower to decode than the default [`Jpegli`](Self::Jpegli) IDCT.
+    /// Honored identically (byte-for-byte) on every u8 decode path — streaming
+    /// `decode()`, `scanline_reader()`, and the parallel path — across all
+    /// subsampling modes and baseline/progressive (see
+    /// `tests/libjpeg_idct_all_paths_parity.rs`).
     Libjpeg,
 }
 

--- a/zenjpeg/tests/libjpeg_idct_all_paths_parity.rs
+++ b/zenjpeg/tests/libjpeg_idct_all_paths_parity.rs
@@ -1,0 +1,248 @@
+//! Every decode path must produce BYTE-IDENTICAL u8 RGB under
+//! `IdctMethod::Libjpeg`, across all subsampling modes and baseline /
+//! progressive — so the libjpeg-turbo-exact reconstruction is independent of
+//! which path the decoder auto-selects (streaming `decode()`, pull-based
+//! `scanline_reader()`, or the multi-threaded fused-parallel path).
+//!
+//! Before this test, the only path-parity coverage for `Libjpeg` was 4:2:0
+//! baseline `decode()` vs `scanline_reader()` (see `libjpeg_idct_color_paths_agree`
+//! in `decode_path_dispatch_parity.rs`). This widens it to the full matrix.
+//!
+//! With `--features __ffi-tests` it additionally asserts every path is
+//! byte-identical to **real libjpeg-turbo** (`mozjpeg-sys`) across all
+//! subsampling — extending the prior 4:2:0-only FFI exactness check
+//! (`test_idct_method_libjpeg_fancy_matches_mozjpeg_exact`) to 4:2:2/4:4:0/4:4:4
+//! on every decode path.
+//!
+//! Run with `--features parallel` to exercise the real multi-threaded path
+//! (without it, `num_threads(4)` runs sequentially and the parallel arm is a
+//! trivial pass).
+//!
+//! Note on the f32 path: `output_target(SrgbF32)` routes the *unclamped*
+//! libjpeg islow IDCT (`idct_int_tiered_libjpeg_unclamped`) but then does f32
+//! color conversion + f32→u8 rounding, so it is intentionally NOT byte-exact
+//! with the u8 paths (it is a higher-precision regime). It is checked here
+//! only to stay within a loose band — a guard against a path regressing to a
+//! wholly different IDCT — not for equality.
+
+use enough::Unstoppable;
+use zenjpeg::decode::{ChromaUpsampling, Decoder, IdctMethod, OutputTarget};
+use zenjpeg::encoder::{ChromaSubsampling, EncoderConfig, PixelLayout};
+
+/// Block-banded RGB with saturated red/blue (stresses clamping + chroma) and
+/// a high-frequency green ramp (stresses interpolation/IDCT).
+fn test_image(w: usize, h: usize) -> Vec<u8> {
+    let mut d = vec![0u8; w * h * 3];
+    for y in 0..h {
+        for x in 0..w {
+            let i = (y * w + x) * 3;
+            d[i] = if (y / 8) % 2 == 0 { 255 } else { 0 };
+            d[i + 1] = ((x * 3 + y * 7) % 200) as u8;
+            d[i + 2] = ((x * 5 + y * 11) % 240) as u8;
+        }
+    }
+    d
+}
+
+fn encode(px: &[u8], w: u32, h: u32, sub: ChromaSubsampling, progressive: bool) -> Vec<u8> {
+    let mut e = EncoderConfig::ycbcr(85.0, sub)
+        .progressive(progressive)
+        .allow_16bit_quant_tables(false)
+        .encode_from_bytes(w, h, PixelLayout::Rgb8Srgb)
+        .expect("encoder");
+    e.push_packed(px, Unstoppable).expect("push");
+    e.finish().expect("finish")
+}
+
+/// `decode()` (streaming / fused-parallel auto-select) at `threads` threads.
+fn decode_full(jpeg: &[u8], threads: usize) -> Vec<u8> {
+    Decoder::new()
+        .idct_method(IdctMethod::Libjpeg)
+        .chroma_upsampling(ChromaUpsampling::Triangle)
+        .auto_orient(false)
+        .num_threads(threads)
+        .decode(jpeg, Unstoppable)
+        .expect("decode")
+        .into_pixels_u8()
+        .expect("u8")
+}
+
+/// `scanline_reader()` (pull-based streaming), single-thread.
+fn decode_scanline(jpeg: &[u8]) -> Vec<u8> {
+    let d = Decoder::new()
+        .idct_method(IdctMethod::Libjpeg)
+        .chroma_upsampling(ChromaUpsampling::Triangle)
+        .auto_orient(false)
+        .num_threads(1);
+    let mut r = d.scanline_reader(jpeg).expect("scanline_reader");
+    let (w, h) = (r.width() as usize, r.height() as usize);
+    let stride = w * 3;
+    let mut px = vec![0u8; stride * h];
+    let mut total = 0;
+    while !r.is_finished() {
+        let out = imgref::ImgRefMut::new(&mut px[total * stride..], stride, h - total);
+        total += r.read_rows_rgb8(out).expect("read");
+    }
+    assert_eq!(total, h, "scanline didn't read all rows");
+    px
+}
+
+/// f32 output path (routes the unclamped libjpeg islow), converted to u8.
+fn decode_f32_to_u8(jpeg: &[u8]) -> Vec<u8> {
+    let img = Decoder::new()
+        .idct_method(IdctMethod::Libjpeg)
+        .chroma_upsampling(ChromaUpsampling::Triangle)
+        .output_target(OutputTarget::SrgbF32)
+        .auto_orient(false)
+        .num_threads(1)
+        .decode(jpeg, Unstoppable)
+        .expect("decode f32");
+    img.pixels_f32()
+        .expect("f32")
+        .iter()
+        .map(|&v| (v * 255.0 + 0.5).clamp(0.0, 255.0) as u8)
+        .collect()
+}
+
+fn max_diff(a: &[u8], b: &[u8]) -> i32 {
+    assert_eq!(a.len(), b.len(), "length mismatch");
+    a.iter()
+        .zip(b)
+        .map(|(x, y)| (*x as i32 - *y as i32).abs())
+        .max()
+        .unwrap_or(0)
+}
+
+#[test]
+fn libjpeg_idct_all_paths_byte_identical() {
+    let subsamplings = [
+        ("4:2:0", ChromaSubsampling::Quarter),
+        ("4:2:2", ChromaSubsampling::HalfHorizontal),
+        ("4:4:0", ChromaSubsampling::HalfVertical),
+        ("4:4:4", ChromaSubsampling::None),
+    ];
+    // Non-MCU-aligned (partial MCUs), aligned, and large (engages parallel).
+    let sizes = [(67usize, 45usize), (128, 96), (256, 192)];
+
+    for &(w, h) in &sizes {
+        let pixels = test_image(w, h);
+        for &(sub_name, sub) in &subsamplings {
+            for progressive in [false, true] {
+                let jpeg = encode(&pixels, w as u32, h as u32, sub, progressive);
+                let label = format!(
+                    "{w}x{h} {sub_name} {}",
+                    if progressive {
+                        "progressive"
+                    } else {
+                        "baseline"
+                    }
+                );
+
+                let full = decode_full(&jpeg, 1);
+                let scanline = decode_scanline(&jpeg);
+                let parallel = decode_full(&jpeg, 4);
+
+                // The u8 paths must be byte-for-byte identical under Libjpeg.
+                assert_eq!(
+                    max_diff(&full, &scanline),
+                    0,
+                    "{label}: scanline_reader() != decode() under IdctMethod::Libjpeg"
+                );
+                assert_eq!(
+                    max_diff(&full, &parallel),
+                    0,
+                    "{label}: parallel (4 threads) != decode() under IdctMethod::Libjpeg"
+                );
+
+                // f32 path uses the unclamped libjpeg islow + f32 color — a
+                // different precision regime, not byte-exact. Loose guard only.
+                let f32_diff = max_diff(&full, &decode_f32_to_u8(&jpeg));
+                assert!(
+                    f32_diff <= 40,
+                    "{label}: f32 path diverges by {f32_diff} (>40) — likely wrong IDCT, \
+                     not just precision"
+                );
+            }
+        }
+    }
+}
+
+// ---- Byte-exactness vs real libjpeg-turbo (mozjpeg-sys FFI) ----
+
+/// Decode with mozjpeg-sys (libjpeg-turbo C) RGB, fancy upsampling.
+#[cfg(feature = "__ffi-tests")]
+fn decode_mozjpeg(data: &[u8]) -> Vec<u8> {
+    use mozjpeg_sys::*;
+    use std::mem;
+    // SAFETY: standard libjpeg-turbo decompress sequence; `out` is sized to
+    // output_height * stride before any scanline is written.
+    unsafe {
+        let mut err: jpeg_error_mgr = mem::zeroed();
+        jpeg_std_error(&mut err);
+        let mut ci: jpeg_decompress_struct = mem::zeroed();
+        ci.common.err = &mut err;
+        jpeg_create_decompress(&mut ci);
+        jpeg_mem_src(&mut ci, data.as_ptr(), data.len() as _);
+        assert_eq!(jpeg_read_header(&mut ci, 1), 1, "mozjpeg read_header");
+        ci.out_color_space = J_COLOR_SPACE::JCS_RGB;
+        ci.do_fancy_upsampling = 1;
+        jpeg_start_decompress(&mut ci);
+        let (w, h) = (ci.output_width, ci.output_height);
+        let stride = w as usize * ci.output_components as usize;
+        let mut out = vec![0u8; h as usize * stride];
+        while ci.output_scanline < h {
+            let off = ci.output_scanline as usize * stride;
+            let mut p = out[off..].as_mut_ptr();
+            jpeg_read_scanlines(&mut ci, &mut p, 1);
+        }
+        jpeg_finish_decompress(&mut ci);
+        jpeg_destroy_decompress(&mut ci);
+        out
+    }
+}
+
+/// Every u8 decode path must be BYTE-FOR-BYTE identical to real libjpeg-turbo
+/// (mozjpeg-sys, fancy upsampling) under `IdctMethod::Libjpeg` + `Triangle`,
+/// across all subsampling modes and baseline/progressive. The existing FFI
+/// check (`test_idct_method_libjpeg_fancy_matches_mozjpeg_exact`) covered only
+/// 4:2:0 via `decode()`; this proves it for 4:2:2 / 4:4:0 / 4:4:4 on every
+/// path too (verified `max_diff == 0` on every cell before asserting).
+#[cfg(feature = "__ffi-tests")]
+#[test]
+fn libjpeg_idct_all_paths_match_libjpeg_turbo() {
+    let subsamplings = [
+        ("4:2:0", ChromaSubsampling::Quarter),
+        ("4:2:2", ChromaSubsampling::HalfHorizontal),
+        ("4:4:0", ChromaSubsampling::HalfVertical),
+        ("4:4:4", ChromaSubsampling::None),
+    ];
+    let sizes = [(67usize, 45usize), (128, 96), (256, 192)];
+    for &(w, h) in &sizes {
+        let pixels = test_image(w, h);
+        for &(sub_name, sub) in &subsamplings {
+            for progressive in [false, true] {
+                let jpeg = encode(&pixels, w as u32, h as u32, sub, progressive);
+                let moz = decode_mozjpeg(&jpeg);
+                let label = format!(
+                    "{w}x{h} {sub_name} {}",
+                    if progressive {
+                        "progressive"
+                    } else {
+                        "baseline"
+                    }
+                );
+                for (path, decoded) in [
+                    ("decode()", decode_full(&jpeg, 1)),
+                    ("scanline_reader()", decode_scanline(&jpeg)),
+                    ("parallel", decode_full(&jpeg, 4)),
+                ] {
+                    assert_eq!(
+                        max_diff(&decoded, &moz),
+                        0,
+                        "{label}: {path} != libjpeg-turbo under IdctMethod::Libjpeg"
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Locks in that the **libjpeg-turbo-exact reconstruction** (`IdctMethod::Libjpeg`) is identical regardless of which decode path the decoder auto-selects, **and** that each path matches **real libjpeg-turbo** across every subsampling.

New `tests/libjpeg_idct_all_paths_parity.rs`:

1. **`libjpeg_idct_all_paths_byte_identical`** — `decode()` (streaming), `scanline_reader()` (pull-based), and the multi-threaded fused-parallel path produce **byte-for-byte identical** u8 RGB under `IdctMethod::Libjpeg`, across **4:2:0 / 4:2:2 / 4:4:0 / 4:4:4 × baseline/progressive × aligned & non-aligned sizes**.
2. **`libjpeg_idct_all_paths_match_libjpeg_turbo`** (`--features __ffi-tests`) — every path is byte-identical (`max_diff == 0`) to **real libjpeg-turbo** (`mozjpeg-sys`) across the same matrix. This **extends the prior 4:2:0-only FFI exactness check** (`test_idct_method_libjpeg_fancy_matches_mozjpeg_exact`) to 4:2:2 / 4:4:0 / 4:4:4 on every decode path. Verified `max_diff == 0` on all 24 cells before asserting.

Both pass ✅.

## What I found

The three u8 paths **already** route `idct_method` → `idct_int_tiered_libjpeg` **and** the turbo h2v2 upsampler bias on every path (`pipeline.rs`, `scanline.rs`, `fused_parallel.rs`) — support was already complete; the gap was **coverage**. This PR is the comprehensive lock.

## Out of scope (different IDCT by design — documented, not changed)

- **f32 output** (`SrgbF32`) routes the same *unclamped* libjpeg islow but does f32 color + f32→u8 rounding, so it's intentionally not byte-exact with the u8 paths (higher-precision regime, diverges 2–30). Guarded loosely (`≤ 40`).
- **`force_f32_idct`** (rotate/transpose transforms) and **Knusperli** deblocking use the f32 `idct.rs` kernel — non-libjpeg-semantics modes.

## Files

- `tests/libjpeg_idct_all_paths_parity.rs` (new)
- `src/decode/config.rs` — `IdctMethod::Libjpeg` rustdoc notes the all-path + libjpeg-turbo guarantee
- `CHANGELOG.md`
