### PR TITLE
docs(zenjpeg): correct stale max_pixels default (100M/256M → 120M) in README+DECODER_PATHS

### DIFF
--- a/zenjpeg/README.md
+++ b/zenjpeg/README.md
@@ -248,7 +248,7 @@ where `Limits` is `zenjpeg::encoder::Limits` built via
 | `.crop(region)` | none | Pixel-level crop (IDCT skipped outside region) |
 | `.num_threads(n)` | `0` (auto) | `1` forces sequential |
 | `.strictness(Strictness)` | `Balanced` | `Strictness::{Strict, Balanced, Lenient, Permissive}` (type at `zenjpeg::decoder::Strictness`) |
-| `.max_pixels(u64)` | 100M | DoS protection |
+| `.max_pixels(u64)` | 120M | DoS protection |
 | `.max_memory(u64)` | 512 MB | Memory limit |
 
 `Strictness` is `zenjpeg::decoder::Strictness`; `.max_pixels` / `.max_memory` take a

--- a/zenjpeg/docs/DECODER_PATHS.md
+++ b/zenjpeg/docs/DECODER_PATHS.md
@@ -153,7 +153,7 @@ Entropy decode runs for full image (DC predictor chain), but IDCT only runs for 
 | `.crop(CropRegion)` | none | Pixel-level crop of output |
 | `.num_threads(usize)` | `0` (auto) | `1` disables parallel |
 | `.strictness(Strictness)` | `Balanced` | Error tolerance for malformed JPEGs |
-| `.max_pixels(u64)` | 256M | Resource limit |
+| `.max_pixels(u64)` | 120M | Resource limit |
 | `.block_smoothing(bool)` | `false` | Progressive rendering smoothing (no effect on final output) |
 
 ### Entry points


### PR DESCRIPTION
Doc-only fix for DOC/CODE drift.

`DEFAULT_MAX_PIXELS` is `120_000_000` (`zenjpeg/src/foundation/alloc.rs:30`), but two doc tables understated/overstated it:

- `zenjpeg/README.md` limits table row for `.max_pixels(u64)` said **100M** → now **120M**. (The same README already says "120 MP cap" further down, so this makes them consistent.)
- `zenjpeg/docs/DECODER_PATHS.md` decoder-limits table row said **256M** → now **120M**.

No code, no public API, no behavior change. CI verifies the build.