### PR TITLE
feat(error): make ErrorKind public so servers can classify decode errors (closes #155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to zenjpeg are documented here. Earlier history
 
 ## [Unreleased]
 
+### Added
+- **`ErrorKind` is now public, re-exported as `zenjpeg::decoder::ErrorKind` and
+  `zenjpeg::encoder::ErrorKind`** (closes #155). The decode/encode error is
+  `Error(pub At<ErrorKind>)` with `.kind() -> &ErrorKind`, but `ErrorKind` lived
+  in the `pub(crate) error` module and was re-exported through zero public paths,
+  so a caller could invoke `.kind()` yet could not *name* any variant to `match`
+  on it — error classification (e.g. 413 too-large / 400 corrupt / 500 OOM)
+  collapsed to `to_string().contains(...)` substring matching. `ErrorKind` is
+  `#[non_exhaustive]`, so this re-export is additive and future variants stay
+  non-breaking. New `tests/error_kind_public.rs` matches `.kind()` against named
+  variants through the public path.
+### Fixed
+- **Crate-root rustdoc decoder example now compiles and runs** (closes #155, item
+  2). The top-of-page `lib.rs` decoder snippet showed a stale 1-arg
+  `Decoder::new().decode(&jpeg_data)?` plus `image.pixels() -> &[u8]`; the real
+  signature is `.decode(data, stop)` returning a `DecodeResult` whose bytes come
+  from `.pixels_u8()`. Replaced the `rust,ignore` block with a real, compiling
+  doctest (encode a tiny image, decode it round-trip) and added a second doctest
+  showing `match err.kind() { ErrorKind::… }` for error classification.
 ### Changed
 - **Default max-pixels limit raised 100 MP → 120 MP** (`DEFAULT_MAX_PIXELS` in
   `foundation/alloc.rs`). 108 MP phone-camera photos are common and were rejected

--- a/docs/public-api/zenjpeg.internal.txt
+++ b/docs/public-api/zenjpeg.internal.txt
@@ -10,15 +10,15 @@
 ## summary
 #
 #   pub modules                                84
-#   pub types (struct/enum/trait/alias)       297
+#   pub types (struct/enum/trait/alias)       298
 #   pub consts/statics                        316
 #   pub macros                                  1
-#   free functions                            370
-#   inherent methods                         1182
-#   struct fields                             748
-#   enum variants                             490
+#   free functions                            376
+#   inherent methods                         1186
+#   struct fields                             751
+#   enum variants                             492
 #   re-exports                                 25
-#   trait roster entries (type × trait)       640
+#   trait roster entries (type × trait)       646
 #   auto-trait-complete types                 131
 #   auto-trait exceptions                       7
 #
@@ -26,13 +26,13 @@
 #   (root)                           78
 #   alloc                             1
 #   analyze                           8
-#   color                           118
+#   color                           117
 #   container                         8
-#   decode                          429
-#   decoder                          53
+#   decode                          444
+#   decoder                          54
 #   detect                           40
 #   encode                         1451
-#   encoder                         131
+#   encoder                         132
 #   entropy                         100
 #   foundation                      342
 #   heuristics                        3
@@ -46,7 +46,7 @@
 #   types                           140
 #   ultrahdr                         12
 
-## items (3335 lines)
+## items (3351 lines)
 
 #[non_exhaustive] #[repr(u8)] pub enum types::ColorSpace [also: decode]
 #[non_exhaustive] pub enum color::icc::TargetColorSpace
@@ -399,6 +399,7 @@ pub enum decode::OwnedDecodedPixels
 pub enum decode::SegmentType [also: encode::extras]
 pub enum decode::StandardProfile
 pub enum decode::Strictness
+pub enum decode::upsample::H2v2Bias
 pub enum detect::content::ContentType
 pub enum detect::content::DeblockAction
 pub enum encode::Exif [also: encode::exif]
@@ -481,8 +482,7 @@ pub fn color::ycbcr::cmyk_to_rgb(u8, u8, u8, u8) -> (u8, u8, u8)
 pub fn color::ycbcr::convert_rgb_to_ycbcr_buffer(&mut [u8])
 pub fn color::ycbcr::convert_ycbcr_to_rgb_buffer(&mut [u8])
 pub fn color::ycbcr::extract_channel(&[u8], types::PixelFormat, usize) -> encoder::Result<alloc::vec::Vec<u8>>
-pub fn color::ycbcr::fused_h2v2_box_ycbcr_to_rgb_u8(&[i16], &[i16], &[i16], &mut [u8], usize)
-pub fn color::ycbcr::fused_h2v2_hfancy_ycbcr_to_rgb_u8(&[i16], &[i16], &[i16], &mut [u8], usize)
+pub fn color::ycbcr::fused_h2v2_box_ycbcr_to_rgb_u8(&[i16], &[i16], &[i16], &mut [u8], usize, bool)
 pub fn color::ycbcr::rgb_to_cmyk(u8, u8, u8) -> (u8, u8, u8, u8)
 pub fn color::ycbcr::rgb_to_ycbcr(u8, u8, u8) -> (u8, u8, u8)
 pub fn color::ycbcr::rgb_to_ycbcr_planes(&[u8], usize, usize) -> encoder::Result<(alloc::vec::Vec<u8>, alloc::vec::Vec<u8>, alloc::vec::Vec<u8>)>
@@ -490,8 +490,8 @@ pub fn color::ycbcr::ycbcr_planes_to_rgb(&[u8], &[u8], &[u8], usize, usize) -> e
 pub fn color::ycbcr::ycbcr_to_rgb_i16_x16(&[i16; 16], &[i16; 16], &[i16; 16], &mut [u8], &mut usize)
 pub fn color::ycbcr_planes_f32_to_rgb_f32(&[f32], &[f32], &[f32], &mut [f32]) [also: color::ycbcr]
 pub fn color::ycbcr_planes_f32_to_rgb_u8(&[f32], &[f32], &[f32], &mut [u8]) [also: color::ycbcr]
-pub fn color::ycbcr_planes_i16_to_rgb_u8(&[i16], &[i16], &[i16], &mut [u8]) [also: color::ycbcr]
-pub fn color::ycbcr_planes_i16_to_xrgba_u8(&[i16], &[i16], &[i16], &mut [u8], bool) [also: color::ycbcr]
+pub fn color::ycbcr_planes_i16_to_rgb_u8(&[i16], &[i16], &[i16], &mut [u8], bool) [also: color::ycbcr]
+pub fn color::ycbcr_planes_i16_to_xrgba_u8(&[i16], &[i16], &[i16], &mut [u8], bool, bool) [also: color::ycbcr]
 pub fn color::ycbcr_to_rgb(u8, u8, u8) -> (u8, u8, u8) [also: color::ycbcr]
 pub fn color::ycbcr_to_rgb_f32(f32, f32, f32) -> (f32, f32, f32) [also: color::ycbcr]
 pub fn color::ycck_planes_to_cmyk_u8(&[f32], &[f32], &[f32], &[f32], &mut [u8]) [also: color::ycbcr]
@@ -555,6 +555,8 @@ pub fn decode::idct_int::idct_int_avx2_raw(archmage::tokens::generated::x86::X64
 pub fn decode::idct_int::idct_int_dc_only(i32, &mut [i16], usize)
 pub fn decode::idct_int::idct_int_dc_only_unclamped(i32, &mut [i16], usize)
 pub fn decode::idct_int::idct_int_libjpeg(&mut [i32; 64], &mut [i16], usize)
+pub fn decode::idct_int::idct_int_libjpeg_auto(&mut [i32; 64], &mut [i16], usize)
+pub fn decode::idct_int::idct_int_libjpeg_auto_unclamped(&mut [i32; 64], &mut [i16], usize)
 pub fn decode::idct_int::idct_int_libjpeg_unclamped(&mut [i32; 64], &mut [i16], usize)
 pub fn decode::idct_int::idct_int_tiered(&mut [i32; 64], &mut [i16], usize, u8)
 pub fn decode::idct_int::idct_int_tiered_libjpeg(&mut [i32; 64], &mut [i16], usize, u8)
@@ -562,18 +564,27 @@ pub fn decode::idct_int::idct_int_tiered_libjpeg_unclamped(&mut [i32; 64], &mut 
 pub fn decode::idct_int::idct_int_tiered_unclamped(&mut [i32; 64], &mut [i16], usize, u8)
 pub fn decode::idct_int::is_dc_only_int(&[i32; 64]) -> bool
 pub fn decode::idct_int::pixels_i16_to_f32_centered(&[i16; 64]) -> [f32; 64]
+pub fn decode::upsample::H2v2Bias::assert_fields_are_eq(&self)
+pub fn decode::upsample::H2v2Bias::clone(&self) -> decode::upsample::H2v2Bias
+pub fn decode::upsample::H2v2Bias::eq(&self, &decode::upsample::H2v2Bias) -> bool
+pub fn decode::upsample::H2v2Bias::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub fn decode::upsample::upsample_h1v2_i16_libjpeg(&[i16], usize, usize, &mut [i16], usize, usize)
 pub fn decode::upsample::upsample_h1v2_i16_libjpeg_strided(&[i16], usize, usize, usize, &mut [i16], usize, usize, usize)
 pub fn decode::upsample::upsample_h1v2_i16_nearest(&[i16], usize, usize, &mut [i16], usize, usize)
 pub fn decode::upsample::upsample_h1v2_i16_nearest_strided(&[i16], usize, usize, usize, &mut [i16], usize, usize, usize)
 pub fn decode::upsample::upsample_h2v1_i16_libjpeg(&[i16], usize, usize, &mut [i16], usize, usize)
 pub fn decode::upsample::upsample_h2v1_i16_libjpeg_strided(&[i16], usize, usize, usize, &mut [i16], usize, usize, usize)
+pub fn decode::upsample::upsample_h2v1_i16_libjpeg_strided_scalar(&[i16], usize, usize, usize, &mut [i16], usize, usize, usize)
 pub fn decode::upsample::upsample_h2v1_i16_nearest(&[i16], usize, usize, &mut [i16], usize, usize)
 pub fn decode::upsample::upsample_h2v1_i16_nearest_strided(&[i16], usize, usize, usize, &mut [i16], usize, usize, usize)
 pub fn decode::upsample::upsample_h2v2_i16_libjpeg(&[i16], usize, usize, &mut [i16], usize, usize)
 pub fn decode::upsample::upsample_h2v2_i16_libjpeg_strided(&[i16], usize, usize, usize, &mut [i16], usize, usize, usize)
+pub fn decode::upsample::upsample_h2v2_i16_libjpeg_strided_turbo(&[i16], usize, usize, usize, &mut [i16], usize, usize, usize)
+pub fn decode::upsample::upsample_h2v2_i16_libjpeg_turbo(&[i16], usize, usize, &mut [i16], usize, usize)
 pub fn decode::upsample::upsample_h2v2_i16_nearest(&[i16], usize, usize, &mut [i16], usize, usize)
 pub fn decode::upsample::upsample_h2v2_i16_nearest_strided(&[i16], usize, usize, usize, &mut [i16], usize, usize, usize)
+pub fn decode::upsample::upsample_h2v2_libjpeg_row(&[i16], &[i16], &mut [i16], usize, usize, decode::upsample::H2v2Bias)
+pub fn decode::upsample::upsample_h2v2_libjpeg_row_scalar(&[i16], &[i16], &mut [i16], usize, usize, decode::upsample::H2v2Bias)
 pub fn decode::upsample::upsample_libjpeg_f32(&[f32], usize, usize, usize, usize, usize, usize) -> alloc::vec::Vec<f32>
 pub fn decode::upsample::upsample_nearest_f32(&[f32], usize, usize, &mut [f32], usize, usize, usize, usize)
 pub fn decoder::ChromaUpsampling::assert_fields_are_eq(&self)
@@ -2435,6 +2446,9 @@ pub decode::UltraHdrReaderConfig::display_boost: f32
 pub decode::UltraHdrReaderConfig::memory_strategy: ultrahdr::GainMapMemory
 pub decode::UltraHdrReaderConfig::mode: ultrahdr::UltraHdrMode
 pub decode::UltraHdrReaderConfig::preserve_metadata: bool
+pub decode::upsample::H2v2Bias::Alternating
+pub decode::upsample::H2v2Bias::Alternating::is_upper: bool
+pub decode::upsample::H2v2Bias::Turbo
 pub decoder::AdobeInfo::color_transform: encode::extras::AdobeColorTransform
 pub decoder::DecodeConfig::correct_color: core::option::Option<color::icc::TargetColorSpace>
 pub decoder::DecodeConfig::output_format: core::option::Option<types::PixelFormat>
@@ -2443,6 +2457,7 @@ pub decoder::DecodeResult::format: types::PixelFormat
 pub decoder::DecodedCoefficients::components: alloc::vec::Vec<decode::ComponentCoefficients>
 pub decoder::DecodedImage::format: types::PixelFormat
 pub decoder::DecodedImageF32::format: types::PixelFormat
+pub decoder::ErrorKind::UnsupportedPixelFormat::format: types::PixelFormat
 pub decoder::JfifInfo::density_units: encode::extras::DensityUnits
 pub decoder::JpegInfo::color_space: types::ColorSpace
 pub decoder::JpegInfo::dimensions: types::Dimensions
@@ -3098,6 +3113,7 @@ pub encoder::EncodePlan::scan_mode: encode::encoder_types::ProgressiveScanMode
 pub encoder::EncodePlan::sof: encode::plan::SofMarker
 pub encoder::EncodePlan::table_family: encode::encoder_types::QuantTableConfig
 pub encoder::EncodePlan::trellis: core::option::Option<encode::trellis::compat::TrellisConfig>
+pub encoder::ErrorKind::UnsupportedPixelFormat::format: types::PixelFormat
 pub encoder::Exif::Fields(encode::exif::ExifFields)
 pub encoder::ExpertConfig::downsampling_method: encode::encoder_types::DownsamplingMethod
 pub encoder::ExpertConfig::quality: encode::encoder_types::Quality
@@ -3384,7 +3400,7 @@ pub types::Subsampling::S422
 pub types::Subsampling::S440
 pub types::Subsampling::S444
 
-## trait impls (196 types)
+## trait impls (197 types)
 
 CmykHandling: TrivialClone
 alloc::vec::Vec<T>: From<foundation::instrumented_vec::InstrumentedVec<T>>
@@ -3405,6 +3421,7 @@ decode::JbrdScanInfo: Clone, Debug, Default
 decode::OrientationHint: Clone, Copy, Debug, Default, Eq, Hash, PartialEq, TrivialClone
 decode::OwnedDecodedPixels: Clone, Debug
 decode::ParallelStrategy: Clone, Copy, Debug, Default, Eq, PartialEq, TrivialClone
+decode::upsample::H2v2Bias: Clone, Copy, Debug, Eq, PartialEq, TrivialClone
 decoder::ChromaUpsampling: TrivialClone
 decoder::CropRegion: TrivialClone
 decoder::DeblockMode: TrivialClone

--- a/docs/public-api/zenjpeg.txt
+++ b/docs/public-api/zenjpeg.txt
@@ -6,21 +6,21 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zenjpeg.txt 1504 lines (supported surface) | zenjpeg.features.txt 427 added (features: boundary-rd,cms,decoder,layout,moxcms,parallel,recompress,recompress-expert,recompress-iqa,target-zq,trellis,ultrahdr,web-sys,zencodec) | zenjpeg.internal.txt 3539 lines (828 hidden + 7219 excluded-feature)
+# files: zenjpeg.txt 1628 lines (supported surface) | zenjpeg.features.txt 427 added (features: boundary-rd,cms,decoder,layout,moxcms,parallel,recompress,recompress-expert,recompress-iqa,target-zq,trellis,ultrahdr,web-sys,zencodec) | zenjpeg.internal.txt 3556 lines (848 hidden + 7222 excluded-feature)
 
 ## summary
 #
 #   pub modules                                17
-#   pub types (struct/enum/trait/alias)       141
+#   pub types (struct/enum/trait/alias)       143
 #   pub consts/statics                         94
 #   pub macros                                  2
 #   free functions                             59
-#   inherent methods                          490
-#   struct fields                             294
-#   enum variants                             329
+#   inherent methods                          494
+#   struct fields                             360
+#   enum variants                             381
 #   re-exports                                  2
-#   trait roster entries (type × trait)       471
-#   auto-trait-complete types                 102
+#   trait roster entries (type × trait)       477
+#   auto-trait-complete types                 103
 #   auto-trait exceptions                      13
 #
 # per-module pub lines:
@@ -28,14 +28,14 @@
 #   blur                              1
 #   container                       276
 #   deblock                          16
-#   decoder                         487
+#   decoder                         547
 #   detect                           56
-#   encoder                         453
+#   encoder                         517
 #   heuristics                       23
 #   lossless                         42
 #   profile                           7
 
-## items (1373 lines)
+## items (1496 lines)
 
 pub mod zenjpeg
 pub mod blur
@@ -358,6 +358,68 @@ pub enum decoder::DepthSource
 pub decoder::DepthSource::DynamicDepth
 pub decoder::DepthSource::GDepthXmp
 pub decoder::DepthSource::MpfDisparity
+#[non_exhaustive] pub enum decoder::ErrorKind [also: encoder]
+pub decoder::ErrorKind::AllocationFailed
+pub decoder::ErrorKind::AllocationFailed::bytes: usize
+pub decoder::ErrorKind::AllocationFailed::context: &'static str
+pub decoder::ErrorKind::Cancelled
+pub decoder::ErrorKind::DecodeError(alloc::string::String)
+pub decoder::ErrorKind::IccError(alloc::string::String)
+pub decoder::ErrorKind::ImageTooLarge
+pub decoder::ErrorKind::ImageTooLarge::limit: u64
+pub decoder::ErrorKind::ImageTooLarge::pixels: u64
+pub decoder::ErrorKind::IncompleteImage
+pub decoder::ErrorKind::IncompleteImage::height: u32
+pub decoder::ErrorKind::IncompleteImage::pushed: u32
+pub decoder::ErrorKind::InternalError
+pub decoder::ErrorKind::InternalError::reason: &'static str
+pub decoder::ErrorKind::InvalidBufferSize
+pub decoder::ErrorKind::InvalidBufferSize::actual: usize
+pub decoder::ErrorKind::InvalidBufferSize::expected: usize
+pub decoder::ErrorKind::InvalidColorFormat
+pub decoder::ErrorKind::InvalidColorFormat::reason: &'static str
+pub decoder::ErrorKind::InvalidConfig(alloc::string::String)
+pub decoder::ErrorKind::InvalidDimensions
+pub decoder::ErrorKind::InvalidDimensions::height: u32
+pub decoder::ErrorKind::InvalidDimensions::reason: &'static str
+pub decoder::ErrorKind::InvalidDimensions::width: u32
+pub decoder::ErrorKind::InvalidHuffmanTable
+pub decoder::ErrorKind::InvalidHuffmanTable::reason: &'static str
+pub decoder::ErrorKind::InvalidHuffmanTable::table_idx: u8
+pub decoder::ErrorKind::InvalidJpegData
+pub decoder::ErrorKind::InvalidJpegData::reason: &'static str
+pub decoder::ErrorKind::InvalidMarker
+pub decoder::ErrorKind::InvalidMarker::context: &'static str
+pub decoder::ErrorKind::InvalidMarker::marker: u8
+pub decoder::ErrorKind::InvalidQuality
+pub decoder::ErrorKind::InvalidQuality::valid_range: &'static str
+pub decoder::ErrorKind::InvalidQuality::value: f32
+pub decoder::ErrorKind::InvalidQuantTable
+pub decoder::ErrorKind::InvalidQuantTable::reason: &'static str
+pub decoder::ErrorKind::InvalidQuantTable::table_idx: u8
+pub decoder::ErrorKind::InvalidScanScript(alloc::string::String)
+pub decoder::ErrorKind::IoError
+pub decoder::ErrorKind::IoError::reason: alloc::string::String
+pub decoder::ErrorKind::SizeOverflow
+pub decoder::ErrorKind::SizeOverflow::context: &'static str
+pub decoder::ErrorKind::StrideTooSmall
+pub decoder::ErrorKind::StrideTooSmall::stride: usize
+pub decoder::ErrorKind::StrideTooSmall::width: u32
+pub decoder::ErrorKind::TooManyRows
+pub decoder::ErrorKind::TooManyRows::height: u32
+pub decoder::ErrorKind::TooManyRows::pushed: u32
+pub decoder::ErrorKind::TooManyScans
+pub decoder::ErrorKind::TooManyScans::count: usize
+pub decoder::ErrorKind::TooManyScans::limit: usize
+pub decoder::ErrorKind::TruncatedData
+pub decoder::ErrorKind::TruncatedData::context: &'static str
+pub decoder::ErrorKind::UnsupportedFeature
+pub decoder::ErrorKind::UnsupportedFeature::feature: &'static str
+pub decoder::ErrorKind::UnsupportedOperation(zencodec::capabilities::UnsupportedOperation)
+pub decoder::ErrorKind::UnsupportedPixelFormat
+pub decoder::ErrorKind::UnsupportedPixelFormat::format: decoder::PixelFormat
+pub fn encoder::ErrorKind::as_argument_error(&self) -> core::option::Option<error::ArgumentError>
+pub fn encoder::ErrorKind::as_resource_error(&self) -> core::option::Option<error::ResourceError>
 pub enum decoder::GDepthFormat
 pub decoder::GDepthFormat::RangeInverse
 pub decoder::GDepthFormat::RangeLinear
@@ -670,7 +732,7 @@ pub const fn decoder::Dimensions::height_in_blocks(self) -> u32
 pub const fn decoder::Dimensions::new(u32, u32) -> Self
 pub const fn decoder::Dimensions::num_pixels(self) -> u64
 pub const fn decoder::Dimensions::width_in_blocks(self) -> u32
-pub struct decoder::Error(pub whereat::at::At<error::ErrorKind>) [also: encoder]
+pub struct decoder::Error(pub whereat::at::At<encoder::ErrorKind>) [also: encoder]
 pub fn encoder::Error::allocation_failed(usize, &'static str) -> Self
 pub fn encoder::Error::at(self) -> Self
 pub fn encoder::Error::cancelled() -> Self
@@ -678,10 +740,10 @@ pub fn encoder::Error::decode_error(alloc::string::String) -> Self
 pub fn encoder::Error::icc_error(alloc::string::String) -> Self
 pub fn encoder::Error::image_too_large(u64, u64) -> Self
 pub fn encoder::Error::incomplete_image(u32, u32) -> Self
-pub fn encoder::Error::inner(&self) -> &whereat::at::At<error::ErrorKind>
+pub fn encoder::Error::inner(&self) -> &whereat::at::At<encoder::ErrorKind>
 pub fn encoder::Error::internal(&'static str) -> Self
-pub fn encoder::Error::into_inner(self) -> whereat::at::At<error::ErrorKind>
-pub fn encoder::Error::into_kind(self) -> error::ErrorKind
+pub fn encoder::Error::into_inner(self) -> whereat::at::At<encoder::ErrorKind>
+pub fn encoder::Error::into_kind(self) -> encoder::ErrorKind
 pub fn encoder::Error::invalid_buffer_size(usize, usize) -> Self
 pub fn encoder::Error::invalid_color_format(&'static str) -> Self
 pub fn encoder::Error::invalid_config(alloc::string::String) -> Self
@@ -693,9 +755,9 @@ pub fn encoder::Error::invalid_quality(f32, &'static str) -> Self
 pub fn encoder::Error::invalid_quant_table(u8, &'static str) -> Self
 pub fn encoder::Error::invalid_scan_script(alloc::string::String) -> Self
 pub fn encoder::Error::io_error(alloc::string::String) -> Self
-pub fn encoder::Error::kind(&self) -> &error::ErrorKind
-pub fn encoder::Error::new(error::ErrorKind) -> Self
-pub const fn encoder::Error::new_untraced(error::ErrorKind) -> Self [also: (root)]
+pub fn encoder::Error::kind(&self) -> &encoder::ErrorKind
+pub fn encoder::Error::new(encoder::ErrorKind) -> Self
+pub const fn encoder::Error::new_untraced(encoder::ErrorKind) -> Self [also: (root)]
 pub fn encoder::Error::size_overflow(&'static str) -> Self
 pub fn encoder::Error::stride_too_small(u32, usize) -> Self
 pub fn encoder::Error::too_many_rows(u32, u32) -> Self
@@ -926,6 +988,67 @@ pub encoder::DownsamplingMethod::Box
 pub encoder::DownsamplingMethod::GammaAware
 pub encoder::DownsamplingMethod::GammaAwareIterative
 pub const fn encoder::DownsamplingMethod::uses_gamma_aware(self) -> bool
+pub encoder::ErrorKind::AllocationFailed
+pub encoder::ErrorKind::AllocationFailed::bytes: usize
+pub encoder::ErrorKind::AllocationFailed::context: &'static str
+pub encoder::ErrorKind::Cancelled
+pub encoder::ErrorKind::DecodeError(alloc::string::String)
+pub encoder::ErrorKind::IccError(alloc::string::String)
+pub encoder::ErrorKind::ImageTooLarge
+pub encoder::ErrorKind::ImageTooLarge::limit: u64
+pub encoder::ErrorKind::ImageTooLarge::pixels: u64
+pub encoder::ErrorKind::IncompleteImage
+pub encoder::ErrorKind::IncompleteImage::height: u32
+pub encoder::ErrorKind::IncompleteImage::pushed: u32
+pub encoder::ErrorKind::InternalError
+pub encoder::ErrorKind::InternalError::reason: &'static str
+pub encoder::ErrorKind::InvalidBufferSize
+pub encoder::ErrorKind::InvalidBufferSize::actual: usize
+pub encoder::ErrorKind::InvalidBufferSize::expected: usize
+pub encoder::ErrorKind::InvalidColorFormat
+pub encoder::ErrorKind::InvalidColorFormat::reason: &'static str
+pub encoder::ErrorKind::InvalidConfig(alloc::string::String)
+pub encoder::ErrorKind::InvalidDimensions
+pub encoder::ErrorKind::InvalidDimensions::height: u32
+pub encoder::ErrorKind::InvalidDimensions::reason: &'static str
+pub encoder::ErrorKind::InvalidDimensions::width: u32
+pub encoder::ErrorKind::InvalidHuffmanTable
+pub encoder::ErrorKind::InvalidHuffmanTable::reason: &'static str
+pub encoder::ErrorKind::InvalidHuffmanTable::table_idx: u8
+pub encoder::ErrorKind::InvalidJpegData
+pub encoder::ErrorKind::InvalidJpegData::reason: &'static str
+pub encoder::ErrorKind::InvalidMarker
+pub encoder::ErrorKind::InvalidMarker::context: &'static str
+pub encoder::ErrorKind::InvalidMarker::marker: u8
+pub encoder::ErrorKind::InvalidQuality
+pub encoder::ErrorKind::InvalidQuality::valid_range: &'static str
+pub encoder::ErrorKind::InvalidQuality::value: f32
+pub encoder::ErrorKind::InvalidQuantTable
+pub encoder::ErrorKind::InvalidQuantTable::reason: &'static str
+pub encoder::ErrorKind::InvalidQuantTable::table_idx: u8
+pub encoder::ErrorKind::InvalidScanScript(alloc::string::String)
+pub encoder::ErrorKind::IoError
+pub encoder::ErrorKind::IoError::reason: alloc::string::String
+pub encoder::ErrorKind::SizeOverflow
+pub encoder::ErrorKind::SizeOverflow::context: &'static str
+pub encoder::ErrorKind::StrideTooSmall
+pub encoder::ErrorKind::StrideTooSmall::stride: usize
+pub encoder::ErrorKind::StrideTooSmall::width: u32
+pub encoder::ErrorKind::TooManyRows
+pub encoder::ErrorKind::TooManyRows::height: u32
+pub encoder::ErrorKind::TooManyRows::pushed: u32
+pub encoder::ErrorKind::TooManyScans
+pub encoder::ErrorKind::TooManyScans::count: usize
+pub encoder::ErrorKind::TooManyScans::limit: usize
+pub encoder::ErrorKind::TruncatedData
+pub encoder::ErrorKind::TruncatedData::context: &'static str
+pub encoder::ErrorKind::UnsupportedFeature
+pub encoder::ErrorKind::UnsupportedFeature::feature: &'static str
+pub encoder::ErrorKind::UnsupportedOperation(zencodec::capabilities::UnsupportedOperation)
+pub encoder::ErrorKind::UnsupportedPixelFormat
+pub encoder::ErrorKind::UnsupportedPixelFormat::format: decoder::PixelFormat
+pub fn encoder::ErrorKind::as_argument_error(&self) -> core::option::Option<error::ArgumentError>
+pub fn encoder::ErrorKind::as_resource_error(&self) -> core::option::Option<error::ResourceError>
 pub enum encoder::Exif
 pub encoder::Exif::Fields(encoder::ExifFields)
 pub encoder::Exif::Raw(alloc::vec::Vec<u8>)
@@ -1192,10 +1315,10 @@ pub fn encoder::Error::decode_error(alloc::string::String) -> Self
 pub fn encoder::Error::icc_error(alloc::string::String) -> Self
 pub fn encoder::Error::image_too_large(u64, u64) -> Self
 pub fn encoder::Error::incomplete_image(u32, u32) -> Self
-pub fn encoder::Error::inner(&self) -> &whereat::at::At<error::ErrorKind>
+pub fn encoder::Error::inner(&self) -> &whereat::at::At<encoder::ErrorKind>
 pub fn encoder::Error::internal(&'static str) -> Self
-pub fn encoder::Error::into_inner(self) -> whereat::at::At<error::ErrorKind>
-pub fn encoder::Error::into_kind(self) -> error::ErrorKind
+pub fn encoder::Error::into_inner(self) -> whereat::at::At<encoder::ErrorKind>
+pub fn encoder::Error::into_kind(self) -> encoder::ErrorKind
 pub fn encoder::Error::invalid_buffer_size(usize, usize) -> Self
 pub fn encoder::Error::invalid_color_format(&'static str) -> Self
 pub fn encoder::Error::invalid_config(alloc::string::String) -> Self
@@ -1207,8 +1330,8 @@ pub fn encoder::Error::invalid_quality(f32, &'static str) -> Self
 pub fn encoder::Error::invalid_quant_table(u8, &'static str) -> Self
 pub fn encoder::Error::invalid_scan_script(alloc::string::String) -> Self
 pub fn encoder::Error::io_error(alloc::string::String) -> Self
-pub fn encoder::Error::kind(&self) -> &error::ErrorKind
-pub fn encoder::Error::new(error::ErrorKind) -> Self
+pub fn encoder::Error::kind(&self) -> &encoder::ErrorKind
+pub fn encoder::Error::new(encoder::ErrorKind) -> Self
 pub fn encoder::Error::size_overflow(&'static str) -> Self
 pub fn encoder::Error::stride_too_small(u32, usize) -> Self
 pub fn encoder::Error::too_many_rows(u32, u32) -> Self
@@ -1411,7 +1534,7 @@ pub fn profile::ProfileStats::reset()
 pub macro profile_block!
 pub macro profile_scope!
 
-## trait impls (117 types)
+## trait impls (118 types)
 
 container::marker::MarkerIter<'a>: Iterator
 container::marker::MarkerKind: Clone, Copy, Debug, Eq, PartialEq
@@ -1487,7 +1610,8 @@ encoder::DownsamplingMethod: Clone, Copy, Debug, Default, Eq, PartialEq
 encoder::EncodePlan: Clone, Debug, Display
 encoder::EncodeStats: Clone, Debug, Default
 encoder::EncoderConfig: Clone, Debug
-encoder::Error: Debug, Display, Error, From<enough::reason::StopReason>, From<std::io::error::Error>, From<whereat::at::At<error::ErrorKind>>, From<zencodec::capabilities::UnsupportedOperation>, From<zencodec::limits::LimitExceeded>, PartialEq
+encoder::Error: Debug, Display, Error, From<encoder::ErrorKind>, From<enough::reason::StopReason>, From<std::io::error::Error>, From<whereat::at::At<encoder::ErrorKind>>, From<zencodec::capabilities::UnsupportedOperation>, From<zencodec::limits::LimitExceeded>, PartialEq
+encoder::ErrorKind: Clone, Debug, Display, Error, PartialEq
 encoder::Exif: Clone, Debug, From<encoder::ExifFields>
 encoder::ExifFields: Clone, Debug, Default
 encoder::ExpertConfig: Clone, Debug
@@ -1529,11 +1653,11 @@ rgb::formats::rgb::Rgb<u8>: encoder::Pixel
 rgb::formats::rgba::Rgba<f32>: encoder::Pixel
 rgb::formats::rgba::Rgba<u16>: encoder::Pixel
 rgb::formats::rgba::Rgba<u8>: encoder::Pixel
-whereat::at::At<error::ErrorKind>: From<encoder::Error>
+whereat::at::At<encoder::ErrorKind>: From<encoder::Error>
 
 ## auto traits
 
-102 types implement all of: Freeze, RefUnwindSafe, Send, Sync, Unpin, UnwindSafe
+103 types implement all of: Freeze, RefUnwindSafe, Send, Sync, Unpin, UnwindSafe
 decoder::DecodeConfig: !RefUnwindSafe !UnwindSafe
 decoder::DecodeInfo: !Freeze
 decoder::DecodePool: !Freeze

--- a/zenjpeg/src/decoder/mod.rs
+++ b/zenjpeg/src/decoder/mod.rs
@@ -58,6 +58,11 @@
 pub type DecodeError = crate::error::Error;
 // Keep legacy aliases for backward compatibility
 pub use crate::error::{Error, Result};
+// `ErrorKind` is the inner kind returned by [`Error::kind()`]. Re-exported here
+// so downstream callers (e.g. servers classifying decode failures into
+// 400/413/500) can name and `match` the variants. `#[non_exhaustive]`, so
+// adding variants later stays non-breaking.
+pub use crate::error::ErrorKind;
 
 // === Main decoder types ===
 pub use crate::decode::{

--- a/zenjpeg/src/encoder/mod.rs
+++ b/zenjpeg/src/encoder/mod.rs
@@ -143,6 +143,10 @@ pub type EncodeError = crate::error::Error;
 pub type EncodeResult<T> = core::result::Result<T, EncodeError>;
 // Keep legacy aliases for backward compatibility
 pub use crate::error::{Error, Result};
+// `ErrorKind` is the inner kind returned by [`Error::kind()`] — re-exported so
+// callers can name and `match` the variants. `#[non_exhaustive]`, so adding
+// variants later stays non-breaking.
+pub use crate::error::ErrorKind;
 
 // === Main encoder types (from encode root modules) ===
 pub use crate::encode::Stop;

--- a/zenjpeg/src/lib.rs
+++ b/zenjpeg/src/lib.rs
@@ -103,11 +103,47 @@
 //! The decoder is in prerelease (always compiled; the API will have
 //! breaking changes).
 //!
-//! ```rust,ignore
-//! use zenjpeg::decoder::{Decoder, DecodedImage};
+//! ```rust
+//! use zenjpeg::decoder::Decoder;
+//! use zenjpeg::encoder::{ChromaSubsampling, EncoderConfig, PixelLayout, Unstoppable};
 //!
-//! let image = Decoder::new().decode(&jpeg_data)?;
-//! let pixels: &[u8] = image.pixels();
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! // (Make a tiny JPEG to decode.)
+//! let pixels = [128u8; 16 * 16 * 3];
+//! let mut enc = EncoderConfig::ycbcr(80.0, ChromaSubsampling::Quarter)
+//!     .encode_from_bytes(16, 16, PixelLayout::Rgb8Srgb)?;
+//! enc.push_packed(&pixels, Unstoppable)?;
+//! let jpeg_data: Vec<u8> = enc.finish()?;
+//!
+//! // Decode with DoS limits + a stop token. `Unstoppable` never cancels;
+//! // pass any `&impl zenjpeg::encoder::Stop` for user-initiated cancellation.
+//! let decoded = Decoder::new()
+//!     .max_pixels(120_000_000) // reject decompression bombs
+//!     .decode(&jpeg_data, Unstoppable)?;
+//!
+//! let (width, height) = decoded.dimensions();
+//! let rgb: &[u8] = decoded.pixels_u8().expect("u8 output (default OutputTarget::Srgb8)");
+//! assert_eq!((width, height), (16, 16));
+//! assert_eq!(rgb.len(), 16 * 16 * 3);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Decode failures carry a [`decoder::ErrorKind`] you can `match` to classify
+//! them (e.g. for HTTP status mapping in a server):
+//!
+//! ```rust
+//! use zenjpeg::decoder::{Decoder, ErrorKind};
+//! use zenjpeg::encoder::Unstoppable;
+//!
+//! let not_a_jpeg = [0u8; 8];
+//! if let Err(e) = Decoder::new().decode(&not_a_jpeg, Unstoppable) {
+//!     match e.kind() {
+//!         ErrorKind::ImageTooLarge { .. } => { /* 413 Payload Too Large */ }
+//!         ErrorKind::AllocationFailed { .. } => { /* 500 Internal Server Error */ }
+//!         _ => { /* 400 Bad Request — corrupt / unsupported input */ }
+//!     }
+//! }
 //! ```
 //!
 //! ## Feature Flags

--- a/zenjpeg/tests/error_kind_public.rs
+++ b/zenjpeg/tests/error_kind_public.rs
@@ -1,0 +1,65 @@
+//! Regression test for #155: a downstream caller can NAME `ErrorKind` variants
+//! to classify decode errors.
+//!
+//! This deliberately uses ONLY the public re-export path
+//! (`zenjpeg::decoder::ErrorKind`) — the same surface a server crate sees —
+//! so that demoting the re-export back to `pub(crate)` would fail to compile.
+
+use zenjpeg::decoder::{Decoder, ErrorKind};
+use zenjpeg::encoder::Unstoppable;
+
+/// `Error::kind()` returns a `&ErrorKind` whose variants can be matched by name.
+#[test]
+fn error_kind_variants_are_nameable_and_matchable() {
+    // Garbage input — not a JPEG — produces a datastream error.
+    let not_a_jpeg = [0u8; 16];
+    let err = Decoder::new()
+        .decode(&not_a_jpeg, Unstoppable)
+        .expect_err("decoding non-JPEG bytes must fail");
+
+    // The whole point of #155: a downstream can `match` on named variants to
+    // map errors onto e.g. HTTP status codes, instead of substring-matching
+    // `to_string()`. Match against several named variants.
+    let classified = match err.kind() {
+        ErrorKind::ImageTooLarge { .. } => "413",
+        ErrorKind::AllocationFailed { .. } => "500",
+        ErrorKind::InvalidJpegData { .. }
+        | ErrorKind::InvalidMarker { .. }
+        | ErrorKind::TruncatedData { .. }
+        | ErrorKind::InvalidBufferSize { .. } => "400",
+        // `ErrorKind` is `#[non_exhaustive]`; downstream code must keep a
+        // catch-all. This arm proves the type is genuinely non-exhaustive
+        // from outside the crate.
+        _ => "400",
+    };
+
+    assert_eq!(
+        classified, "400",
+        "garbage input should classify as a 400-class error"
+    );
+}
+
+/// A decompression-bomb rejection produces a nameable `ImageTooLarge` kind.
+#[test]
+fn max_pixels_limit_is_classifiable() {
+    use zenjpeg::encoder::{ChromaSubsampling, EncoderConfig, PixelLayout};
+
+    // Encode a small image, then decode it with an impossibly low pixel cap.
+    let pixels = [200u8; 32 * 32 * 3];
+    let mut enc = EncoderConfig::ycbcr(80.0, ChromaSubsampling::Quarter)
+        .encode_from_bytes(32, 32, PixelLayout::Rgb8Srgb)
+        .expect("config builds");
+    enc.push_packed(&pixels, Unstoppable).expect("push rows");
+    let jpeg = enc.finish().expect("encode");
+
+    let err = Decoder::new()
+        .max_pixels(16) // 32x32 = 1024 px > 16
+        .decode(&jpeg, Unstoppable)
+        .expect_err("decode must reject input over the pixel cap");
+
+    assert!(
+        matches!(err.kind(), ErrorKind::ImageTooLarge { .. }),
+        "over-cap decode should be ImageTooLarge, got: {:?}",
+        err.kind()
+    );
+}


### PR DESCRIPTION
Closes #155.

## Problem

The public decode/encode error is `Error(pub At<ErrorKind>)` with `.kind() -> &ErrorKind`, but `ErrorKind` lived in the `pub(crate) mod error` and was re-exported through **zero** public paths. So a server could call `err.kind()` yet **could not name any `ErrorKind` variant** to `match` on it — classifying "image too large (413) vs corrupt (400) vs OOM (500)" collapsed to `err.to_string().contains("too large")` substring matching.

## Changes (all additive, non-breaking)

**1. `ErrorKind` is now nameable.** Re-exported as `zenjpeg::decoder::ErrorKind` and `zenjpeg::encoder::ErrorKind` (the same `crate::error::ErrorKind` backs both `DecodeError` and `EncodeError`). It was already `pub` *inside* the `pub(crate)` module and is `#[non_exhaustive]`, so this is purely the missing re-export and future variants stay non-breaking. **No version bump needed** — exposing a type is additive (would be a patch/minor, not a leftmost-digit break).

**2. New `tests/error_kind_public.rs`** matches `.kind()` against named variants **through the public path** (so demoting the re-export back to `pub(crate)` would fail to compile — a regression guard for #155). Covers garbage-input classification and `ImageTooLarge` from a `max_pixels` cap. Both tests pass.

**3. Crate-root rustdoc decoder example now compiles and runs** (#155 item 2). The top-of-page `lib.rs` snippet was a `rust,ignore` block showing a stale 1-arg `Decoder::new().decode(&jpeg_data)?` + `image.pixels() -> &[u8]`. The real API is `.decode(data, stop)` → `DecodeResult`, bytes via `.pixels_u8()`. Replaced with a real, compiling round-trip doctest, plus a second doctest demonstrating `match err.kind() { ErrorKind::… }` for HTTP-status classification.

**4. Regenerated `docs/public-api/` snapshots** (`ErrorKind` now appears under `decoder`/`encoder`; only additive lines + summary counters changed, nothing removed).

**5. CHANGELOG** Added/Fixed entries.

## Out of scope

The dead, never-`mod`-ed-in `decoder/error.rs` + `encoder/error.rs` (the hierarchical `Error { kind, trace }` / `ErrorKind` the issue notes is unreachable) were left untouched — wiring them in or deleting them is a separate cleanup, not this additive fix.

## Verification

Scoped to zenjpeg (zenjpeg's full suite is huge), via `run-heavy` (no `target-cpu=native`):
- `cargo build -p zenjpeg --lib` — green
- `cargo test -p zenjpeg --doc` — green, 15 passed (the two crate-root `lib.rs` doctests now run instead of being ignored)
- `cargo test -p zenjpeg --test error_kind_public` — green, 2 passed
- `cargo clippy -p zenjpeg --lib` — green (no new warnings)
- `cargo fmt -p zenjpeg --check` — clean

Leaving OPEN — new public type, worth a glance.
