### PR TITLE
feat: typed one-shot zenjpeg::encode(PixelSlice, quality) + decode_rgb8

### DIFF
--- a/docs/public-api/zenjpeg.features.txt
+++ b/docs/public-api/zenjpeg.features.txt
@@ -12,7 +12,7 @@
 #   pub modules                                 4
 #   pub types (struct/enum/trait/alias)        52
 #   pub consts/statics                          4
-#   free functions                             32
+#   free functions                             33
 #   inherent methods                          108
 #   struct fields                              70
 #   enum variants                              78
@@ -22,14 +22,14 @@
 #   auto-trait exceptions                       7
 #
 # per-module pub lines:
-#   (root)                           37
+#   (root)                           38
 #   decoder                           3
 #   encoder                          40
 #   layout                           67
 #   recompress                      154
 #   ultrahdr                         72
 
-## items (373 lines)
+## items (374 lines)
 
 pub fn decoder::DecodeConfig::correct_color(self, core::option::Option<decoder::TargetColorSpace>) -> Self
 pub fn decoder::DecodeConfig::ultrahdr_reader<'a>(&self, &'a [u8], ultrahdr::UltraHdrReaderConfig) -> encoder::Result<ultrahdr::UltraHdrReader<'a>>
@@ -402,6 +402,7 @@ pub fn JpegEncoderConfig::with_sharp_yuv(self, bool) -> Self
 pub fn JpegEncoderConfig::with_subsampling(self, encoder::ChromaSubsampling) -> Self
 pub fn JpegEncoderConfig::ycbcr(f32, encoder::ChromaSubsampling) -> Self
 pub struct JpegStreamingDecoder<'a>
