### PR TITLE
feat(limits): raise default max pixels 100MP→120MP (admit ~108MP photos)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to zenjpeg are documented here. Earlier history
 
 ## [Unreleased]
 
+### Changed
+- **Default max-pixels limit raised 100 MP → 120 MP** (`DEFAULT_MAX_PIXELS` in
+  `foundation/alloc.rs`). 108 MP phone-camera photos are common and were rejected
+  by the old 100 MP cap; 120 MP admits them with headroom. Non-breaking: a looser
+  default limit. Callers that set an explicit `max_pixels(...)` are unaffected.
+  Updated the decoder/`Limits` default docs and README examples to match.
+
 ### Fixed
 - **docs(readme): unify `Unstoppable` import path + quality arg type, name
   `Strictness`, add end-to-end decode→encode example — fixes first-try compile

--- a/zenjpeg/README.md
+++ b/zenjpeg/README.md
@@ -21,7 +21,7 @@ fn transcode(input_path: &str, output_path: &str) -> Result<(), Box<dyn std::err
     // pass any `&impl zenjpeg::encoder::Stop` (e.g. a shared atomic flag) instead
     // to support user-initiated cancellation.
     let decoded = Decoder::new()
-        .max_pixels(100_000_000) // reject decompression bombs (100 MP)
+        .max_pixels(120_000_000) // reject decompression bombs (120 MP, admits ~108 MP camera photos)
         .max_memory(512 * 1024 * 1024) // cap allocation at 512 MB
         .decode(&jpeg_bytes, Unstoppable)?;
 
