### PR TITLE
fix(error): preserve At trace at the zq/lossy boundaries (map_err_at)

### DIFF
--- a/zenjpeg/src/encode/zq.rs
+++ b/zenjpeg/src/encode/zq.rs
@@ -888,11 +888,12 @@ fn measure(
     use zensim::{DiffmapWeighting, RgbSlice};
     let dec = crate::decode::Decoder::new()
         .decode(jpeg, Unstoppable)
-        .map_err(|e| {
-            crate::error::Error::invalid_config(alloc::format!(
-                "decode for measurement failed: {e}"
-            ))
-        })?;
+        // `decode` returns the crate's own `Error`, a newtype over `At<ErrorKind>`
+        // that already carries a trace from the decode site. Extend that trace with
+        // this caller's location instead of stringifying it into a fresh
+        // `invalid_config` (which would discard the original trace and ErrorKind).
+        // (Closure form so `Error::at`'s `#[track_caller]` records this line.)
+        .map_err(|e| e.at())?;
     let pixels = dec.into_pixels_u8().ok_or_else(|| {
         crate::error::Error::invalid_config("decoder returned non-u8 pixels".into())
     })?;

--- a/zenjpeg/src/layout/lossy.rs
+++ b/zenjpeg/src/layout/lossy.rs
@@ -10,6 +10,7 @@ use alloc::vec::Vec;
 
 use enough::Stop;
 use imgref::ImgRefMut;
+use whereat::ResultAtExt;
 use zenresize::{PixelDescriptor, StreamingResize};
 
 use crate::decode::{ChromaUpsampling, DecodeConfig, JpegInfo};
@@ -121,17 +122,16 @@ fn decode_resize_encode(
 
         let available = resizer
             .push_rows(&buf[..row_bytes * rows_read], row_bytes, rows_read as u32)
-            .map_err(|e| {
-                crate::error::Error::new(crate::error::ErrorKind::InternalError {
-                    reason: match e.error() {
-                        zenresize::StreamingError::AlreadyFinished => "resize: push after finish",
-                        zenresize::StreamingError::InputTooShort => "resize: input row too short",
-                        zenresize::StreamingError::RingBufferOverflow => {
-                            "resize: ring buffer overflow"
-                        }
-                        _ => "resize: unknown streaming error",
-                    },
-                })
+            // `push_rows` returns `At<StreamingError>`; map the inner variant to our
+            // `ErrorKind` with `map_err_at` so the resize-call trace is carried through
+            // (the trailing `?` then wraps the resulting `At<ErrorKind>` into `Error`).
+            .map_err_at(|inner| crate::error::ErrorKind::InternalError {
+                reason: match inner {
+                    zenresize::StreamingError::AlreadyFinished => "resize: push after finish",
+                    zenresize::StreamingError::InputTooShort => "resize: input row too short",
+                    zenresize::StreamingError::RingBufferOverflow => "resize: ring buffer overflow",
+                    _ => "resize: unknown streaming error",
+                },
             })?;
         drain_resizer(&mut resizer, available, &mut encoder, stop)?;
     }
@@ -203,17 +203,16 @@ pub(crate) fn resize_simple(
 
         let available = resizer
             .push_rows(&buf[..row_bytes * rows_read], row_bytes, rows_read as u32)
-            .map_err(|e| {
-                crate::error::Error::new(crate::error::ErrorKind::InternalError {
-                    reason: match e.error() {
-                        zenresize::StreamingError::AlreadyFinished => "resize: push after finish",
-                        zenresize::StreamingError::InputTooShort => "resize: input row too short",
-                        zenresize::StreamingError::RingBufferOverflow => {
-                            "resize: ring buffer overflow"
-                        }
-                        _ => "resize: unknown streaming error",
-                    },
-                })
+            // `push_rows` returns `At<StreamingError>`; map the inner variant to our
+            // `ErrorKind` with `map_err_at` so the resize-call trace is carried through
+            // (the trailing `?` then wraps the resulting `At<ErrorKind>` into `Error`).
+            .map_err_at(|inner| crate::error::ErrorKind::InternalError {
+                reason: match inner {
+                    zenresize::StreamingError::AlreadyFinished => "resize: push after finish",
+                    zenresize::StreamingError::InputTooShort => "resize: input row too short",
+                    zenresize::StreamingError::RingBufferOverflow => "resize: ring buffer overflow",
+                    _ => "resize: unknown streaming error",
+                },
             })?;
         drain_resizer(&mut resizer, available, &mut encoder, stop)?;
     }


### PR DESCRIPTION
Two cross-crate trace-loss boundaries where an `At<...>` error was consumed and its location trace discarded.

## Sites fixed

**`zenjpeg/src/encode/zq.rs`** (`measure`, behind `target-zq`) — `Decoder::decode` returns the crate's own `Error`, a newtype over `At<ErrorKind>` that already carries a trace from the decode site. The old code stringified it into a fresh `Error::invalid_config(format!("...: {e}"))`, which discards the inner `AtTrace` *and* the `ErrorKind`, capturing a brand-new trace at this line:

```rust
.map_err(|e| e.at())?;   // was: .map_err(|e| Error::invalid_config(format!("decode for measurement failed: {e}")))?
```

`Error::at()` (`#[track_caller]`) extends the existing trace with this line and keeps the original `ErrorKind`.

**`zenjpeg/src/layout/lossy.rs`** (x2, both `push_rows` drains, behind `layout`) — `StreamingResize::push_rows` returns `Result<u32, At<StreamingError>>`. The old code read `e.error()` (borrow of the inner variant) and built a fresh `Error::new(ErrorKind::InternalError { .. })`, dropping the resize-call trace:

```rust
.map_err_at(|inner| crate::error::ErrorKind::InternalError {
    reason: match inner { /* same per-variant strings */ },
})?;
```

`map_err_at` (from `whereat::ResultAtExt`) maps `At<StreamingError>` → `At<ErrorKind>` carrying the trace through; the trailing `?` then wraps it into `Error` via the existing `From<At<ErrorKind>> for Error`. Per-variant `reason` strings are unchanged. Added `use whereat::ResultAtExt;`.

## Left as-is (not a trace boundary)

The sibling `zensim::compute_with_ref_and_diffmap` call in zq.rs returns a **bare** `ZensimError` (not `At<...>`), so there is no trace to preserve — its `Error::invalid_config(format!(...))` mapping is correct and untouched.

## Verification (under `run-heavy`, no `target-cpu=native`, scoped)

The full suite is large, so the build was scoped to the two affected feature paths:

- `cargo build -p zenjpeg --lib --features layout,target-zq` — rc=0 (no errors; zero warnings on the edited lines; the 285 warnings are pre-existing dead-code)
- `cargo clippy -p zenjpeg --lib --features layout,target-zq` — rc=0 (no clippy warnings on the edited lines)
- `cargo fmt -p zenjpeg --check` — clean
- No in-module unit tests match `zq`/`lossy`; the test harness compiled cleanly with these features (`--list`).

Diff scope: `zenjpeg/src/encode/zq.rs` + `zenjpeg/src/layout/lossy.rs` only.