+pub fn encode(zenpixels::buffer::PixelSlice<'_>, u8) -> encoder::Result<alloc::vec::Vec<u8>>
 pub type JpegDecoding = JpegDecoderConfig
 pub type JpegEncoding = JpegEncoderConfig
 

--- a/docs/public-api/zenjpeg.txt
+++ b/docs/public-api/zenjpeg.txt
@@ -6,7 +6,7 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zenjpeg.txt 1629 lines (supported surface) | zenjpeg.features.txt 427 added (features: boundary-rd,cms,decoder,layout,moxcms,parallel,recompress,recompress-expert,recompress-iqa,target-zq,trellis,ultrahdr,web-sys,zencodec) | zenjpeg.internal.txt 3560 lines (839 hidden + 7238 excluded-feature)
+# files: zenjpeg.txt 1630 lines (supported surface) | zenjpeg.features.txt 428 added (features: boundary-rd,cms,decoder,layout,moxcms,parallel,recompress,recompress-expert,recompress-iqa,target-zq,trellis,ultrahdr,web-sys,zencodec) | zenjpeg.internal.txt 3560 lines (839 hidden + 7238 excluded-feature)
 
 ## summary
 #
@@ -14,7 +14,7 @@
 #   pub types (struct/enum/trait/alias)       143
 #   pub consts/statics                         94
 #   pub macros                                  2
-#   free functions                             60
+#   free functions                             61
 #   inherent methods                          494
 #   struct fields                             360
 #   enum variants                             381
@@ -24,7 +24,7 @@
 #   auto-trait exceptions                      13
 #
 # per-module pub lines:
-#   (root)                           67
+#   (root)                           68
 #   blur                              1
 #   container                       276
 #   deblock                          16
@@ -35,7 +35,7 @@
 #   lossless                         42
 #   profile                           7
 
-## items (1497 lines)
+## items (1498 lines)
 
 pub mod zenjpeg
 pub mod blur
@@ -1534,6 +1534,7 @@ pub fn profile::ProfileStats::record(&'static str, core::time::Duration)
 pub fn profile::ProfileStats::reset()
 pub macro profile_block!
 pub macro profile_scope!
+pub fn decode_rgb8(&[u8]) -> encoder::Result<(alloc::vec::Vec<u8>, u32, u32)>
 
 ## trait impls (118 types)
 

--- a/zenjpeg/CHANGELOG.md
+++ b/zenjpeg/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **One-shot crate-root convenience functions** — `zenjpeg::encode(img: zenpixels::PixelSlice, quality)`
+  encodes a self-describing pixel slice to a baseline YCbCr 4:2:0 JPEG in one
+  call (format + dimensions + row stride ride with the pixels — no redundant
+  `width`/`height`, no buffer-length mismatch to guard against; requires the
+  `zencodec` feature), and `zenjpeg::decode_rgb8(jpeg) -> (Vec<u8>, u32, u32)`
+  decodes any JPEG (grayscale / YCbCr / CMYK) to tightly-packed RGB8 +
+  dimensions. Purely additive wrappers over the `JpegEncoderConfig` encode path
+  / `Decoder`; the builder API stays the power path. Mirrors zenresize / zenpng.
+
 - **BQuarter-aware XYB subsampling pick in `EncoderConfig::adaptive`** — when
   the adaptive oracle chooses XYB, it now picks Full vs BQuarter from
   zenanalyze's `xyb_bquarter_chroma_loss` (id 139, the per-color-sensitivity-

--- a/zenjpeg/README.crates.md
+++ b/zenjpeg/README.crates.md
@@ -18,12 +18,41 @@ no C dependencies.
 
 ```toml
 [dependencies]
-zenjpeg = "0.8"
+zenjpeg = { version = "0.8", features = ["zencodec"] }
 ```
 
-Encode with the `EncoderConfig` builder and decode with `Decoder`. The builder
-covers chroma subsampling, XYB color, progressive scans, embedded ICC/EXIF/XMP,
-resource limits, and cooperative cancellation.
+The one-shot path encodes a self-describing `zenpixels::PixelSlice` to a JPEG at
+a quality level, and decodes any JPEG back to RGB8 + dimensions, each in a single
+call. The slice carries the pixel format, dimensions, and row stride, so the
+dimensions ride *with* the pixels — there is no separate width/height to keep in
+sync and no buffer-length mismatch to guard against.
+
+```rust
+use zenjpeg::{decode_rgb8, encode};
+use zenpixels::{PixelDescriptor, PixelSlice};
+
+// A 16×16 RGB image — dims + stride + format ride with the pixels.
+let (width, height) = (16u32, 16u32);
+let rgb: Vec<u8> = (0..width * height)
+    .flat_map(|i| { let v = (i % 256) as u8; [v, 255 - v, 128] })
+    .collect();
+let img = PixelSlice::new(&rgb, width, height, width as usize * 3, PixelDescriptor::RGB8_SRGB)?;
+
+// Encode to a baseline JPEG at quality 85 — no separate width/height arguments.
+let jpeg = encode(img, 85)?;
+
+// Decode any JPEG back to tightly-packed RGB8 + dimensions.
+let (pixels, w, h) = decode_rgb8(&jpeg)?;
+
+assert_eq!((w, h), (width, height));
+assert_eq!(pixels.len(), (width * height * 3) as usize); // JPEG is lossy — sizes match, bytes approximate
+```
+
+`encode` takes a self-describing `zenpixels::PixelSlice` (needs the `zencodec`
+feature) and encodes standard YCbCr 4:2:0; `decode_rgb8` normalizes grayscale,
+YCbCr and CMYK sources to 8-bit RGB. For chroma-subsampling control, XYB color,
+progressive scans, embedded ICC/EXIF/XMP, resource limits, or cooperative
+cancellation, drop down to the builder API below.
 
 ### Encode (builder)
 

--- a/zenjpeg/README.md
+++ b/zenjpeg/README.md
@@ -16,12 +16,41 @@ no C dependencies.
 
 ```toml
 [dependencies]
-zenjpeg = "0.8"
+zenjpeg = { version = "0.8", features = ["zencodec"] }
 ```
 
-Encode with the `EncoderConfig` builder and decode with `Decoder`. The builder
-covers chroma subsampling, XYB color, progressive scans, embedded ICC/EXIF/XMP,
-resource limits, and cooperative cancellation.
+The one-shot path encodes a self-describing `zenpixels::PixelSlice` to a JPEG at
+a quality level, and decodes any JPEG back to RGB8 + dimensions, each in a single
+call. The slice carries the pixel format, dimensions, and row stride, so the
+dimensions ride *with* the pixels — there is no separate width/height to keep in
+sync and no buffer-length mismatch to guard against.
+
+```rust
+use zenjpeg::{decode_rgb8, encode};
+use zenpixels::{PixelDescriptor, PixelSlice};
+
+// A 16×16 RGB image — dims + stride + format ride with the pixels.
+let (width, height) = (16u32, 16u32);
+let rgb: Vec<u8> = (0..width * height)
+    .flat_map(|i| { let v = (i % 256) as u8; [v, 255 - v, 128] })
+    .collect();
+let img = PixelSlice::new(&rgb, width, height, width as usize * 3, PixelDescriptor::RGB8_SRGB)?;
+
+// Encode to a baseline JPEG at quality 85 — no separate width/height arguments.
+let jpeg = encode(img, 85)?;
+
+// Decode any JPEG back to tightly-packed RGB8 + dimensions.
+let (pixels, w, h) = decode_rgb8(&jpeg)?;
+
+assert_eq!((w, h), (width, height));
+assert_eq!(pixels.len(), (width * height * 3) as usize); // JPEG is lossy — sizes match, bytes approximate
+```
+
+`encode` takes a self-describing `zenpixels::PixelSlice` (needs the `zencodec`
+feature) and encodes standard YCbCr 4:2:0; `decode_rgb8` normalizes grayscale,
+YCbCr and CMYK sources to 8-bit RGB. For chroma-subsampling control, XYB color,
+progressive scans, embedded ICC/EXIF/XMP, resource limits, or cooperative
+cancellation, drop down to the builder API below.
 
 ### Encode (builder)
 

--- a/zenjpeg/src/lib.rs
+++ b/zenjpeg/src/lib.rs
@@ -359,3 +359,116 @@ pub use codec::{
 // zennode pipeline node definitions (EncodeJpeg, DecodeJpeg)
 // #[cfg(feature = "zennode")]
 // pub mod zennode_defs;
+
+// ============================================================================
+// One-shot convenience functions (crate root)
+// ============================================================================
+//
+// Purely-additive free helpers that do the core job — pixels → JPEG and JPEG →
+// RGB8 — in a single call with sane defaults, for callers who haven't read the
+// builder docs. The encode input is a self-describing [`zenpixels::PixelSlice`]
+// (format + dimensions + row stride ride with the pixels), so there is no
+// redundant `width`/`height` to keep in sync and no buffer-length mismatch to
+// guard against. Reach for the streaming builder API ([`encoder::EncoderConfig`]
+// / [`decoder::Decoder`]) when you need chroma-subsampling control, XYB color,
+// progressive scans, embedded ICC/EXIF/XMP, resource limits, or cooperative
+// cancellation.
+
+/// Encode a [`zenpixels::PixelSlice`] to a baseline JPEG in one call.
+///
+/// The slice is self-describing: it carries the pixel format (RGB8, RGBA8,
+/// grayscale, 16-bit, f32, …), the dimensions, and the row stride, so there is
+/// no separate `width`/`height` argument to keep in sync and no buffer-length
+/// mismatch to guard against — strided slices are handled directly. `quality`
+/// is `0..=100` (higher = better; `85` is a good web default). Encodes standard
+/// YCbCr with 4:2:0 chroma — the most widely compatible JPEG configuration.
+///
+/// Requires the `zencodec` feature (the typed [`zenpixels`] encode path). For
+/// 4:4:4 / 4:2:2 chroma, XYB color, progressive scans, embedded ICC/EXIF/XMP,
+/// or cooperative cancellation, use the [`encoder::EncoderConfig`] builder.
+///
+/// # Errors
+/// Returns an error if the slice's pixel format is not one the encoder
+/// supports, plus any encode error bubbled up from the underlying pipeline.
+///
+/// ```
+/// use zenjpeg::{decode_rgb8, encode};
+/// use zenpixels::{PixelDescriptor, PixelSlice};
+///
+/// // A 16×16 RGB image — dims + stride + format ride with the pixels.
+/// let (width, height) = (16u32, 16u32);
+/// let rgb: Vec<u8> = (0..width * height)
+///     .flat_map(|i| { let v = (i % 256) as u8; [v, 255 - v, 128] })
+///     .collect();
+/// let img = PixelSlice::new(&rgb, width, height, width as usize * 3, PixelDescriptor::RGB8_SRGB)?;
+///
+/// // Encode to a baseline JPEG at quality 85 — no separate width/height args.
+/// let jpeg = encode(img, 85)?;
+///
+/// // Decode any JPEG back to tightly-packed RGB8 + dimensions.
+/// let (pixels, w, h) = decode_rgb8(&jpeg)?;
+///
+/// assert_eq!((w, h), (width, height));
+/// assert_eq!(pixels.len(), (width * height * 3) as usize); // JPEG is lossy — sizes match, bytes approximate
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[cfg(feature = "zencodec")]
+pub fn encode(img: zenpixels::PixelSlice<'_>, quality: u8) -> crate::error::Result<Vec<u8>> {
+    // `JpegEncoderConfig::ycbcr(..).encode(slice)` runs the default config → job
+    // → encode path: it pulls RGB8 rows from the (possibly strided) slice via
+    // `zenpixels-convert` and feeds the streaming encoder. 4:2:0 chroma matches
+    // the most widely compatible JPEG configuration.
+    let output = crate::codec::JpegEncoderConfig::ycbcr(
+        f32::from(quality),
+        crate::encoder::ChromaSubsampling::Quarter,
+    )
+    .encode(img)?;
+    Ok(output.into_vec())
+}
+
+/// Decode a JPEG (any color space) to tightly-packed 8-bit RGB in one call.
+///
+/// Returns `(rgb, width, height)` where `rgb` is exactly `width * height * 3`
+/// bytes (`R, G, B` per pixel, no stride padding, sRGB). Grayscale, YCbCr and
+/// CMYK / YCCK sources are all normalized to 8-bit RGB.
+///
+/// For f32 / linear-light output, resource limits (decompression-bomb
+/// protection), strictness control, preserved metadata, or cooperative
+/// cancellation, use the [`decoder::Decoder`] builder.
+///
+/// # Errors
+/// Returns an error if `jpeg` is not a valid / supported JPEG, or a resource
+/// limit is exceeded.
+///
+/// ```
+/// use zenjpeg::decode_rgb8;
+/// use zenjpeg::encoder::{ChromaSubsampling, EncoderConfig, PixelLayout};
+///
+/// // A 16×16 RGB image, tightly packed (width * height * 3 bytes).
+/// let (width, height) = (16u32, 16u32);
+/// let rgb: Vec<u8> = (0..width * height)
+///     .flat_map(|i| { let v = (i % 256) as u8; [v, 255 - v, 128] })
+///     .collect();
+///
+/// // Encode a baseline JPEG via the builder, then round-trip it back to RGB8.
+/// let jpeg = EncoderConfig::ycbcr(85u8, ChromaSubsampling::Quarter)
+///     .encode_bytes(&rgb, width, height, PixelLayout::Rgb8Srgb)?;
+/// let (pixels, w, h) = decode_rgb8(&jpeg)?;
+///
+/// assert_eq!((w, h), (width, height));
+/// assert_eq!(pixels.len(), (width * height * 3) as usize); // JPEG is lossy — sizes match, bytes approximate
+/// # Ok::<(), zenjpeg::encoder::EncodeError>(())
+/// ```
+pub fn decode_rgb8(jpeg: &[u8]) -> crate::error::Result<(Vec<u8>, u32, u32)> {
+    // `PixelFormat::Rgb` makes the decoder emit 3-channel RGB for every input
+    // (grayscale is expanded, CMYK/YCCK is converted); the default
+    // `OutputTarget::Srgb8` keeps it u8.
+    let decoded = crate::decoder::Decoder::new()
+        .output_format(crate::types::PixelFormat::Rgb)
+        .decode(jpeg, enough::Unstoppable)?;
+    let (width, height) = decoded.dimensions();
+    let rgb = decoded
+        .into_pixels_u8()
+        .ok_or_else(|| crate::error::Error::internal("decode produced no u8 pixels"))?;
+    Ok((rgb, width, height))
+}


### PR DESCRIPTION
## Typed one-shot encode + unchanged decode

Adds two crate-root one-shot convenience functions (the zen README §5 onboarding convention), mirroring **zenresize #14** (ImgRef) and **zenpng #18** (`encode(PixelSlice)`):

- `zenjpeg::encode(img: zenpixels::PixelSlice<'_>, quality: u8) -> Result<Vec<u8>>` — encodes a **self-describing** pixel slice to a baseline YCbCr 4:2:0 JPEG in one call. The `PixelSlice` carries pixel format **+ dimensions + row stride**, so the geometry rides *with* the pixels: there is no redundant `width`/`height` to keep in sync and no buffer-length-vs-dimensions mismatch to guard against, and strided slices are handled directly. Wraps the default `JpegEncoderConfig` → job → encode path at the given quality. Gated behind the existing `zencodec` feature (the typed `zenpixels` encode path). Does **not** re-export any `zenpixels` types — callers `use zenpixels::PixelSlice`.
- `zenjpeg::decode_rgb8(jpeg: &[u8]) -> Result<(Vec<u8>, u32, u32)>` — decodes any JPEG (grayscale / YCbCr / CMYK) to tightly-packed RGB8 + dimensions. JPEG bytes are already self-describing, so this stays as-is.

### Why this shape

The prior encoder one-shot `encode_rgb8_quality(rgb: &[u8], width, height, quality)` took a bare `&[u8]` plus separate `width`/`height` and a runtime length guard — the redundant-dimensions + length-mismatch smell. It was removed from `main` in the immediately preceding commit (`f7859b20`); this PR replaces it with the typed `encode(PixelSlice, quality)` so dimensions/stride/format travel with the pixels and the encoder accepts the formats it supports.

### Docs / snapshots

- README Quick Start now leads with `encode` / `decode_rgb8` (toml shows `features = ["zencodec"]`); `README.crates.md` regenerated.
- CHANGELOG `[Unreleased] → Added` updated.
- Public-API snapshot regenerated: `decode_rgb8` in the default surface, `encode` in the `zencodec` feature surface.

### Verified locally

- `cargo test --doc -p zenjpeg` (default) and `--features zencodec` (17 doctests pass, incl. the encode round-trip)
- `cargo clippy -p zenjpeg --all-targets -- -D warnings` (default) and `--features zencodec`
- `cargo fmt -p zenjpeg --check`