@@ -43,7 +43,7 @@ fn transcode(input_path: &str, output_path: &str) -> Result<(), Box<dyn std::err
 decoder accepts, so a single import covers both the decode and encode calls. To
 set all limits in one value (and reuse them via the request builder), use
 [`Limits`](#per-image-metadata-three-layer-pattern):
-`zenjpeg::encoder::Limits::default().max_pixels(100_000_000).max_memory(512 * 1024 * 1024)`.
+`zenjpeg::encoder::Limits::default().max_pixels(120_000_000).max_memory(512 * 1024 * 1024)`.
 
 ## Quick Start
 
@@ -260,7 +260,7 @@ use zenjpeg::encoder::Unstoppable;
 
 let result = Decoder::new()
     .strictness(Strictness::Strict)   // reject any spec violation or truncation
-    .max_pixels(100_000_000)          // 100 MP cap
+    .max_pixels(120_000_000)          // 120 MP cap (admits ~108 MP camera photos)
     .max_memory(512 * 1024 * 1024)    // 512 MB cap
     .decode(&jpeg_bytes, Unstoppable)?;
 ```

--- a/zenjpeg/src/decode/config.rs
+++ b/zenjpeg/src/decode/config.rs
@@ -879,7 +879,7 @@ pub struct DecodeConfig {
     /// (default), no color conversion is performed.
     pub correct_color: Option<TargetColorSpace>,
     /// Maximum pixels allowed (for DoS protection).
-    /// Default is 100 megapixels. Set to 0 for unlimited.
+    /// Default is 120 megapixels (admits common ~108 MP camera photos). Set to 0 for unlimited.
     /// Use `max_pixels()` method to set.
     pub(crate) max_pixels: u64,
     /// Maximum total memory for allocations (for DoS protection).

--- a/zenjpeg/src/decode/mod.rs
+++ b/zenjpeg/src/decode/mod.rs
@@ -355,7 +355,7 @@ impl DecodeConfig {
 
     /// Sets the maximum number of pixels allowed (for DoS protection).
     ///
-    /// Default is 100 megapixels. Set to 0 for unlimited.
+    /// Default is 120 megapixels (admits common ~108 MP camera photos). Set to 0 for unlimited.
     #[must_use]
     pub fn max_pixels(mut self, pixels: u64) -> Self {
         self.max_pixels = pixels;

--- a/zenjpeg/src/decoder/mod.rs
+++ b/zenjpeg/src/decoder/mod.rs
@@ -36,12 +36,12 @@
 //!
 //! // Set resource limits (DoS protection)
 //! let decoder = Decoder::new()
-//!     .max_pixels(100_000_000)      // 100 megapixels max
+//!     .max_pixels(120_000_000)      // 120 megapixels max (admits common ~108 MP camera photos)
 //!     .max_memory(512_000_000);     // 512 MB max allocation
 //!
 //! // Or use Limits struct
 //! let limits = Limits {
-//!     max_pixels: Some(100_000_000),
+//!     max_pixels: Some(120_000_000),
 //!     max_memory: Some(512_000_000),
 //!     max_output: None,
 //! };

--- a/zenjpeg/src/foundation/alloc.rs
+++ b/zenjpeg/src/foundation/alloc.rs
@@ -25,9 +25,9 @@ pub use crate::foundation::instrumented_vec::{
 /// Slightly under 64K to prevent overflow in 16-bit calculations.
 pub const JPEG_MAX_DIMENSION: u32 = 65500;
 
-/// Default maximum pixels (100 megapixels).
-/// This is a reasonable limit for most applications.
-pub const DEFAULT_MAX_PIXELS: u64 = 100_000_000;
+/// Default maximum pixels (120 megapixels).
+/// This is a reasonable limit for most applications (admits common ~108 MP camera photos).
+pub const DEFAULT_MAX_PIXELS: u64 = 120_000_000;
 
 /// Maximum number of progressive scans allowed.
 pub const MAX_SCANS: usize = 256;
@@ -796,7 +796,7 @@ mod tests {
         assert!(validate_dimensions(70000, 100, DEFAULT_MAX_PIXELS).is_err());
 
         // Exceeds max_pixels
-        assert!(validate_dimensions(20000, 20000, 100_000_000).is_err()); // 400M > 100M
+        assert!(validate_dimensions(20000, 20000, 120_000_000).is_err()); // 400M > 120M
     }
 
     #[test]

--- a/zenjpeg/src/types.rs
+++ b/zenjpeg/src/types.rs
@@ -601,7 +601,7 @@ impl Dimensions {
 /// use zenjpeg::encoder::Limits;
 ///
 /// let limits = Limits::default()
-///     .max_pixels(100_000_000)       // 100 megapixels
+///     .max_pixels(120_000_000)       // 120 megapixels (admits common ~108 MP camera photos)
 ///     .max_memory(512 * 1024 * 1024) // 512 MB
 ///     .max_output(50 * 1024 * 1024); // 50 MB output
 /// ```


### PR DESCRIPTION
User-directed limit bump.

108 MP phone-camera photos are common and were being rejected by zenjpeg's
default 100 MP pixel cap (`DEFAULT_MAX_PIXELS`). This raises the default to
120 MP, which admits 108 MP images with headroom.

**Non-breaking:** this only *loosens* a default limit. Callers that set an
explicit `max_pixels(...)` (or `Limits { max_pixels: Some(...) }`) are
unaffected. Byte/memory limits (`max_memory`, `max_output`) are untouched.

### Changes
- `zenjpeg/src/foundation/alloc.rs`: `DEFAULT_MAX_PIXELS` `100_000_000` → `120_000_000` (+ doc comment).
- `zenjpeg/src/decode/config.rs`, `zenjpeg/src/decode/mod.rs`, `zenjpeg/src/decoder/mod.rs`: default-limit doc/example references 100 → 120 MP.
- `zenjpeg/src/types.rs`: `Limits` doc example 100 → 120 MP.
- `zenjpeg/README.md`: 3 `max_pixels` references (including the `Limits::default()` default claim) 100 → 120 MP.
- `zenjpeg/src/foundation/alloc.rs` (test): `validate_dimensions` boundary literal `100_000_000` → `120_000_000`; the 400 MP over-limit assertion stays valid (400M still exceeds 120M).
- `CHANGELOG.md`: `### Changed` entry under `[Unreleased]`.

### Verification
`grep` over `zenjpeg/src` confirms no remaining pixel-limit reference to 100 MP (`100_000_000` / "100 megapixel"); the only 100_000_000 occurrences left in the tree are in `docs/SECURITY*.md` design-proposal snapshots (illustrative, fictional struct/const names — left as historical record) and unrelated byte/memory limits. CI is the build/test gate (not run locally to avoid contention with concurrent agents).