### PR TITLE
feat(error): adopt zencodec CategorizedError taxonomy (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to zenjpeg are documented here. Earlier history
 
 ## [Unreleased]
 
+### Changed
+- **zencodec trait impls now return the `At<zencodec::CodecError>` envelope
+  (Pattern B).** The `EncoderConfig` / `EncodeJob` / `Encoder` / `DecoderConfig` /
+  `DecodeJob` / `Decode` / `StreamingDecode` impls in `crate::codec` (and the
+  delegating `JpegEncoderConfig::encode` / `JpegDecoderConfig::{decode,
+  probe_header, probe_full_metadata}` convenience methods) switch their
+  `type Error` from `crate::error::Error` to `At<CodecError>`. This makes the
+  coarse `ErrorCategory` **and** the codec name (`Some("zenjpeg")`) recoverable by
+  a generic consumer *through `Dyn*` dispatch*: once the concrete error is erased
+  to `zencodec::decode::BoxedError`, `CodecErrorExt::error_category()` /
+  `codec_error()` downcast it back to the envelope (under the prior Pattern A
+  `type Error = Error`, the erased `dyn Error` carried no `CategorizedError`
+  vtable, so both returned `None`). The native `crate::error::Error`
+  (`Error(At<ErrorKind>)`) is unchanged and remains the rich error for direct
+  (non-`zencodec`) callers; it is now the envelope's `detail` + category source,
+  bridged by `From<Error>` / `From<ErrorKind> for At<CodecError>`. Builds on the
+  #103 `CategorizedError` adoption below.
+
 ### Docs
 - README overhauled and split into a GitHub `README.md` (full badge row) and a generated badge-free `README.crates.md` for crates.io (the crate `readme` field now points at it); corrected the feature table (the `decoder`/`trellis` flags are documented as always-compiled no-ops), refreshed the crosslink footer, and added `benchmarks/README.md` reproduction methodology.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ All notable changes to zenjpeg are documented here. Earlier history
 - README overhauled and split into a GitHub `README.md` (full badge row) and a generated badge-free `README.crates.md` for crates.io (the crate `readme` field now points at it); corrected the feature table (the `decoder`/`trellis` flags are documented as always-compiled no-ops), refreshed the crosslink footer, and added `benchmarks/README.md` reproduction methodology.
 
 ### Added
+- **`zencodec::CategorizedError` implemented for the public error type** (zencodec
+  #103 taxonomy adoption). `crate::error::Error` and its inner `ErrorKind` — the
+  type behind `zenjpeg::decoder::Error` / `encoder::Error` / `DecodeError` /
+  `EncodeError` and the `zencodec` `EncoderConfig`/`DecoderConfig` adapter's
+  `type Error` — now report `codec_name() -> Some("zenjpeg")` and a **total**
+  `category() -> ErrorCategory` mapping every variant: malformed bitstream →
+  `MalformedImage`, truncation → `UnexpectedEof`, unsupported JPEG feature →
+  `UnsupportedImageFeature`, pixel-format negotiation → `UnsupportedPixelFormat`,
+  caller dials/config → `InvalidParameters`, buffer geometry → `InvalidBuffer`,
+  push/finish sequencing → `InvalidState`, ICC-synthesis failure → `CmsRequired`,
+  pixel-limit → `LimitsExceeded(Pixels)`, alloc / size-overflow → `OutOfMemory`,
+  I/O → `Io`; the `Cancelled(StopReason)` and `UnsupportedOperation` arms delegate
+  to the wrapped zencodec cause types. `recompress::Error` (feature `recompress`)
+  is categorized too. Codec-agnostic consumers can now route zenjpeg failures
+  (HTTP status, retry policy, logging) without naming a zenjpeg type. The match is
+  exhaustive, so a future `ErrorKind` variant must be categorized or the build
+  fails. **TEMP dev patch:** the workspace `Cargo.toml` pins `zencodec` to the
+  `cancellation-classification-99` git branch (PR #103) until `zencodec 0.1.26`
+  ships this API — revert the `[patch.crates-io]` entry and bump the dep at
+  landing.
 - **`AllocPreference` honored per decode allocation site + `estimate_decode_resources`.**
   The zencodec decode boundary now threads
   `ResourceLimits::prefer_fallible_allocations` (a 3-mode `AllocPreference`:
@@ -67,6 +87,14 @@ All notable changes to zenjpeg are documented here. Earlier history
   doctest (encode a tiny image, decode it round-trip) and added a second doctest
   showing `match err.kind() { ErrorKind::… }` for error classification.
 ### Changed
+- **Located public errors: no reshape needed for the #103 guidance.** zenjpeg's
+  encode/decode error is already `Error(pub At<ErrorKind>)` carrying a `whereat`
+  location trace, with crate info registered via `whereat::define_at_crate_info!`
+  and `#[track_caller]` constructors capturing the origin. The `CategorizedError`
+  adoption above is therefore purely additive (classification only) — **not** a
+  breaking error-type or signature change. (The one error type still without a
+  trace is the feature-gated `recompress::Error`, a plain enum; making it located
+  would be a separate, isolated change.)
 - **BREAKING: `ErrorKind::Cancelled` now carries the `enough::StopReason`**
   (`Cancelled(enough::StopReason)`, was a unit variant) (8a03cb65). The wrapped
   reason distinguishes an explicit cancel (`StopReason::Cancelled`) from a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,6 +3166,7 @@ dependencies = [
  "img-parts",
  "imgref",
  "jpeg-decoder",
+ "jpegli-internals-sys",
  "kamadak-exif",
  "linear-srgb",
  "magetypes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,8 +3121,7 @@ dependencies = [
 [[package]]
 name = "zencodec"
 version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9328427935f563e3cc12aaab76ad4afe946d1a60611a74047184682afc20ed"
+source = "git+https://github.com/imazen/zencodec?branch=cancellation-classification-99#2c7fb39840ed03c02423554f8fe621b07055267f"
 dependencies = [
  "almost-enough",
  "enough",
@@ -3167,7 +3166,6 @@ dependencies = [
  "img-parts",
  "imgref",
  "jpeg-decoder",
- "jpegli-internals-sys",
  "kamadak-exif",
  "linear-srgb",
  "magetypes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,3 +206,6 @@ manual_is_multiple_of = "allow"  # Common pattern in ported code
 # ultrahdr-core 0.5.0 on crates.io predates full_reconstruction_boost (the
 # canonical ReconstructHdr boost route, heic#20). Drop on next publish.
 ultrahdr-core = { git = "https://github.com/imazen/ultrahdr", rev = "3ac20f99d45e985e09f274fc07181b238385e703" }
+# TEMP: until zencodec 0.1.26 ships (PR #103 — CategorizedError taxonomy).
+# Drop and bump the workspace dep to the released version at landing time.
+zencodec = { git = "https://github.com/imazen/zencodec", branch = "cancellation-classification-99" }

--- a/zenjpeg/examples/mem_probe_encode.rs
+++ b/zenjpeg/examples/mem_probe_encode.rs
@@ -40,7 +40,9 @@ fn status_kb(field: &str) -> u64 {
 fn main() {
     let a: Vec<String> = std::env::args().collect();
     if a.len() < 7 {
-        eprintln!("usage: mem_probe_encode <rgb8.bin> <w> <h> <444|422|420|gray> <effort 0|1|2> <quality>");
+        eprintln!(
+            "usage: mem_probe_encode <rgb8.bin> <w> <h> <444|422|420|gray> <effort 0|1|2> <quality>"
+        );
         std::process::exit(2);
     }
     let path = &a[1];

--- a/zenjpeg/src/codec.rs
+++ b/zenjpeg/src/codec.rs
@@ -18,24 +18,36 @@
 //! | `DecodeJob<'a>` | [`JpegDecodeJob`] |
 //! | `Decode` | [`JpegDecoder`] |
 //! | `StreamingDecode` | [`JpegStreamingDecoder`] |
-//! | `AnimationFrameDecode` | `Unsupported<Error>` (JPEG has no animation) |
+//! | `AnimationFrameDecode` | `Unsupported<At<CodecError>>` (JPEG has no animation) |
+//!
+//! # Error envelope (Pattern B)
+//!
+//! Every trait impl below uses `type Error = At<zencodec::CodecError>` — the
+//! shared envelope — so a generic consumer recovers the
+//! [`ErrorCategory`](zencodec::ErrorCategory) and codec name even after the
+//! concrete error is erased to `BoxedError` through `Dyn*` dispatch. The native
+//! [`Error`]/[`ErrorKind`] remain the detail + category source, bridged into the
+//! envelope by `From<Error>`/`From<ErrorKind> for At<CodecError>` (see
+//! `crate::error`); `?` and `.into()` carry codec internals across the boundary
+//! unchanged.
 
 extern crate alloc;
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
 
 use rgb::{Gray, Rgb};
+use whereat::At;
 use zencodec::decode::{DecodeCapabilities, DecodeOutput, OutputInfo};
 use zencodec::encode::{EncodeCapabilities, EncodeOutput};
 use zencodec::{
-    ImageFormat, ImageInfo, Metadata, ResourceLimits, Unsupported, UnsupportedOperation,
+    CodecError, ImageFormat, ImageInfo, Metadata, ResourceLimits, Unsupported, UnsupportedOperation,
 };
 use zenpixels::{PixelBuffer, PixelDescriptor, PixelSlice, PixelSliceMut};
 
 use crate::encode::encoder_config::EncoderConfig;
 use crate::encode::encoder_types::{ChromaSubsampling, PixelLayout, Quality};
 use crate::encode::exif::Exif;
-use crate::error::Error;
+use crate::error::{Error, ErrorKind};
 use crate::types::PixelFormat;
 
 // ── Backwards compat aliases ─────────────────────────────────────────────────
@@ -205,7 +217,12 @@ impl JpegEncoderConfig {
     }
 
     /// Convenience: encode pixels with this config via the type-erased path.
-    pub fn encode(&self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, Error> {
+    ///
+    /// Returns the shared [`At<CodecError>`] envelope (the same `type Error` the
+    /// zencodec trait path uses), so the category + codec name survive type
+    /// erasure; recover the native [`Error`] detail via
+    /// [`CodecError::detail`](zencodec::CodecError::detail) when needed.
+    pub fn encode(&self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, At<CodecError>> {
         use zencodec::encode::{EncodeJob as _, Encoder as _, EncoderConfig as _};
         self.clone().job().encoder()?.encode(pixels)
     }
@@ -301,7 +318,7 @@ fn interp_quality(table: &[(f32, f32)], x: f32) -> f32 {
 }
 
 impl zencodec::encode::EncoderConfig for JpegEncoderConfig {
-    type Error = Error;
+    type Error = At<CodecError>;
     type Job = JpegEncodeJob;
 
     fn format() -> ImageFormat {
@@ -464,7 +481,7 @@ pub struct JpegEncodeJob {
 }
 
 impl zencodec::encode::EncodeJob for JpegEncodeJob {
-    type Error = Error;
+    type Error = At<CodecError>;
     type Enc = JpegEncoder;
     type AnimationFrameEnc = ();
 
@@ -524,7 +541,7 @@ impl zencodec::encode::EncodeJob for JpegEncodeJob {
     }
 
     fn animation_frame_encoder(self) -> Result<Self::AnimationFrameEnc, Self::Error> {
-        Err(UnsupportedOperation::AnimationEncode.into())
+        Err(ErrorKind::UnsupportedOperation(UnsupportedOperation::AnimationEncode).into())
     }
 }
 
@@ -750,22 +767,23 @@ impl JpegEncoder {
 }
 
 impl zencodec::encode::Encoder for JpegEncoder {
-    type Error = Error;
+    type Error = At<CodecError>;
 
     fn reject(op: UnsupportedOperation) -> Self::Error {
-        Error::from(op)
+        ErrorKind::UnsupportedOperation(op).into()
     }
 
     fn preferred_strip_height(&self) -> u32 {
         16
     }
 
-    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, Error> {
+    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, Self::Error> {
         let layout = descriptor_to_layout(pixels.descriptor())?;
         let width = pixels.width();
         let height = pixels.rows();
         let data = pixels.contiguous_bytes();
         self.encode_bytes_inner(&data, width, height, layout)
+            .map_err(Into::into)
     }
 
     fn encode_srgba8(
@@ -775,7 +793,7 @@ impl zencodec::encode::Encoder for JpegEncoder {
         width: u32,
         height: u32,
         stride_pixels: u32,
-    ) -> Result<EncodeOutput, Error> {
+    ) -> Result<EncodeOutput, Self::Error> {
         if make_opaque {
             for chunk in data.chunks_exact_mut(4) {
                 chunk[3] = 255;
@@ -793,7 +811,7 @@ impl zencodec::encode::Encoder for JpegEncoder {
         Ok(EncodeOutput::new(output, ImageFormat::Jpeg))
     }
 
-    fn push_rows(&mut self, rows: PixelSlice<'_>) -> Result<(), Error> {
+    fn push_rows(&mut self, rows: PixelSlice<'_>) -> Result<(), Self::Error> {
         let desc = rows.descriptor();
         let layout = descriptor_to_layout(desc)?;
 
@@ -854,7 +872,8 @@ impl zencodec::encode::Encoder for JpegEncoder {
                 if acc.width != width || acc.descriptor != desc {
                     return Err(Error::unsupported_feature(
                         "push_rows: width or format changed between calls",
-                    ));
+                    )
+                    .into());
                 }
                 acc.data.extend_from_slice(&data);
                 acc.total_rows += rows.rows();
@@ -863,7 +882,7 @@ impl zencodec::encode::Encoder for JpegEncoder {
         Ok(())
     }
 
-    fn finish(mut self) -> Result<EncodeOutput, Error> {
+    fn finish(mut self) -> Result<EncodeOutput, Self::Error> {
         // Streaming path: finish the native encoder directly.
         if let Some(enc) = self.streaming_enc.take() {
             let output = enc.finish()?;
@@ -876,13 +895,13 @@ impl zencodec::encode::Encoder for JpegEncoder {
             .accumulator
             .take()
             .ok_or_else(|| Error::unsupported_feature("finish() called without any push_rows()"))?;
-        self.encode_accumulated(acc)
+        self.encode_accumulated(acc).map_err(Into::into)
     }
 
     fn encode_from(
         self,
         source: &mut dyn FnMut(u32, PixelSliceMut<'_>) -> usize,
-    ) -> Result<EncodeOutput, Error> {
+    ) -> Result<EncodeOutput, Self::Error> {
         use zenpixels::PixelSliceMut;
 
         let (img_w, img_h) = self.image_size.ok_or_else(|| {
@@ -1143,19 +1162,22 @@ impl JpegDecoderConfig {
     }
 
     /// Convenience: probe image header with this config.
-    pub fn probe_header(&self, data: &[u8]) -> Result<ImageInfo, Error> {
+    ///
+    /// Returns the shared [`At<CodecError>`] envelope (the zencodec trait path's
+    /// `type Error`) so category + codec name survive type erasure.
+    pub fn probe_header(&self, data: &[u8]) -> Result<ImageInfo, At<CodecError>> {
         use zencodec::decode::{DecodeJob as _, DecoderConfig as _};
         self.clone().job().probe(data)
     }
 
     /// Convenience: probe full image metadata (may be expensive).
-    pub fn probe_full_metadata(&self, data: &[u8]) -> Result<ImageInfo, Error> {
+    pub fn probe_full_metadata(&self, data: &[u8]) -> Result<ImageInfo, At<CodecError>> {
         use zencodec::decode::{DecodeJob as _, DecoderConfig as _};
         self.clone().job().probe_full(data)
     }
 
     /// Convenience: decode image with this config.
-    pub fn decode(&self, data: &[u8]) -> Result<DecodeOutput, Error> {
+    pub fn decode(&self, data: &[u8]) -> Result<DecodeOutput, At<CodecError>> {
         use zencodec::decode::{Decode as _, DecodeJob as _, DecoderConfig as _};
         self.clone()
             .job()
@@ -1184,7 +1206,7 @@ static DECODE_DESCRIPTORS: &[PixelDescriptor] = &[
 ];
 
 impl zencodec::decode::DecoderConfig for JpegDecoderConfig {
-    type Error = Error;
+    type Error = At<CodecError>;
     type Job<'a> = JpegDecodeJob;
 
     fn formats() -> &'static [ImageFormat] {
@@ -1260,10 +1282,10 @@ pub struct JpegDecodeJob {
 }
 
 impl<'a> zencodec::decode::DecodeJob<'a> for JpegDecodeJob {
-    type Error = Error;
+    type Error = At<CodecError>;
     type Dec = JpegDecoder<'a>;
     type StreamDec = JpegStreamingDecoder<'a>;
-    type AnimationFrameDec = Unsupported<Error>;
+    type AnimationFrameDec = Unsupported<At<CodecError>>;
 
     fn with_stop(mut self, stop: zencodec::StopToken) -> Self {
         self.stop = Some(stop);
@@ -1425,7 +1447,7 @@ impl<'a> zencodec::decode::DecodeJob<'a> for JpegDecodeJob {
         _data: Cow<'a, [u8]>,
         _preferred: &[PixelDescriptor],
     ) -> Result<Self::AnimationFrameDec, Self::Error> {
-        Err(UnsupportedOperation::AnimationDecode.into())
+        Err(ErrorKind::UnsupportedOperation(UnsupportedOperation::AnimationDecode).into())
     }
 }
 
@@ -1485,7 +1507,7 @@ fn push_decoder_native<'a>(
     data: Cow<'a, [u8]>,
     sink: &mut dyn zencodec::decode::DecodeRowSink,
     preferred: &[PixelDescriptor],
-) -> Result<OutputInfo, Error> {
+) -> Result<OutputInfo, At<CodecError>> {
     use imgref::ImgRefMut;
     use zenpixels::{ChannelLayout, ChannelType};
 
@@ -1587,9 +1609,11 @@ fn push_decoder_native<'a>(
 
     while !reader.is_finished() {
         // Check cooperative cancellation before decoding each MCU-row strip.
+        // `StopReason` is not a `core::error::Error`, so route it through the
+        // native `Error` (→ `ErrorKind::Cancelled`) before the envelope bridge.
         if let Some(ref stop) = job.stop {
             use enough::Stop;
-            stop.check()?;
+            stop.check().map_err(Error::from)?;
         }
 
         let remaining = height - y as usize;
@@ -1652,7 +1676,8 @@ fn push_decoder_native<'a>(
             _ => {
                 return Err(Error::unsupported_feature(
                     "unsupported pixel format for push_decoder",
-                ));
+                )
+                .into());
             }
         };
 
@@ -1720,7 +1745,7 @@ fn push_decoder_direct<'a>(
     descriptor: PixelDescriptor,
     format: PixelFormat,
     header: &crate::decode::JpegInfo,
-) -> Result<OutputInfo, Error> {
+) -> Result<OutputInfo, At<CodecError>> {
     use enough::Unstoppable;
 
     let wrap = |e: zencodec::decode::SinkError| Error::io_error(e.to_string());
@@ -1887,7 +1912,7 @@ fn push_decoder_via_full_decode<'a>(
     job: JpegDecodeJob,
     data: Cow<'a, [u8]>,
     sink: &mut dyn zencodec::decode::DecodeRowSink,
-) -> Result<OutputInfo, Error> {
+) -> Result<OutputInfo, At<CodecError>> {
     use zencodec::decode::{Decode as _, DecodeJob as _};
 
     let wrap = |e: zencodec::decode::SinkError| Error::io_error(e.to_string());
@@ -1895,10 +1920,8 @@ fn push_decoder_via_full_decode<'a>(
     // Build a decoder from the same config and hand it the data. This path
     // runs the full CMYK-aware decode (Decode::decode below overrides
     // output_format to PixelFormat::Cmyk when cmyk_handling is Passthrough
-    // and the JPEG is 4-component).
-    let decoder = job
-        .decoder(data, &[])
-        .map_err(|_| Error::internal("push-decoder fallback: decoder creation failed"))?;
+    // and the JPEG is 4-component). Both calls already return the envelope.
+    let decoder = job.decoder(data, &[])?;
     let output = decoder.decode()?;
     let info = output.info().clone();
     let pixels = output.pixels();
@@ -2060,9 +2083,9 @@ pub struct JpegDecoder<'a> {
 }
 
 impl zencodec::decode::Decode for JpegDecoder<'_> {
-    type Error = Error;
+    type Error = At<CodecError>;
 
-    fn decode(self) -> Result<DecodeOutput, Error> {
+    fn decode(self) -> Result<DecodeOutput, Self::Error> {
         {
             use crate::decode::OutputTarget;
             use crate::types::PixelFormat;
@@ -2086,7 +2109,9 @@ impl zencodec::decode::Decode for JpegDecoder<'_> {
                             .and_then(|i| i.xmp)
                             .is_some_and(|x| x.contains("hdrgm:"));
                         if has_gain_map_xmp {
-                            return self.decode_reconstruct_hdr(target_headroom);
+                            return self
+                                .decode_reconstruct_hdr(target_headroom)
+                                .map_err(Into::into);
                         }
                         // No gain map: the base image IS the image.
                     }
@@ -2095,13 +2120,14 @@ impl zencodec::decode::Decode for JpegDecoder<'_> {
                         let _ = target_headroom;
                         return Err(Error::unsupported_feature(
                             "GainMapRender::ReconstructHdr requires the `ultrahdr` feature",
-                        ));
+                        )
+                        .into());
                     }
                 }
                 _ => {
-                    return Err(Error::unsupported_feature(
-                        "unrecognized GainMapRender mode",
-                    ));
+                    return Err(
+                        Error::unsupported_feature("unrecognized GainMapRender mode").into(),
+                    );
                 }
             }
 
@@ -2131,9 +2157,12 @@ impl zencodec::decode::Decode for JpegDecoder<'_> {
             // Previously three separate read_info() calls.
             let header = cfg.read_info(&data)?;
 
-            // Dimension limits
+            // Dimension limits. `check_dimensions` yields a `LimitExceeded`
+            // (foreign — no envelope bridge), so map through the native `Error`.
             if limits.max_width.is_some() || limits.max_height.is_some() {
-                limits.check_dimensions(header.dimensions.width, header.dimensions.height)?;
+                limits
+                    .check_dimensions(header.dimensions.width, header.dimensions.height)
+                    .map_err(Error::from)?;
             }
 
             // Progressive policy
@@ -2147,7 +2176,8 @@ impl zencodec::decode::Decode for JpegDecoder<'_> {
             {
                 return Err(Error::unsupported_feature(
                     "progressive JPEG rejected by decode policy",
-                ));
+                )
+                .into());
             }
 
             // Passthrough CMYK handling
@@ -2302,7 +2332,8 @@ impl zencodec::decode::Decode for JpegDecoder<'_> {
             if matches!(self.gain_map_render, zencodec::GainMapRender::Components) {
                 return Err(Error::unsupported_feature(
                     "GainMapRender::Components requires the `ultrahdr` feature",
-                ));
+                )
+                .into());
             }
 
             if let Some(extras) = jpeg_extras {
@@ -2570,17 +2601,20 @@ pub struct JpegStreamingDecoder<'a> {
 }
 
 impl zencodec::decode::StreamingDecode for JpegStreamingDecoder<'_> {
-    type Error = Error;
+    type Error = At<CodecError>;
 
-    fn next_batch(&mut self) -> Result<Option<(u32, PixelSlice<'_>)>, Error> {
+    fn next_batch(&mut self) -> Result<Option<(u32, PixelSlice<'_>)>, Self::Error> {
         {
             use imgref::ImgRefMut;
             use zenpixels::{ChannelLayout, ChannelType};
 
-            // Check cooperative cancellation before doing work.
+            // Check cooperative cancellation before doing work. `StopReason` is
+            // not a `core::error::Error`, so route it through the native `Error`
+            // (→ `ErrorKind::Cancelled`, which categorizes as Cancelled/TimedOut)
+            // before the bridge lifts it into the envelope.
             if let Some(ref stop) = self.stop {
                 use enough::Stop;
-                stop.check()?;
+                stop.check().map_err(Error::from)?;
             }
 
             if self.reader.is_finished() {
@@ -2652,7 +2686,8 @@ impl zencodec::decode::StreamingDecode for JpegStreamingDecoder<'_> {
                 _ => {
                     return Err(Error::unsupported_feature(
                         "unsupported pixel format for streaming decode",
-                    ));
+                    )
+                    .into());
                 }
             };
 
@@ -4234,5 +4269,92 @@ mod push_decode_stride_tests {
         // Larger image ⇒ strictly larger peak and wall time.
         assert!(el_peak > es_peak);
         assert!(el.wall_ms().unwrap_or(0) >= es.wall_ms().unwrap_or(0));
+    }
+}
+
+#[cfg(test)]
+mod pattern_b_envelope_tests {
+    //! Pattern B forcing tests: the `At<CodecError>` envelope must carry the
+    //! category + codec name across `Dyn*` type erasure. Under Pattern A
+    //! (`type Error = Error`) the erased `BoxedError` is a plain `dyn Error` with
+    //! no `CategorizedError` vtable, so both recoveries return `None`; the
+    //! envelope is exactly what flips them to `Some`.
+    use super::*;
+    use zencodec::decode::DynDecoderConfig;
+    use zencodec::{CodecError, CodecErrorExt, ErrorCategory};
+
+    /// SOI + SOF0 declaring **zero** components: passes the SOI gate, then fails
+    /// structurally inside the frame-header parse
+    /// (`invalid_jpeg_data("number of components is zero")` →
+    /// [`ErrorCategory::MalformedImage`]). Long enough to reach the structural
+    /// error rather than a truncation/EOF path — a REAL category, not a
+    /// stand-in.
+    const MALFORMED_JPEG: &[u8] = &[
+        0xFF, 0xD8, // SOI
+        0xFF, 0xC0, // SOF0
+        0x00, 0x08, // segment length = 8
+        0x08, // sample precision = 8
+        0x00, 0x10, // height = 16
+        0x00, 0x10, // width = 16
+        0x00, // component count = 0  ← malformed
+    ];
+
+    /// THE forcing test. Drive zenjpeg through `&dyn DynDecoderConfig` (the
+    /// codec-agnostic dyn path), let the concrete `At<CodecError>` erase to
+    /// `BoxedError` (`Box<dyn Error + Send + Sync>`), and confirm BOTH the
+    /// category and the codec name still come back.
+    #[test]
+    fn dyn_decode_envelope_recovers_category_and_codec() {
+        let cfg = JpegDecoderConfig::new();
+        let dyn_cfg: &dyn DynDecoderConfig = &cfg;
+        let erased = dyn_cfg
+            .dyn_job()
+            .probe(MALFORMED_JPEG)
+            .expect_err("a malformed JPEG must fail to probe");
+
+        // `error_category()` / `codec_error()` downcast the erased boxed error
+        // back to the concrete `At<CodecError>` — possible only because the
+        // trait boundary returns the envelope (Pattern B).
+        assert_eq!(
+            erased.error_category(),
+            Some(ErrorCategory::MalformedImage),
+            "category must survive Dyn* type erasure"
+        );
+        assert_eq!(
+            erased.codec_error().and_then(CodecError::codec),
+            Some("zenjpeg"),
+            "codec name must survive Dyn* type erasure"
+        );
+    }
+
+    /// The same recovery on the typed convenience method, which now returns the
+    /// envelope directly (no erasure needed — reads category/codec off the
+    /// inner [`CodecError`]).
+    #[test]
+    fn typed_probe_header_carries_envelope() {
+        let err = JpegDecoderConfig::new()
+            .probe_header(MALFORMED_JPEG)
+            .expect_err("malformed JPEG must fail");
+        assert_eq!(err.error().category(), ErrorCategory::MalformedImage);
+        assert_eq!(err.error().codec(), Some("zenjpeg"));
+    }
+
+    /// A decode through the dyn path erases the same way: the envelope is
+    /// recovered from the `into_decoder(...).decode()` boxed error too.
+    #[test]
+    fn dyn_decode_decode_path_carries_envelope() {
+        use std::borrow::Cow;
+        let cfg = JpegDecoderConfig::new();
+        let dyn_cfg: &dyn DynDecoderConfig = &cfg;
+        let erased = dyn_cfg
+            .dyn_job()
+            .into_decoder(Cow::Borrowed(MALFORMED_JPEG), &[])
+            .and_then(|dec| dec.decode())
+            .expect_err("a malformed JPEG must fail to decode");
+        assert_eq!(erased.error_category(), Some(ErrorCategory::MalformedImage));
+        assert_eq!(
+            erased.codec_error().and_then(CodecError::codec),
+            Some("zenjpeg")
+        );
     }
 }

--- a/zenjpeg/src/detect/mod.rs
+++ b/zenjpeg/src/detect/mod.rs
@@ -101,6 +101,27 @@ impl core::fmt::Display for ProbeError {
 
 impl std::error::Error for ProbeError {}
 
+/// Codec-agnostic classification of [`probe`] failures (zencodec #103). Mirrors
+/// the encode/decode taxonomy so a consumer routing on category sees probe and
+/// full-decode failures the same way.
+impl zencodec::CategorizedError for ProbeError {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some("zenjpeg")
+    }
+
+    fn category(&self) -> zencodec::ErrorCategory {
+        use zencodec::ErrorCategory as C;
+        match self {
+            // Not enough bytes yet, or header cut short → need more input.
+            Self::TooShort | Self::Truncated => C::UnexpectedEof,
+            // No SOI marker: this isn't a JPEG at all → the format isn't handled.
+            Self::NotJpeg => C::UnsupportedImageType,
+            // Has SOI but no DQT before the scan → structurally broken JPEG.
+            Self::NoQuantTables => C::MalformedImage,
+        }
+    }
+}
+
 /// Probe a JPEG from its raw bytes.
 ///
 /// Reads only headers (~500 bytes), no entropy decoding.
@@ -632,5 +653,15 @@ mod tests {
         data.extend_from_slice(&[0xFF, MARKER_EOI]);
 
         data
+    }
+
+    #[test]
+    fn probe_error_category_mapping() {
+        use zencodec::{CategorizedError, ErrorCategory as C};
+        assert_eq!(ProbeError::TooShort.codec_name(), Some("zenjpeg"));
+        assert_eq!(ProbeError::TooShort.category(), C::UnexpectedEof);
+        assert_eq!(ProbeError::Truncated.category(), C::UnexpectedEof);
+        assert_eq!(ProbeError::NotJpeg.category(), C::UnsupportedImageType);
+        assert_eq!(ProbeError::NoQuantTables.category(), C::MalformedImage);
     }
 }

--- a/zenjpeg/src/error.rs
+++ b/zenjpeg/src/error.rs
@@ -864,6 +864,49 @@ impl zencodec::CategorizedError for Error {
 }
 
 // ============================================================================
+// CodecError envelope bridges (Pattern B) — the zencodec trait boundary
+// ============================================================================
+//
+// zenjpeg's zencodec trait impls (`crate::codec`) use the shared envelope
+// `At<zencodec::CodecError>` as their `type Error`, so a generic consumer
+// recovers the [`category`](zencodec::CategorizedError::category) **and** the
+// codec name through `Dyn*` dispatch — where the concrete error is erased to a
+// boxed `dyn Error` (zencodec's `BoxedError`) and only the envelope is
+// recoverable (via `CodecErrorExt::codec_error`). The native [`Error`] /
+// [`ErrorKind`] stay the detail + category source; these two `From` impls let
+// the adapter return the envelope through `?` / `.into()` with no rewrite of the
+// fallible internals.
+//
+// `CodecError::of` reads the category + codec name from the value's
+// [`CategorizedError`] impl and keeps the `whereat` trace on the *outside*
+// (`At<CodecError>`). The orphan rule permits these (the local `Error` /
+// `ErrorKind` appears in the trait reference) but forbids `From<At<ErrorKind>>`
+// (both `At<_>` types are foreign), so an already-located `At<ErrorKind>` is
+// converted at the call site with `.map_err(zencodec::CodecError::of)` instead.
+
+impl From<Error> for At<zencodec::CodecError> {
+    /// Wrap the already-located [`Error`] (`Error(At<ErrorKind>)`) as the shared
+    /// envelope, preserving its existing `whereat` trace and reading category +
+    /// codec name from the inner [`ErrorKind`].
+    #[inline]
+    fn from(err: Error) -> Self {
+        zencodec::CodecError::of(err.into_inner())
+    }
+}
+
+impl From<ErrorKind> for At<zencodec::CodecError> {
+    /// Locate a bare [`ErrorKind`] (`start_at`) and wrap it as the envelope — for
+    /// the adapter's reject stubs / API guards that build an `ErrorKind`
+    /// directly rather than going through a located [`Error`].
+    #[track_caller]
+    #[inline]
+    fn from(kind: ErrorKind) -> Self {
+        use whereat::ErrorAtExt;
+        zencodec::CodecError::of(kind.start_at())
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 

--- a/zenjpeg/src/error.rs
+++ b/zenjpeg/src/error.rs
@@ -759,6 +759,111 @@ impl From<crate::foundation::aligned_alloc::AllocError> for Error {
 }
 
 // ============================================================================
+// CategorizedError - coarse, codec-agnostic classification (zencodec #103)
+// ============================================================================
+
+/// Map each [`ErrorKind`] variant to exactly one [`zencodec::ErrorCategory`].
+///
+/// This is the codec-agnostic routing axis: a consumer (an HTTP layer, a retry
+/// policy, a logger) reads [`category()`](zencodec::CategorizedError::category)
+/// without naming any zenjpeg type. The match is exhaustive — `ErrorKind` is
+/// `#[non_exhaustive]` to *callers*, but within this crate a new variant must be
+/// categorized here or the build fails, so the mapping stays total.
+impl zencodec::CategorizedError for ErrorKind {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some("zenjpeg")
+    }
+
+    fn category(&self) -> zencodec::ErrorCategory {
+        use zencodec::ErrorCategory as C;
+        use zencodec::LimitKind as L;
+        match self {
+            // === Caller-supplied parameters / configuration ===
+            // Dimensions (zero or out of range), the colour-format combo, and the
+            // encoder dials are caller inputs, not image-data faults.
+            Self::InvalidDimensions { .. }
+            | Self::InvalidColorFormat { .. }
+            | Self::InvalidQuality { .. }
+            | Self::InvalidScanScript(_)
+            | Self::InvalidConfig(_) => C::InvalidParameters,
+
+            // === Caller pixel-buffer geometry ===
+            // Wrong byte count, or a stride narrower than the row — a buffer
+            // layout fault, distinct from a bad config knob.
+            Self::InvalidBufferSize { .. } | Self::StrideTooSmall { .. } => C::InvalidBuffer,
+
+            // === Pixel-format negotiation found no acceptable format ===
+            Self::UnsupportedPixelFormat { .. } => C::UnsupportedPixelFormat,
+
+            // === A valid JPEG feature this codec doesn't implement ===
+            // (arithmetic coding, 12-bit samples, …). The variant's primary
+            // meaning; a few encoder-side API guards reuse this constructor too
+            // (documented at those call sites).
+            Self::UnsupportedFeature { .. } => C::UnsupportedImageFeature,
+
+            // === Memory / size acquisition failures ===
+            // A real allocation failure is OOM. A size-calculation overflow means
+            // the requested buffer cannot be represented at all — an
+            // allocation-infeasibility, so it joins OOM (mirrors zenpng's
+            // overflow → OutOfMemory convention) rather than claiming "internal
+            // bug" or borrowing an ill-fitting LimitKind.
+            Self::AllocationFailed { .. } | Self::SizeOverflow { .. } => C::OutOfMemory,
+
+            // === A configured ResourceLimits cap was exceeded ===
+            Self::ImageTooLarge { .. } => C::LimitsExceeded(L::Pixels),
+
+            // === I/O / output-sink failure ===
+            Self::IoError { .. } => C::Io(zencodec::CodecIoKind::opaque()),
+
+            // === Colour management required ===
+            // The sole erroring ICC path is "an ICC must be synthesized for the
+            // source CICP but cannot be" — a CMS transform the codec will not
+            // perform itself.
+            Self::IccError(_) => C::CmsRequired,
+
+            // === Malformed / corrupt bitstream content ===
+            Self::InvalidJpegData { .. }
+            | Self::InvalidMarker { .. }
+            | Self::InvalidHuffmanTable { .. }
+            | Self::InvalidQuantTable { .. }
+            | Self::DecodeError(_)
+            // No LimitKind covers "progressive scans"; an over-the-cap scan count
+            // is pathological bitstream structure → reject as malformed.
+            | Self::TooManyScans { .. } => C::MalformedImage,
+
+            // === Truncated input ===
+            Self::TruncatedData { .. } => C::UnexpectedEof,
+
+            // === Caller API-protocol violation (wrong sequence / row count) ===
+            Self::TooManyRows { .. } | Self::IncompleteImage { .. } => C::InvalidState,
+
+            // === Internal invariant / bug ===
+            Self::InternalError { .. } => C::Internal,
+
+            // === Delegate to the wrapped zencodec cause types ===
+            // Each carries its own `CategorizedError` impl: `StopReason` splits
+            // cancelled vs timed-out, `UnsupportedOperation` splits pixel-format
+            // vs operation gaps.
+            Self::Cancelled(reason) => reason.category(),
+            Self::UnsupportedOperation(op) => op.category(),
+        }
+    }
+}
+
+/// The public [`Error`] newtype delegates to its [`ErrorKind`]. Consumers holding
+/// an `At<ErrorKind>` (via [`Error::into_inner`]) get the same classification for
+/// free through zencodec's blanket `impl CategorizedError for At<E>`.
+impl zencodec::CategorizedError for Error {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some("zenjpeg")
+    }
+
+    fn category(&self) -> zencodec::ErrorCategory {
+        self.kind().category()
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -902,5 +1007,94 @@ mod tests {
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
         let err: Error = io_err.into();
         assert!(matches!(err.kind(), ErrorKind::IoError { .. }));
+    }
+
+    #[test]
+    fn categorized_error_codec_name() {
+        use zencodec::CategorizedError;
+        let err = Error::invalid_jpeg_data("bad SOI");
+        assert_eq!(err.codec_name(), Some("zenjpeg"));
+        assert_eq!(err.kind().codec_name(), Some("zenjpeg"));
+    }
+
+    #[test]
+    fn categorized_error_category_mapping() {
+        use enough::StopReason;
+        use zencodec::{CategorizedError, ErrorCategory as C, LimitKind};
+
+        // Spot-check every branch of the mapping, including the delegating arms.
+        let cases: &[(Error, C)] = &[
+            // Caller parameters / config.
+            (
+                Error::invalid_dimensions(0, 10, "zero width"),
+                C::InvalidParameters,
+            ),
+            (
+                Error::invalid_color_format("rgb+cmyk"),
+                C::InvalidParameters,
+            ),
+            (
+                Error::invalid_quality(200.0, "0..100"),
+                C::InvalidParameters,
+            ),
+            (
+                Error::invalid_scan_script("bad".into()),
+                C::InvalidParameters,
+            ),
+            (Error::invalid_config("bad".into()), C::InvalidParameters),
+            // Pixel-buffer geometry.
+            (Error::invalid_buffer_size(100, 50), C::InvalidBuffer),
+            (Error::stride_too_small(64, 16), C::InvalidBuffer),
+            // Unsupported feature / format.
+            (
+                Error::unsupported_feature("arithmetic coding"),
+                C::UnsupportedImageFeature,
+            ),
+            (
+                Error::unsupported_pixel_format(crate::types::PixelFormat::Rgb),
+                C::UnsupportedPixelFormat,
+            ),
+            // Memory / size.
+            (Error::allocation_failed(1 << 20, "buf"), C::OutOfMemory),
+            (Error::size_overflow("w*h*bpp"), C::OutOfMemory),
+            (
+                Error::image_too_large(1_000_000, 100),
+                C::LimitsExceeded(LimitKind::Pixels),
+            ),
+            // I/O.
+            (
+                Error::io_error("disk".into()),
+                C::Io(zencodec::CodecIoKind::opaque()),
+            ),
+            // Colour management.
+            (Error::icc_error("cannot synthesize".into()), C::CmsRequired),
+            // Malformed bitstream.
+            (Error::invalid_jpeg_data("not a jpeg"), C::MalformedImage),
+            (Error::invalid_marker(0xFF, "scan"), C::MalformedImage),
+            (Error::invalid_huffman_table(0, "bad"), C::MalformedImage),
+            (Error::invalid_quant_table(0, "bad"), C::MalformedImage),
+            (Error::decode_error("boom".into()), C::MalformedImage),
+            (Error::too_many_scans(9999, 100), C::MalformedImage),
+            // Truncation.
+            (Error::truncated_data("scan body"), C::UnexpectedEof),
+            // API-protocol state.
+            (Error::too_many_rows(10, 12), C::InvalidState),
+            (Error::incomplete_image(10, 5), C::InvalidState),
+            // Internal.
+            (Error::internal("invariant"), C::Internal),
+            // Delegated cause types.
+            (Error::cancelled(), C::Cancelled),
+            (Error::from(StopReason::TimedOut), C::TimedOut),
+            (
+                Error::from(zencodec::UnsupportedOperation::AnimationEncode),
+                C::UnsupportedOperation,
+            ),
+        ];
+
+        for (err, expected) in cases {
+            assert_eq!(err.category(), *expected, "category mismatch for {err:?}");
+            // The located wrapper classifies identically via the blanket At impl.
+            assert_eq!(err.inner().category(), *expected);
+        }
     }
 }

--- a/zenjpeg/src/recompress/error.rs
+++ b/zenjpeg/src/recompress/error.rs
@@ -41,3 +41,53 @@ impl From<crate::encoder::Error> for Error {
         Error::Zenjpeg(format!("{e}"))
     }
 }
+
+/// Codec-agnostic classification of recompression failures (zencodec #103).
+///
+/// The downstream-tool arms (`Zenjpeg` / `Zensim`) flatten their typed cause to
+/// a `String`, so the underlying category can't be delegated; they report as
+/// [`Internal`](zencodec::ErrorCategory::Internal) — a failure inside the
+/// recompress pipeline, not attributable to the caller's request.
+impl zencodec::CategorizedError for Error {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some("zenjpeg")
+    }
+
+    fn category(&self) -> zencodec::ErrorCategory {
+        use zencodec::ErrorCategory as C;
+        match self {
+            // Caller asked for a target outside [0, 100].
+            Self::TargetOutOfRange(_) => C::InvalidParameters,
+            // Probing the source JPEG header failed → unreadable / bad input.
+            Self::Probe(_) => C::MalformedImage,
+            // The source uses a JPEG feature the recompressor doesn't handle.
+            Self::Unsupported(_) => C::UnsupportedImageFeature,
+            // Downstream zenjpeg / zensim failures (typed cause flattened to a
+            // String) and broken internal invariants are all internal faults.
+            Self::Zenjpeg(_) | Self::Zensim(_) | Self::Internal(_) => C::Internal,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zencodec::{CategorizedError, ErrorCategory as C};
+
+    #[test]
+    fn category_mapping() {
+        assert_eq!(Error::TargetOutOfRange(101.0).codec_name(), Some("zenjpeg"));
+        assert_eq!(
+            Error::TargetOutOfRange(101.0).category(),
+            C::InvalidParameters
+        );
+        assert_eq!(Error::Probe("eof".into()).category(), C::MalformedImage);
+        assert_eq!(
+            Error::Unsupported("12-bit").category(),
+            C::UnsupportedImageFeature
+        );
+        assert_eq!(Error::Zenjpeg("io".into()).category(), C::Internal);
+        assert_eq!(Error::Zensim("score".into()).category(), C::Internal);
+        assert_eq!(Error::Internal("invariant").category(), C::Internal);
+    }
+}


### PR DESCRIPTION
## Summary

Adopts the **zencodec #103 `CategorizedError` taxonomy** so codec-agnostic
consumers can classify zenjpeg failures (HTTP status, retry policy, logging)
without naming a zenjpeg-specific type.

### Task A — `CategorizedError` (done)

`impl zencodec::CategorizedError` on every public top-level error, each
reporting `codec_name() -> Some("zenjpeg")` plus a **total, exhaustive**
`category() -> ErrorCategory`:

| Error type | Surface |
|---|---|
| `crate::error::Error` + inner `ErrorKind` | THE main encode/decode error — also the type behind `decoder::Error`, `encoder::Error`, `DecodeError`, `EncodeError`, and the `zencodec` `EncoderConfig`/`DecoderConfig` adapter's `type Error` |
| `detect::ProbeError` | the public `detect::probe()` |
| `recompress::Error` | the `recompress` entry point (feature `recompress`) |

The `ErrorKind` match is exhaustive (no wildcard), so a future variant must be
categorized or the build fails — the mapping stays total. Mapping + `codec_name`
tests added for all three (`error::tests`, `detect::tests`, `recompress::error::tests`).

Because `ErrorKind` is `#[non_exhaustive]` only to *callers*, a consumer holding
an `At<ErrorKind>` (via `Error::into_inner`) gets the same classification through
zencodec's blanket `impl CategorizedError for At<E>`.

#### Category mapping (judgment calls noted)

- Malformed bitstream (`InvalidJpegData` / `InvalidMarker` / `InvalidHuffmanTable` / `InvalidQuantTable` / `DecodeError`) → `MalformedImage`
- `TruncatedData` → `UnexpectedEof`
- `UnsupportedFeature` (arithmetic coding, 12-bit, …) → `UnsupportedImageFeature`
- `UnsupportedPixelFormat` → `UnsupportedPixelFormat`
- Caller dials/config (`InvalidDimensions` / `InvalidColorFormat` / `InvalidQuality` / `InvalidScanScript` / `InvalidConfig`) → `InvalidParameters`
- Buffer geometry (`InvalidBufferSize` / `StrideTooSmall`) → `InvalidBuffer`
- `TooManyRows` / `IncompleteImage` (push/finish sequencing) → `InvalidState`
- `IccError` (ICC-synthesis-for-CICP failure) → `CmsRequired`
- `ImageTooLarge` → `LimitsExceeded(Pixels)`
- `AllocationFailed` **and** `SizeOverflow` → `OutOfMemory`
- `IoError` → `Io(CodecIoKind::opaque())`
- `InternalError` → `Internal`
- `Cancelled(StopReason)` / `UnsupportedOperation` → **delegate** to the wrapped zencodec cause type

Judgment calls:
- **`SizeOverflow` → `OutOfMemory`**: a size-calc overflow means the buffer can't be represented at all — an allocation-infeasibility (mirrors zenpng's overflow→OutOfMemory) rather than claiming an internal bug or borrowing an ill-fitting `LimitKind`.
- **`TooManyScans` → `MalformedImage`**: no `LimitKind` covers progressive scans; an over-the-cap scan count is pathological bitstream structure.
- **`InvalidDimensions` → `InvalidParameters`**: it's primarily a caller-argument error; note `From<LimitExceeded::{Width,Height}>` also routes through this variant, so the rare limit-forwarding case reads as `InvalidParameters` rather than `LimitsExceeded`.
- **`ProbeError::NotJpeg` → `UnsupportedImageType`** (matches the category's "not a PNG" example); `NoQuantTables` → `MalformedImage`; `TooShort`/`Truncated` → `UnexpectedEof`.

### Task B — located `At<>` public errors (already satisfied)

This task was written assuming zenjpeg returned non-located errors. It does not:
the public encode/decode error is already **`Error(pub At<ErrorKind>)`** carrying
a `whereat` location trace, with **`whereat::define_at_crate_info!` already in
`lib.rs`** and `#[track_caller]` constructors capturing the origin. So **no
error-type reshape or signature break was needed** — the adoption here is purely
additive (classification only). Doing a gratuitous `Error → bare At<ErrorKind>`
breaking change would churn the whole public API for zero functional gain and
lose the newtype's convenience constructors, so it was deliberately **not** done.

**Remaining (documented, not blocking):** the feature-gated `recompress::Error`
is categorized but is a plain enum without a trace; the niche aux errors
`MpfError` / `XmpError` / `ReencodeError` / `TransformError` are neither
categorized nor located. Making any of them located would each be a small,
isolated follow-up.

## Validation

All via `run-heavy --mem 14G --jobs 6` (sibling agents building concurrently):

- `cargo test -p zenjpeg --lib --tests --features "parallel,moxcms,ultrahdr,zencodec,__test-utils"` → **1185 lib + all integration suites pass, 0 failures** (incl. the 4 new categorization tests).
- `cargo clippy -p zenjpeg --lib --tests --features "parallel,moxcms,ultrahdr,zencodec,__test-utils" -- -D warnings` → **clean**.
- `rustfmt --check` on all changed files → **clean**.

Note: the 344M `jpegli-cpp` C++ submodule (FFI parity dev-deps) isn't checked out
in the jj workspace; validation replicated CI's `superwork` exclusion
(drop `cjpegli-ffi` / `jpegli-internals-sys`) locally — that change was **not**
committed. The `recompress`-feature clippy debt in `recompress/strategies/*`,
`aq.rs`, `calibration/*` etc. is **pre-existing** (CI doesn't clippy `recompress`)
and untouched here.

## TEMP dev patch

Workspace `Cargo.toml` pins `zencodec` to the
`cancellation-classification-99` git branch (PR #103, rev `2c7fb398`) until
`zencodec 0.1.26` ships the `CategorizedError` API. **Revert the
`[patch.crates-io]` entry and bump the dep to the released version at landing.**
