### PR TITLE
docs: state encode_from_bytes/rgb/ycbcr_planar w/h are u32

### DIFF
--- a/zenjpeg/README.md
+++ b/zenjpeg/README.md
@@ -145,11 +145,11 @@ zenjpeg = { version = "0.6", features = ["moxcms"] }
 
 | Method | Input Type | Use Case |
 |--------|------------|----------|
-| `encode_from_bytes(w, h, layout)` | `&[u8]` | Raw byte buffers |
-| `encode_from_rgb::<P>(w, h)` | `rgb` crate types | `RGB<u8>`, `RGBA<f32>`, etc. |
-| `encode_from_ycbcr_planar(w, h)` | `YCbCrPlanes` | Video pipeline output |
+| `encode_from_bytes(w: u32, h: u32, layout)` | `&[u8]` | Raw byte buffers |
+| `encode_from_rgb::<P>(w: u32, h: u32)` | `rgb` crate types | `RGB<u8>`, `RGBA<f32>`, etc. |
+| `encode_from_ycbcr_planar(w: u32, h: u32)` | `YCbCrPlanes` | Video pipeline output |
 
-All three return a streaming `Encoder`. Push rows with `push_packed()`, finish with `finish()`. One-shot convenience: `config.request().encode(&pixels, w, h)`.
+Width and height are `u32` (pixels) on every entry point. All three return a streaming `Encoder`. Push rows with `push_packed()`, finish with `finish()`. One-shot convenience: `config.request().encode(&pixels, w, h)`.
 
 ### Builder Methods
 


### PR DESCRIPTION
## What

The README **Entry Points** table documented `encode_from_bytes(w, h, layout)`, `encode_from_rgb::<P>(w, h)`, and `encode_from_ycbcr_planar(w, h)` with **untyped** `w, h`. A reader couldn't tell `u32` from `usize`, so the call was a compile coin-flip. This annotates all three streaming entry points as `u32` and adds an explicit "width and height are `u32` (pixels)" note.

## Verified against source

- `zenjpeg/src/encode/request.rs:156` — `encode_from_bytes(self, width: u32, height: u32, layout: PixelLayout)`
- `zenjpeg/src/encode/encoder_config.rs:1550` — same signature
- `encode_from_rgb` / `encode_from_ycbcr_planar` — also `u32` (request.rs:169/177)

Diff is **README-only** (1 file, 4/4 lines).

## Context

Found via an insulated external-developer usability test of the published docs. The same test flagged a Feature-Flags / C-library / 'unsafe-free by default' contradiction in the **retired** `jpegli-rs` 0.12.0 README (frozen on crates.io since 2026-01-24, repo redirects to `imazen/zenjpeg`). That contradiction **does not exist** in this going-forward `zenjpeg` README: `default = []` is genuinely unsafe-free with safe archmage SIMD (`#![forbid(unsafe_code)]`), and color management is pure-Rust `moxcms` — no `lcms2`/`cms-lcms2`, no `unsafe_simd`, no `wide` crate. So only the (still-present) `encode_from_bytes` type gap carried forward, and that's what this PR fixes.